### PR TITLE
Use VITE_API_URL for frontend API calls

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,1 @@
+VITE_API_URL=https://vacationsync-api.onrender.com

--- a/client/src/components/LocationSearch.tsx
+++ b/client/src/components/LocationSearch.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Loader2, Search, MapPin, Plane, Building, Globe, X, Star, Clock, DollarSign } from 'lucide-react';
+import { apiFetch } from '@/lib/api';
 
 interface LocationResult {
   id: string;
@@ -95,7 +96,7 @@ export default function LocationSearch({
 
   const loadPopularDestinations = async () => {
     try {
-      const response = await fetch('/api/locations/search', {
+      const response = await apiFetch('/api/locations/search', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -148,7 +149,7 @@ export default function LocationSearch({
     setShowingPopular(false);
     
     try {
-      const response = await fetch('/api/locations/search', {
+      const response = await apiFetch('/api/locations/search', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -205,7 +206,7 @@ export default function LocationSearch({
       
       if (result.type === 'CITY') {
         try {
-          const airportResponse = await fetch('/api/locations/search', {
+          const airportResponse = await apiFetch('/api/locations/search', {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',

--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { MapPin, Plane, Globe, Building } from "lucide-react";
+import { apiFetch } from "@/lib/api";
 
 interface LocationResult {
   type: 'airport' | 'city' | 'metro' | 'state' | 'country';
@@ -70,7 +71,7 @@ export default function SmartLocationSearch({
     debounceRef.current = setTimeout(async () => {
       setIsLoading(true);
       try {
-        const response = await fetch(`/api/locations/search?q=${encodeURIComponent(query)}`);
+        const response = await apiFetch(`/api/locations/search?q=${encodeURIComponent(query)}`);
         if (response.ok) {
           const data = await response.json();
           // ROOT CAUSE 2 FIX: Ensure results is always an array

--- a/client/src/components/activity-search.tsx
+++ b/client/src/components/activity-search.tsx
@@ -19,6 +19,7 @@ import {
   Users
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
+import { apiFetch } from "@/lib/api";
 import type { TripWithDetails } from "@shared/schema";
 
 interface Activity {
@@ -95,7 +96,7 @@ export default function ActivitySearch({ tripId, trip, user }: ActivitySearchPro
         sortBy
       });
       
-      const response = await fetch(`/api/activities/discover?${params}`, {
+      const response = await apiFetch(`/api/activities/discover?${params}`, {
         credentials: 'include',
       });
       

--- a/client/src/components/manual-refresh-button.tsx
+++ b/client/src/components/manual-refresh-button.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
+import { buildApiUrl } from "@/lib/api";
 
 export function ManualRefreshButton() {
   const handleRefresh = () => {
     // Clear all storage and force a complete refresh
     localStorage.clear();
     sessionStorage.clear();
-    window.location.href = '/api/logout';
+    window.location.href = buildApiUrl("/api/logout");
   };
 
   return (

--- a/client/src/components/packing-list.tsx
+++ b/client/src/components/packing-list.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { buildApiUrl } from "@/lib/api";
 import type { PackingItem, User } from "@shared/schema";
 import { format } from "date-fns";
 
@@ -69,7 +70,7 @@ export function PackingList({ tripId }: PackingListProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = buildApiUrl("/api/login");
         }, 500);
         return;
       }
@@ -98,7 +99,7 @@ export function PackingList({ tripId }: PackingListProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = buildApiUrl("/api/login");
         }, 500);
         return;
       }
@@ -131,7 +132,7 @@ export function PackingList({ tripId }: PackingListProps) {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = buildApiUrl("/api/login");
         }, 500);
         return;
       }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,6 +1,26 @@
 // client/src/lib/api.ts
-export async function fetchJSON(path: string) {
-  const res = await fetch(path);
+const rawApiBaseUrl = import.meta.env.VITE_API_URL ?? "";
+const API_BASE_URL = rawApiBaseUrl.replace(/\/+$/, "");
+
+export function buildApiUrl(path: string) {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  if (!API_BASE_URL) {
+    return path;
+  }
+
+  const normalisedPath = path.startsWith("/") ? path.slice(1) : path;
+  return `${API_BASE_URL}/${normalisedPath}`;
+}
+
+export function apiFetch(path: string, init?: RequestInit) {
+  return fetch(buildApiUrl(path), init);
+}
+
+export async function fetchJSON(path: string, init?: RequestInit) {
+  const res = await apiFetch(path, init);
   const text = await res.text();
   // Try to parse JSON, but return raw text if it isn't JSON
   try {

--- a/client/src/lib/locationUtils.ts
+++ b/client/src/lib/locationUtils.ts
@@ -1,4 +1,5 @@
 // Enhanced location utilities with IndexedDB caching and search optimization
+import { apiFetch } from "./api";
 
 interface LocationResult {
   id: string;
@@ -231,7 +232,7 @@ class LocationUtils {
     
     // Make API request
     try {
-      const response = await fetch('/api/locations/search', {
+      const response = await apiFetch('/api/locations/search', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -299,7 +300,7 @@ class LocationUtils {
     }
     
     try {
-      const response = await fetch('/api/locations/stats');
+      const response = await apiFetch('/api/locations/stats');
       
       if (!response.ok) {
         throw new Error(`Stats failed: ${response.status}`);
@@ -320,7 +321,7 @@ class LocationUtils {
   // Refresh all location data
   static async refreshLocationData(): Promise<{ success: boolean; message: string }> {
     try {
-      const response = await fetch('/api/locations/refresh', {
+      const response = await apiFetch('/api/locations/refresh', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { buildApiUrl } from "./api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -32,7 +33,7 @@ export async function apiRequest(
 ): Promise<Response> {
   const body = options.body ? (typeof options.body === 'string' ? options.body : JSON.stringify(options.body)) : undefined;
   
-  const res = await fetch(url, {
+  const res = await fetch(buildApiUrl(url), {
     method: options.method,
     headers: body ? { "Content-Type": "application/json" } : {},
     body,
@@ -49,7 +50,7 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const res = await fetch(buildApiUrl(queryKey.join("/") as string), {
       credentials: "include",
     });
 

--- a/client/src/pages/activities.tsx
+++ b/client/src/pages/activities.tsx
@@ -29,6 +29,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { apiFetch, buildApiUrl } from "@/lib/api";
 import type { TripWithDetails } from "@shared/schema";
 
 interface Activity {
@@ -76,7 +77,7 @@ export default function Activities() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
       return;
     }
@@ -128,7 +129,7 @@ export default function Activities() {
         sortBy
       });
       
-      const response = await fetch(`/api/activities/discover?${params}`, {
+      const response = await apiFetch(`/api/activities/discover?${params}`, {
         credentials: 'include',
       });
       
@@ -187,7 +188,7 @@ export default function Activities() {
       // Combine date and time into ISO string
       const startDateTime = new Date(`${startDate}T${startTime}`).toISOString();
       
-      const response = await fetch(`/api/trips/${tripId}/activities`, {
+      const response = await apiFetch(`/api/trips/${tripId}/activities`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -223,7 +224,7 @@ export default function Activities() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = buildApiUrl("/api/login");
         }, 500);
         return;
       }

--- a/client/src/pages/amadeus-test.tsx
+++ b/client/src/pages/amadeus-test.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Loader2, Plane, Building, MapPin, Calendar, Users, Database } from 'lucide-react';
 import { Link } from 'wouter';
+import { apiFetch } from '@/lib/api';
 
 interface FlightResult {
   id: string;
@@ -90,7 +91,7 @@ export default function AmadeusTest() {
     setFlightLoading(true);
     setFlightError(null);
     try {
-      const response = await fetch('/api/flights/search', {
+      const response = await apiFetch('/api/flights/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(flightForm)
@@ -114,7 +115,7 @@ export default function AmadeusTest() {
     setHotelLoading(true);
     setHotelError(null);
     try {
-      const response = await fetch('/api/hotels/search', {
+      const response = await apiFetch('/api/hotels/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(hotelForm)
@@ -138,7 +139,7 @@ export default function AmadeusTest() {
     setActivityLoading(true);
     setActivityError(null);
     try {
-      const response = await fetch('/api/activities/search', {
+      const response = await apiFetch('/api/activities/search', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(activityForm)

--- a/client/src/pages/flights.tsx
+++ b/client/src/pages/flights.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { buildApiUrl } from "@/lib/api";
 import { format } from "date-fns";
 import { Plane, Clock, MapPin, User, Users, Edit, Trash2, Plus, Search, Filter, ArrowUpDown, SlidersHorizontal, ChevronDown, Share2, ArrowLeft, Check, X, PlaneTakeoff, PlaneLanding, ArrowRight, ExternalLink } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -550,7 +551,9 @@ export default function FlightsPage() {
           description: "You need to be logged in to rank flights.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({
@@ -601,7 +604,9 @@ export default function FlightsPage() {
           description: "You need to be logged in to propose flights.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       console.error("Error proposing flight:", error);

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -19,6 +19,7 @@ import { ManualRefreshButton } from "@/components/manual-refresh-button";
 import { Link } from "wouter";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
+import { buildApiUrl } from "@/lib/api";
 import type { TripWithDetails } from "@shared/schema";
 
 export default function Home() {
@@ -166,7 +167,7 @@ export default function Home() {
                   localStorage.clear();
                   sessionStorage.clear();
                   // Force a full page reload to logout endpoint
-                  window.location.replace('/api/logout');
+                  window.location.replace(buildApiUrl("/api/logout"));
                 }}
               >
                 Logout

--- a/client/src/pages/hotels.tsx
+++ b/client/src/pages/hotels.tsx
@@ -9,6 +9,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { apiFetch, buildApiUrl } from "@/lib/api";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Label } from "@/components/ui/label";
@@ -216,7 +217,7 @@ export default function HotelsPage() {
         return;
       }
 
-      const response = await fetch("/api/hotels/search", {
+      const response = await apiFetch("/api/hotels/search", {
         method: "POST",
         headers: {
           'Content-Type': 'application/json',
@@ -581,7 +582,9 @@ export default function HotelsPage() {
           description: "You need to be logged in to propose hotels.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({
@@ -616,7 +619,9 @@ export default function HotelsPage() {
           description: "You need to be logged in to rank hotels.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({
@@ -671,7 +676,9 @@ export default function HotelsPage() {
           description: "You need to be logged in to add hotels.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({
@@ -706,7 +713,9 @@ export default function HotelsPage() {
           description: "You need to be logged in to update hotels.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({
@@ -737,7 +746,9 @@ export default function HotelsPage() {
           description: "You need to be logged in to delete hotels.",
           variant: "destructive",
         });
-        setTimeout(() => window.location.href = "/api/login", 500);
+        setTimeout(() => {
+          window.location.href = buildApiUrl("/api/login");
+        }, 500);
         return;
       }
       toast({

--- a/client/src/pages/join.tsx
+++ b/client/src/pages/join.tsx
@@ -9,6 +9,7 @@ import { Calendar, MapPin, Users, CheckCircle, AlertCircle, Plane } from "lucide
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { apiFetch, buildApiUrl } from "@/lib/api";
 import { format } from "date-fns";
 
 export default function Join() {
@@ -31,7 +32,7 @@ export default function Join() {
     if (!authLoading && !isAuthenticated && shareCode) {
       // Pass the current path as returnTo parameter
       const returnUrl = encodeURIComponent(window.location.pathname);
-      window.location.href = `/api/login?returnTo=${returnUrl}`;
+      window.location.href = buildApiUrl(`/api/login?returnTo=${returnUrl}`);
       return;
     }
   }, [isAuthenticated, authLoading, shareCode]);
@@ -44,7 +45,7 @@ export default function Join() {
       try {
         setLoading(true);
         // First check if user is already a member by trying to get trip details
-        const tripResponse = await fetch(`/api/trips/share/${shareCode}`, {
+        const tripResponse = await apiFetch(`/api/trips/share/${shareCode}`, {
           credentials: 'include',
         });
         
@@ -78,7 +79,7 @@ export default function Join() {
 
   const joinTripMutation = useMutation({
     mutationFn: async () => {
-      const response = await fetch(`/api/trips/join/${shareCode}`, {
+      const response = await apiFetch(`/api/trips/join/${shareCode}`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Calendar, Users, MapPin, Bell, Plane, Camera, Heart, Compass, Star } from "lucide-react";
 import { HeroTravelMascot, TravelMascot, TravelDecorations } from "@/components/TravelMascot";
+import { buildApiUrl } from "@/lib/api";
 
 export default function Landing() {
   return (
@@ -43,9 +44,9 @@ export default function Landing() {
             and create unforgettable memories together with personalized travel calendars.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <Button 
+            <Button
               size="lg"
-              onClick={() => window.location.href = '/api/login'}
+              onClick={() => (window.location.href = buildApiUrl("/api/login"))}
               className="sunset-gradient hover:opacity-90 text-white text-lg px-8 py-4 font-semibold shadow-2xl hover:shadow-3xl transition-all duration-300 transform hover:scale-105"
             >
               <Plane className="mr-2 w-5 h-5" />

--- a/client/src/pages/location-database.tsx
+++ b/client/src/pages/location-database.tsx
@@ -10,6 +10,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Loader2, Search, Database, MapPin, Plane, Building, Globe, RefreshCw, Download, TestTube, CheckCircle, XCircle } from 'lucide-react';
 import LocationTestSuite, { TestResult } from '@/lib/locationTests';
+import { apiFetch } from '@/lib/api';
 
 interface LocationResult {
   id: string;
@@ -68,7 +69,7 @@ export default function LocationDatabase() {
   const loadStats = async () => {
     setStatsLoading(true);
     try {
-      const response = await fetch('/api/locations/stats');
+      const response = await apiFetch('/api/locations/stats');
       if (response.ok) {
         const data = await response.json();
         setStats(data);
@@ -88,7 +89,7 @@ export default function LocationDatabase() {
     setSearchResults([]);
     
     try {
-      const response = await fetch('/api/locations/search', {
+      const response = await apiFetch('/api/locations/search', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -122,7 +123,7 @@ export default function LocationDatabase() {
     setRefreshProgress(null);
     
     try {
-      const response = await fetch('/api/locations/refresh', {
+      const response = await apiFetch('/api/locations/refresh', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/client/src/pages/member-schedule.tsx
+++ b/client/src/pages/member-schedule.tsx
@@ -17,6 +17,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { buildApiUrl } from "@/lib/api";
 import { ActivityCard } from "@/components/activity-card";
 import { CalendarGrid } from "@/components/calendar-grid";
 import { Sidebar } from "@/components/sidebar";
@@ -43,7 +44,7 @@ export default function MemberSchedule() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
       return;
     }
@@ -70,7 +71,7 @@ export default function MemberSchedule() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
     }
   }, [tripError, toast]);

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -20,6 +20,7 @@ import { useOnboarding } from "@/hooks/useOnboarding";
 import { Smartphone, Settings, User as UserIcon, MapPin, Plane, PlayCircle, ArrowLeft, Search } from "lucide-react";
 import { useState, useEffect } from "react";
 import { Link } from "wouter";
+import { apiFetch } from "@/lib/api";
 
 const profileFormSchema = z.object({
   cashAppUsername: z.string().optional(),
@@ -67,7 +68,7 @@ export default function Profile() {
     }
 
     try {
-      const response = await fetch(`/api/locations/search?q=${encodeURIComponent(query)}`);
+      const response = await apiFetch(`/api/locations/search?q=${encodeURIComponent(query)}`);
       if (response.ok) {
         const results = await response.json();
         setLocationResults(results);

--- a/client/src/pages/proposals.tsx
+++ b/client/src/pages/proposals.tsx
@@ -12,6 +12,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { buildApiUrl } from "@/lib/api";
 import { format, formatDistanceToNow } from "date-fns";
 import { 
   ArrowLeft,
@@ -67,7 +68,7 @@ function ProposalsPage({ tripId }: ProposalsPageProps = {}) {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
     }
   }, [authLoading, isAuthenticated, toast]);
@@ -78,7 +79,7 @@ function ProposalsPage({ tripId }: ProposalsPageProps = {}) {
     enabled: !!tripId && isAuthenticated,
     retry: (failureCount, error) => {
       if (isUnauthorizedError(error)) {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
         return false;
       }
       return failureCount < 3;
@@ -127,7 +128,7 @@ function ProposalsPage({ tripId }: ProposalsPageProps = {}) {
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
         return;
       }
       toast({
@@ -155,7 +156,7 @@ function ProposalsPage({ tripId }: ProposalsPageProps = {}) {
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
         return;
       }
       toast({
@@ -183,7 +184,7 @@ function ProposalsPage({ tripId }: ProposalsPageProps = {}) {
     },
     onError: (error) => {
       if (isUnauthorizedError(error)) {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
         return;
       }
       toast({

--- a/client/src/pages/restaurants.tsx
+++ b/client/src/pages/restaurants.tsx
@@ -21,6 +21,7 @@ import { format } from "date-fns";
 import { CalendarIcon, MapPin, Phone, Clock, Star, Users, ExternalLink, Search, Filter, ChefHat, DollarSign, SortAsc, Utensils, Globe, ArrowLeft } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { apiRequest } from "@/lib/queryClient";
+import { apiFetch, buildApiUrl } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import type { TripWithDetails, RestaurantWithDetails } from "@shared/schema";
 import SmartLocationSearch from "@/components/SmartLocationSearch";
@@ -104,7 +105,7 @@ export default function RestaurantsPage() {
         params.append("priceRange", searchPriceRange);
       }
       
-      const response = await fetch(`/api/restaurants/search?${params}`);
+      const response = await apiFetch(`/api/restaurants/search?${params}`);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
@@ -177,7 +178,7 @@ export default function RestaurantsPage() {
           variant: "destructive",
         });
         setTimeout(() => {
-          window.location.href = "/api/login";
+          window.location.href = buildApiUrl("/api/login");
         }, 500);
         return;
       }
@@ -280,7 +281,7 @@ export default function RestaurantsPage() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
       return;
     }

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -34,6 +34,7 @@ import {
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { apiFetch, buildApiUrl } from "@/lib/api";
 import { CalendarGrid } from "@/components/calendar-grid";
 import { ActivityCard } from "@/components/activity-card";
 import { AddActivityModal } from "@/components/add-activity-modal";
@@ -87,7 +88,7 @@ export default function Trip() {
         variant: "destructive",
       });
       setTimeout(() => {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
       }, 500);
     }
   }, [authLoading, isAuthenticated, toast]);
@@ -98,7 +99,7 @@ export default function Trip() {
     enabled: !!id && isAuthenticated,
     retry: (failureCount, error) => {
       if (isUnauthorizedError(error)) {
-        window.location.href = "/api/login";
+        window.location.href = buildApiUrl("/api/login");
         return false;
       }
       return failureCount < 3;
@@ -1218,7 +1219,7 @@ function WeatherReport({ trip }: { trip: TripWithDetails }) {
         endDate: new Date(trip.endDate).toISOString().split('T')[0]
       });
       
-      const response = await fetch(`/api/weather?${params}`);
+      const response = await apiFetch(`/api/weather?${params}`);
       if (!response.ok) {
         throw new Error(`Weather API error: ${response.status}`);
       }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,42 +1,45 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
 
-export default defineConfig({
-  plugins: [
-    react(),
-    runtimeErrorOverlay(),
-    ...(process.env.NODE_ENV !== "production" &&
-    process.env.REPL_ID !== undefined
+export default defineConfig(async ({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const rawApiUrl = env.VITE_API_URL ?? "http://127.0.0.1:5000";
+  const apiProxyTarget = rawApiUrl.replace(/\/+$/, "");
+
+  const replitPlugins =
+    process.env.NODE_ENV !== "production" && process.env.REPL_ID !== undefined
       ? [
           await import("@replit/vite-plugin-cartographer").then((m) =>
             m.cartographer(),
           ),
         ]
-      : []),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
-    },
-  },
-  root: path.resolve(import.meta.dirname, "client"), // still point to client
-build: {
-  outDir: "dist", // ✅ relative to client → ends up in VacationSync/dist
-  emptyOutDir: true,
-},
+      : [];
 
-  server: {
-    fs: {
-      strict: true,
-      deny: ["**/.*"],
+  return {
+    plugins: [react(), runtimeErrorOverlay(), ...replitPlugins],
+    resolve: {
+      alias: {
+        "@": path.resolve(import.meta.dirname, "client", "src"),
+        "@shared": path.resolve(import.meta.dirname, "shared"),
+        "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      },
     },
-    proxy: {
-      "/health": "http://127.0.0.1:3000",
-      "/search": "http://127.0.0.1:3000",
+    root: path.resolve(import.meta.dirname, "client"), // still point to client
+    build: {
+      outDir: "dist", // ✅ relative to client → ends up in VacationSync/dist
+      emptyOutDir: true,
     },
-  },
+    server: {
+      fs: {
+        strict: true,
+        deny: ["**/.*"],
+      },
+      proxy: {
+        "/health": apiProxyTarget,
+        "/search": apiProxyTarget,
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- centralize API URL resolution through `buildApiUrl`/`apiFetch` and update React Query helpers and components to consume `import.meta.env.VITE_API_URL`
- ensure redirects and forms that hit backend routes build their targets from the environment and provide a default `.env.local`
- load `VITE_API_URL` in `vite.config.ts` so dev proxies follow the configured backend origin

## Testing
- npm run check *(fails: repository already has numerous TypeScript errors in client and server code)*

------
https://chatgpt.com/codex/tasks/task_e_68cda03b3cd08329b75aeb5d1208435e