### PR TITLE
Update Vercel config to use client dist directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,10 +2,12 @@
   "builds": [
     {
       "src": "package.json",
-      "use": "@vercel/static-build"
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "client/dist"
+      }
     }
-  ],
-  "outputDirectory": "dist"
+  ]
 }
 
 


### PR DESCRIPTION
## Summary
- configure the Vercel static build to point at the client/dist output directory
- remove the deprecated top-level outputDirectory setting now that the build config specifies distDir

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cdb80e1a508329b875026aba508f90