### PR TITLE
Update Vercel distDir to match Vite build output

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
       "src": "package.json",
       "use": "@vercel/static-build",
       "config": {
-        "distDir": "dist"
+        "distDir": "client/dist"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- adjust the Vercel static build configuration to use the Vite output folder `client/dist`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdcc48581083298767480b528d4cdd