### PR TITLE
Add fallback routes to Vercel configuration

### DIFF
--- a/client/vercel.json
+++ b/client/vercel.json
@@ -7,6 +7,10 @@
         "distDir": "dist"
       }
     }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- add a filesystem handler and catch-all route in the Vercel config so non-file requests serve the SPA entrypoint

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d17a178be88329b91247c80887d9d7