### PR TITLE
Fix login redirect to authenticated home

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -71,7 +71,7 @@ export default function Login() {
         title: "Welcome back!",
         description: "You have successfully logged in.",
       });
-      setLocation(safeReturnTo ?? "/home"); // ✅ redirect into app
+      setLocation(safeReturnTo ?? "/"); // ✅ redirect into app
     },
     onError: (error: any) => {
       let errorMessage = "Invalid username/email or password.";


### PR DESCRIPTION
## Summary
- update the login mutation success handler to default to the authenticated home route instead of /home

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d1b089857c832998ef69b83d389671