### PR TITLE
Use shared DB pool for session store

### DIFF
--- a/server/sessionAuth.ts
+++ b/server/sessionAuth.ts
@@ -2,6 +2,8 @@ import type { Express, RequestHandler } from "express";
 import session, { type CookieOptions, type SessionOptions } from "express-session";
 import connectPg from "connect-pg-simple";
 
+import { pool } from "./db";
+
 const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000;
 
 declare module "express-session" {
@@ -53,7 +55,7 @@ function buildSessionOptions(): SessionOptions {
 
   if (process.env.DATABASE_URL) {
     options.store = new PgStore({
-      conString: process.env.DATABASE_URL,
+      pool,
       tableName: "sessions",
       createTableIfMissing: false,
     });


### PR DESCRIPTION
## Summary
- import the shared database pool into the session auth module
- configure the Postgres session store to reuse the shared pool for TLS-enabled connections

## Testing
- `npm run check` *(fails: existing TypeScript errors in unrelated client and server files)*

------
https://chatgpt.com/codex/tasks/task_e_68d1bbf15b8883298684df5140736c6c