### PR TITLE
Add owner membership record when creating trips

### DIFF
--- a/client/src/components/member-list.tsx
+++ b/client/src/components/member-list.tsx
@@ -61,7 +61,8 @@ export function MemberList({ trip }: MemberListProps) {
                           {member.user.id === trip.createdBy && (
                             <Crown className="w-4 h-4 text-yellow-500" />
                           )}
-                          {member.role === 'organizer' && member.user.id !== trip.createdBy && (
+                          {(member.role === 'organizer' || member.role === 'owner') &&
+                            member.user.id !== trip.createdBy && (
                             <Badge variant="secondary" className="text-xs">
                               Organizer
                             </Badge>


### PR DESCRIPTION
## Summary
- ensure createTrip adds the creator to trip_members with owner/admin defaults based on available columns
- look up trip_members column metadata so inserts work whether role or is_admin exists
- treat owner roles consistently when joining and when rendering the member list badge

## Testing
- npm run check *(fails: existing TypeScript errors throughout project)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ec777ed8832994a4142a6a71fc5b