### PR TITLE
Configure CORS for deployed frontend

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -8,13 +8,25 @@ import { createSessionMiddleware } from "./sessionAuth";
 const app = express();
 app.set("trust proxy", 1);
 
-const corsOrigins = (process.env.CORS_ORIGINS ?? process.env.CORS_ORIGIN ?? "")
-  .split(",")
-  .map((origin) => origin.trim())
-  .filter(Boolean);
+const defaultClientUrl = process.env.CLIENT_URL ?? "http://localhost:3000";
+const allowedOrigins = Array.from(
+  new Set(
+    [
+      process.env.CORS_ORIGINS,
+      process.env.CORS_ORIGIN,
+      defaultClientUrl,
+      "https://vacation-sync-urgg.vercel.app",
+      "http://localhost:3000",
+    ]
+      .filter(Boolean)
+      .flatMap((originString) => originString!.split(","))
+      .map((origin) => origin.trim())
+      .filter(Boolean)
+  )
+);
 
 const corsOptions: CorsOptions = {
-  origin: corsOrigins.length ? corsOrigins : true,
+  origin: allowedOrigins,
   credentials: true,
 };
 


### PR DESCRIPTION
## Summary
- configure Express CORS middleware to whitelist the deployed frontend, CLIENT_URL env fallback, and localhost
- ensure credentials are allowed and the middleware runs before other handlers

## Testing
- npm run check *(fails: existing TypeScript errors across client and server unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d1f24d9e80832980db7d16e9dbf2ac