### PR TITLE
Fix add expense modal grid layout

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -4,15 +4,32 @@ import { useMutation, useQueryClient, useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { apiRequest } from "@/lib/queryClient";
-import { generateCashAppUrl, generateVenmoUrl, generatePaymentNote } from "@/lib/paymentUtils";
+import {
+  generateCashAppUrl,
+  generateVenmoUrl,
+  generatePaymentNote,
+} from "@/lib/paymentUtils";
 import { CurrencyConverter } from "@/components/currency-converter";
 import { useToast } from "@/hooks/use-toast";
 import { insertExpenseSchema, type TripWithDetails } from "@shared/schema";
@@ -25,31 +42,42 @@ interface AddExpenseModalProps {
   tripId: number;
 }
 
-const formSchema = insertExpenseSchema.omit({ 
-  tripId: true 
-}).extend({
-  amount: z.string().min(1, "Amount is required").refine(
-    (val) => !isNaN(parseFloat(val)) && parseFloat(val) > 0,
-    "Amount must be a positive number"
-  ),
-  selectedMembers: z.array(z.string()).min(1, "Select at least one member to split with"),
-});
+const formSchema = insertExpenseSchema
+  .omit({
+    tripId: true,
+  })
+  .extend({
+    amount: z
+      .string()
+      .min(1, "Amount is required")
+      .refine(
+        (val) => !isNaN(parseFloat(val)) && parseFloat(val) > 0,
+        "Amount must be a positive number",
+      ),
+    selectedMembers: z
+      .array(z.string())
+      .min(1, "Select at least one member to split with"),
+  });
 
 type FormData = z.infer<typeof formSchema>;
 
 const expenseCategories = [
-  { value: 'food', label: 'Food & Dining' },
-  { value: 'transport', label: 'Transportation' },
-  { value: 'accommodation', label: 'Accommodation' },
-  { value: 'entertainment', label: 'Entertainment' },
-  { value: 'shopping', label: 'Shopping' },
-  { value: 'other', label: 'Other' },
+  { value: "food", label: "Food & Dining" },
+  { value: "transport", label: "Transportation" },
+  { value: "accommodation", label: "Accommodation" },
+  { value: "entertainment", label: "Entertainment" },
+  { value: "shopping", label: "Shopping" },
+  { value: "other", label: "Other" },
 ];
 
-export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalProps) {
+export function AddExpenseModal({
+  open,
+  onOpenChange,
+  tripId,
+}: AddExpenseModalProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [requestCurrency, setRequestCurrency] = useState<string>('USD'); // Currency to request payment in
+  const [requestCurrency, setRequestCurrency] = useState<string>("USD"); // Currency to request payment in
   const [conversionData, setConversionData] = useState<{
     fromCurrency: string;
     toCurrency: string;
@@ -79,11 +107,11 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      description: '',
-      amount: '',
-      category: 'other',
-      currency: 'USD',
-      splitType: 'equal',
+      description: "",
+      amount: "",
+      category: "other",
+      currency: "USD",
+      splitType: "equal",
       activityId: undefined,
       splitData: null,
       receiptUrl: undefined,
@@ -95,7 +123,7 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
     mutationFn: async (data: FormData) => {
       const totalAmount = parseFloat(data.amount);
       const splitAmount = totalAmount / data.selectedMembers.length;
-      
+
       const expenseData = {
         ...data,
         amount: totalAmount,
@@ -103,18 +131,22 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
         splitData: {
           members: data.selectedMembers,
           splitAmount: splitAmount,
-          splitType: 'equal'
-        }
+          splitType: "equal",
+        },
       };
-      
+
       await apiRequest(`/api/trips/${tripId}/expenses`, {
-        method: 'POST',
+        method: "POST",
         body: JSON.stringify(expenseData),
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/expenses`] });
-      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/expenses/balances`] });
+      queryClient.invalidateQueries({
+        queryKey: [`/api/trips/${tripId}/expenses`],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [`/api/trips/${tripId}/expenses/balances`],
+      });
       toast({
         title: "Success",
         description: "Expense added successfully",
@@ -141,7 +173,7 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit(onSubmit)}
-            className="flex h-full min-h-0 flex-col"
+            className="grid h-full min-h-0 flex-1 grid-rows-[auto_minmax(0,1fr)_auto]"
           >
             <header className="flex items-center border-b border-border px-6 py-5 pr-12">
               <DialogTitle className="text-lg font-semibold">
@@ -149,7 +181,7 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
               </DialogTitle>
             </header>
 
-            <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5 pb-32 overscroll-contain sm:pb-8">
+            <div className="min-h-0 space-y-6 overflow-y-auto px-6 py-5 pb-32 overscroll-contain sm:pb-8">
               <FormField
                 control={form.control}
                 name="description"
@@ -167,20 +199,31 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
               <div className="space-y-3">
                 <FormLabel>Amount &amp; Currency</FormLabel>
                 <CurrencyConverter
-                  amount={form.watch('amount') || ''}
-                  onAmountChange={(amount) => form.setValue('amount', amount)}
-                  currency={form.watch('currency') || 'USD'}
-                  onCurrencyChange={(currency) => form.setValue('currency', currency)}
+                  amount={form.watch("amount") || ""}
+                  onAmountChange={(amount) => form.setValue("amount", amount)}
+                  currency={form.watch("currency") || "USD"}
+                  onCurrencyChange={(currency) =>
+                    form.setValue("currency", currency)
+                  }
                   tripId={tripId}
-                  showConversion={requestCurrency !== (form.watch('currency') || 'USD')}
-                  onConversionChange={(conversion) => setConversionData(conversion)}
+                  showConversion={
+                    requestCurrency !== (form.watch("currency") || "USD")
+                  }
+                  onConversionChange={(conversion) =>
+                    setConversionData(conversion)
+                  }
                   targetCurrency={requestCurrency}
                 />
 
                 <div className="rounded-lg border bg-blue-50 p-4 shadow-sm shadow-blue-100/20">
                   <div className="mb-3 flex items-center justify-between gap-3">
-                    <label className="text-sm font-medium text-blue-900">Request payment in:</label>
-                    <Select value={requestCurrency} onValueChange={setRequestCurrency}>
+                    <label className="text-sm font-medium text-blue-900">
+                      Request payment in:
+                    </label>
+                    <Select
+                      value={requestCurrency}
+                      onValueChange={setRequestCurrency}
+                    >
                       <SelectTrigger className="w-32">
                         <SelectValue />
                       </SelectTrigger>
@@ -195,22 +238,25 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                     </Select>
                   </div>
                   <p className="min-h-[18px] text-xs text-blue-700">
-                    {requestCurrency === (form.watch('currency') || 'USD')
+                    {requestCurrency === (form.watch("currency") || "USD")
                       ? "Using original expense currency - no conversion needed"
-                      : `Payment requests will use ${requestCurrency} (converted from ${form.watch('currency') || 'USD'})`}
+                      : `Payment requests will use ${requestCurrency} (converted from ${form.watch("currency") || "USD"})`}
                   </p>
                 </div>
 
                 <div className="flex min-h-[44px] flex-col justify-center rounded-lg border border-green-200 bg-green-50 p-3">
-                  {requestCurrency !== (form.watch('currency') || 'USD') ? (
+                  {requestCurrency !== (form.watch("currency") || "USD") ? (
                     conversionData ? (
                       <div className="flex flex-col gap-2 text-sm text-green-800 sm:flex-row sm:items-center sm:justify-between">
                         <span>
-                          {form.watch('currency')} {form.watch('amount')} = {requestCurrency}{' '}
+                          {form.watch("currency")} {form.watch("amount")} ={" "}
+                          {requestCurrency}{" "}
                           {conversionData.convertedAmount.toFixed(2)}
                         </span>
                         <span className="text-xs text-green-600">
-                          Rate: 1 {conversionData.fromCurrency} = {conversionData.rate.toFixed(4)} {conversionData.toCurrency}
+                          Rate: 1 {conversionData.fromCurrency} ={" "}
+                          {conversionData.rate.toFixed(4)}{" "}
+                          {conversionData.toCurrency}
                         </span>
                       </div>
                     ) : (
@@ -220,7 +266,8 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                     )
                   ) : (
                     <span className="text-xs text-green-700">
-                      Select a different request currency to preview conversion details here.
+                      Select a different request currency to preview conversion
+                      details here.
                     </span>
                   )}
                 </div>
@@ -228,11 +275,11 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                 <p
                   className={`min-h-[18px] text-xs ${
                     form.formState.errors.amount
-                      ? 'font-medium text-destructive'
-                      : 'text-muted-foreground'
+                      ? "font-medium text-destructive"
+                      : "text-muted-foreground"
                   }`}
                 >
-                  {form.formState.errors.amount?.message ?? ' '}
+                  {form.formState.errors.amount?.message ?? " "}
                 </p>
               </div>
 
@@ -242,7 +289,10 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Category</FormLabel>
-                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder="Select a category" />
@@ -250,7 +300,10 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                       </FormControl>
                       <SelectContent>
                         {expenseCategories.map((category) => (
-                          <SelectItem key={category.value} value={category.value}>
+                          <SelectItem
+                            key={category.value}
+                            value={category.value}
+                          >
                             {category.label}
                           </SelectItem>
                         ))}
@@ -275,7 +328,9 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                       </CardHeader>
                       <CardContent className="space-y-2">
                         {trip?.members?.map((member) => {
-                          const isSelected = field.value.includes(member.user.id);
+                          const isSelected = field.value.includes(
+                            member.user.id,
+                          );
                           return (
                             <div
                               key={member.user.id}
@@ -287,14 +342,20 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                                 onCheckedChange={(checked) => {
                                   const newSelection = checked
                                     ? [...field.value, member.user.id]
-                                    : field.value.filter((id) => id !== member.user.id);
+                                    : field.value.filter(
+                                        (id) => id !== member.user.id,
+                                      );
                                   field.onChange(newSelection);
                                 }}
                               />
                               <Avatar className="h-8 w-8">
-                                <AvatarImage src={member.user.profileImageUrl || undefined} />
+                                <AvatarImage
+                                  src={member.user.profileImageUrl || undefined}
+                                />
                                 <AvatarFallback>
-                                  {member.user.firstName?.[0] || member.user.email?.[0] || 'U'}
+                                  {member.user.firstName?.[0] ||
+                                    member.user.email?.[0] ||
+                                    "U"}
                                 </AvatarFallback>
                               </Avatar>
                               <div className="min-w-0 flex-1">
@@ -302,14 +363,22 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                                   {member.user.firstName} {member.user.lastName}
                                 </p>
                                 <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
-                                  {(member.user.cashAppUsername || member.user.phoneNumber) && (
-                                    <Badge variant="secondary" className="text-xs whitespace-nowrap">
+                                  {(member.user.cashAppUsername ||
+                                    member.user.phoneNumber) && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-xs whitespace-nowrap"
+                                    >
                                       <Smartphone className="mr-1 h-3 w-3" />
                                       CashApp
                                     </Badge>
                                   )}
-                                  {(member.user.venmoUsername || member.user.phoneNumber) && (
-                                    <Badge variant="secondary" className="text-xs whitespace-nowrap">
+                                  {(member.user.venmoUsername ||
+                                    member.user.phoneNumber) && (
+                                    <Badge
+                                      variant="secondary"
+                                      className="text-xs whitespace-nowrap"
+                                    >
                                       <Smartphone className="mr-1 h-3 w-3" />
                                       Venmo
                                     </Badge>
@@ -328,17 +397,25 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                                 <div className="ml-auto text-right">
                                   <p className="text-sm font-medium">
                                     {(() => {
-                                      const expenseCurrency = form.watch('currency') || 'USD';
-                                      const originalAmount = parseFloat(form.watch('amount') || '0');
+                                      const expenseCurrency =
+                                        form.watch("currency") || "USD";
+                                      const originalAmount = parseFloat(
+                                        form.watch("amount") || "0",
+                                      );
 
-                                      if (requestCurrency !== expenseCurrency && conversionData) {
+                                      if (
+                                        requestCurrency !== expenseCurrency &&
+                                        conversionData
+                                      ) {
                                         return `${requestCurrency} ${(conversionData.convertedAmount / field.value.length).toFixed(2)}`;
                                       }
 
                                       return `${expenseCurrency} ${(originalAmount / field.value.length).toFixed(2)}`;
                                     })()}
                                   </p>
-                                  <p className="text-xs text-gray-500">per person</p>
+                                  <p className="text-xs text-gray-500">
+                                    per person
+                                  </p>
                                 </div>
                               )}
                             </div>
@@ -351,7 +428,7 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                 )}
               />
 
-              {form.watch('selectedMembers')?.length > 0 && (
+              {form.watch("selectedMembers")?.length > 0 && (
                 <Card>
                   <CardHeader className="pb-3">
                     <CardTitle className="flex items-center gap-2 text-sm font-medium">
@@ -360,17 +437,27 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                     </CardTitle>
                   </CardHeader>
                   <CardContent className="space-y-2">
-                    {form.watch('selectedMembers')?.map((memberId) => {
-                      const member = trip?.members?.find((m) => m.user.id === memberId)?.user;
+                    {form.watch("selectedMembers")?.map((memberId) => {
+                      const member = trip?.members?.find(
+                        (m) => m.user.id === memberId,
+                      )?.user;
                       if (!member) return null;
 
-                      const expenseCurrency = form.watch('currency') || 'USD';
-                      const originalAmount = parseFloat(form.watch('amount') || '0');
+                      const expenseCurrency = form.watch("currency") || "USD";
+                      const originalAmount = parseFloat(
+                        form.watch("amount") || "0",
+                      );
 
                       const splitAmount =
                         requestCurrency !== expenseCurrency && conversionData
-                          ? (conversionData.convertedAmount / form.watch('selectedMembers').length).toFixed(2)
-                          : (originalAmount / form.watch('selectedMembers').length).toFixed(2);
+                          ? (
+                              conversionData.convertedAmount /
+                              form.watch("selectedMembers").length
+                            ).toFixed(2)
+                          : (
+                              originalAmount /
+                              form.watch("selectedMembers").length
+                            ).toFixed(2);
 
                       const displayCurrency = requestCurrency;
 
@@ -381,9 +468,13 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                         >
                           <div className="flex items-center gap-2">
                             <Avatar className="h-6 w-6">
-                              <AvatarImage src={member.profileImageUrl || undefined} />
+                              <AvatarImage
+                                src={member.profileImageUrl || undefined}
+                              />
                               <AvatarFallback className="text-xs">
-                                {member.firstName?.[0] || member.email?.[0] || 'U'}
+                                {member.firstName?.[0] ||
+                                  member.email?.[0] ||
+                                  "U"}
                               </AvatarFallback>
                             </Avatar>
                             <span className="text-sm font-medium">
@@ -396,12 +487,19 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                             </span>
                             <div className="flex flex-wrap gap-2">
                               {(() => {
-                                const cashAppUrl = generateCashAppUrl(member, splitAmount);
-                                const expenseName = form.getValues().description;
+                                const cashAppUrl = generateCashAppUrl(
+                                  member,
+                                  splitAmount,
+                                );
+                                const expenseName =
+                                  form.getValues().description;
                                 const venmoUrl = generateVenmoUrl(
                                   member,
                                   splitAmount,
-                                  generatePaymentNote(expenseName || 'Trip expense', trip?.name || undefined)
+                                  generatePaymentNote(
+                                    expenseName || "Trip expense",
+                                    trip?.name || undefined,
+                                  ),
                                 );
 
                                 return (
@@ -412,12 +510,12 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                                         variant="outline"
                                         size="sm"
                                         onClick={() => {
-                                          window.open(cashAppUrl, '_blank');
+                                          window.open(cashAppUrl, "_blank");
                                           toast({
-                                            title: 'Opening CashApp',
+                                            title: "Opening CashApp",
                                             description: member.phoneNumber
-                                              ? 'Redirecting to CashApp with phone number for direct payment'
-                                              : 'Redirecting to CashApp with username',
+                                              ? "Redirecting to CashApp with phone number for direct payment"
+                                              : "Redirecting to CashApp with username",
                                           });
                                         }}
                                         className="px-2 py-1 text-xs"
@@ -431,12 +529,12 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                                         variant="outline"
                                         size="sm"
                                         onClick={() => {
-                                          window.open(venmoUrl, '_blank');
+                                          window.open(venmoUrl, "_blank");
                                           toast({
-                                            title: 'Opening Venmo',
+                                            title: "Opening Venmo",
                                             description: member.phoneNumber
-                                              ? 'Redirecting to Venmo with phone number for direct payment'
-                                              : 'Redirecting to Venmo with username',
+                                              ? "Redirecting to Venmo with phone number for direct payment"
+                                              : "Redirecting to Venmo with username",
                                           });
                                         }}
                                         className="px-2 py-1 text-xs"
@@ -462,7 +560,10 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                 render={({ field }) => (
                   <FormItem className="hidden">
                     <FormLabel>Split Type</FormLabel>
-                    <Select onValueChange={field.onChange} defaultValue={field.value}>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
                       <FormControl>
                         <SelectTrigger>
                           <SelectValue placeholder="How to split the expense" />
@@ -470,7 +571,9 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                       </FormControl>
                       <SelectContent>
                         <SelectItem value="equal">Split Equally</SelectItem>
-                        <SelectItem value="percentage">By Percentage</SelectItem>
+                        <SelectItem value="percentage">
+                          By Percentage
+                        </SelectItem>
                         <SelectItem value="exact">Exact Amounts</SelectItem>
                       </SelectContent>
                     </Select>
@@ -489,7 +592,7 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                       <Input
                         placeholder="Link to receipt or photo"
                         {...field}
-                        value={field.value || ''}
+                        value={field.value || ""}
                       />
                     </FormControl>
                     <FormMessage />
@@ -512,7 +615,9 @@ export function AddExpenseModal({ open, onOpenChange, tripId }: AddExpenseModalP
                 className="w-full sm:w-auto"
                 disabled={createExpenseMutation.isPending}
               >
-                {createExpenseMutation.isPending ? 'Adding...' : 'Create expense'}
+                {createExpenseMutation.isPending
+                  ? "Adding..."
+                  : "Create expense"}
               </Button>
             </footer>
           </form>


### PR DESCRIPTION
## Summary
- make the add expense modal form the grid container so the header, scrollable body, and sticky footer stay aligned
- constrain the modal body with `min-h-0` overflow handling so payment quick links appear without forcing the page to scroll
- rerun Prettier on the modal component for consistent formatting

## Testing
- npx prettier --write client/src/components/add-expense-modal.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d2d3b9a2b8832eb831e0229601c7dd