### PR TITLE
Capture structured grocery notes

### DIFF
--- a/client/src/components/grocery-list.tsx
+++ b/client/src/components/grocery-list.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -9,15 +9,93 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
-import { Plus, ShoppingCart, Receipt, DollarSign, Trash2 } from "lucide-react";
-import type { GroceryItemWithDetails, User } from "@shared/schema";
+import { Plus, ShoppingCart, Receipt, DollarSign, Trash2, Users } from "lucide-react";
+import type { GroceryItemWithDetails, TripMember, User } from "@shared/schema";
 
 interface GroceryListProps {
   tripId: number;
   user?: User;
+  members?: TripMemberWithUser[];
 }
+
+type NewGroceryItemForm = {
+  item: string;
+  category: string;
+  quantity: string;
+  estimatedCost: string;
+  notes: string;
+  allergies: string;
+  exclusions: string;
+};
+
+type TripMemberWithUser = TripMember & { user: User };
+
+const normalizeTagList = (value: unknown): string[] => {
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+      .filter((entry) => entry.length > 0);
+  }
+
+  return [];
+};
+
+const toStructuredNotes = (
+  notes: GroceryItemWithDetails["notes"],
+): { text: string; allergies: string[]; exclusions: string[] } => {
+  if (!notes) {
+    return { text: "", allergies: [], exclusions: [] };
+  }
+
+  if (typeof notes === "string") {
+    return { text: notes.trim(), allergies: [], exclusions: [] };
+  }
+
+  return {
+    text: typeof notes.text === "string" ? notes.text.trim() : "",
+    allergies: normalizeTagList(notes.allergies),
+    exclusions: normalizeTagList(notes.exclusions),
+  };
+};
+
+const renderTagBadges = (
+  tags: string[],
+  prefix: string,
+  variant: "destructive" | "outline",
+) =>
+  tags.length > 0 ? (
+    <div className="flex flex-wrap gap-2 mt-2">
+      {tags.map((tag) => (
+        <Badge key={tag} variant={variant}>
+          {prefix}
+          {tag}
+        </Badge>
+      ))}
+    </div>
+  ) : null;
+
+const renderNotesSection = (notes: GroceryItemWithDetails["notes"]) => {
+  const { text, allergies, exclusions } = toStructuredNotes(notes);
+
+  return (
+    <>
+      {text && <p className="text-sm text-gray-600 mt-1">{text}</p>}
+      {renderTagBadges(allergies, "Allergy: ", "destructive")}
+      {renderTagBadges(exclusions, "Exclude: ", "outline")}
+    </>
+  );
+};
 
 const categories = [
   "produce",
@@ -31,19 +109,25 @@ const categories = [
   "other"
 ];
 
-export function GroceryList({ tripId, user }: GroceryListProps) {
+export function GroceryList({ tripId, user, members = [] }: GroceryListProps) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
-  const [newItem, setNewItem] = useState({
-    name: "",
+  const [activeAllergyFilters, setActiveAllergyFilters] = useState<string[]>([]);
+  const createEmptyNewItem = (): NewGroceryItemForm => ({
+    item: "",
     category: "other",
     estimatedCost: "",
     notes: "",
-    quantity: 1,
+    allergies: "",
+    exclusions: "",
+    quantity: "1",
   });
+  const [newItem, setNewItem] = useState<NewGroceryItemForm>(createEmptyNewItem());
+  const allergyPreview = normalizeTagList(newItem.allergies);
+  const exclusionPreview = normalizeTagList(newItem.exclusions);
 
-  const { data: groceryItems = [], isLoading } = useQuery({
+  const { data: groceryItems = [], isLoading } = useQuery<GroceryItemWithDetails[]>({
     queryKey: ["/api/trips", tripId, "groceries"],
   });
 
@@ -66,15 +150,18 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
         description: "Item added to grocery list",
       });
       setIsAddDialogOpen(false);
-      setNewItem({ name: "", category: "other", estimatedCost: "", notes: "", quantity: 1 });
+      setNewItem(createEmptyNewItem());
     },
   });
 
   const participateMutation = useMutation({
-    mutationFn: async (itemId: number) => {
-      return await apiRequest(`/api/groceries/${itemId}/participate`, {
-        method: "POST",
-      });
+    mutationFn: async ({ itemId, userId }: { itemId: number; userId?: string }) => {
+      const options: { method: string; body?: any } = { method: "POST" };
+      if (userId) {
+        options.body = { userId };
+      }
+
+      return await apiRequest(`/api/groceries/${itemId}/participate`, options);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/trips", tripId, "groceries"] });
@@ -116,16 +203,32 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
   });
 
   const handleAddItem = () => {
-    if (!newItem.name.trim()) return;
-    
+    const itemName = newItem.item.trim();
+    if (!itemName) return;
+
+    const estimatedCostValue = parseFloat(newItem.estimatedCost);
+    const quantityValue = newItem.quantity.trim();
+    const notesText = newItem.notes.trim();
+    const notesPayload =
+      notesText || allergyPreview.length || exclusionPreview.length
+        ? {
+            ...(notesText ? { text: notesText } : {}),
+            ...(allergyPreview.length ? { allergies: allergyPreview } : {}),
+            ...(exclusionPreview.length ? { exclusions: exclusionPreview } : {}),
+          }
+        : undefined;
+
     addItemMutation.mutate({
-      ...newItem,
-      estimatedCost: newItem.estimatedCost || "0",
+      item: itemName,
+      category: newItem.category,
+      quantity: quantityValue ? quantityValue : undefined,
+      notes: notesPayload,
+      estimatedCost: Number.isFinite(estimatedCostValue) ? estimatedCostValue : undefined,
     });
   };
 
-  const handleParticipate = (itemId: number) => {
-    participateMutation.mutate(itemId);
+  const handleParticipate = (itemId: number, participantId?: string) => {
+    participateMutation.mutate({ itemId, userId: participantId });
   };
 
   const handleDeleteItem = (itemId: number) => {
@@ -136,9 +239,43 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
     markPurchasedMutation.mutate({ itemId, actualCost });
   };
 
-  const getItemsByCategory = (category: string) => {
-    return (groceryItems as GroceryItemWithDetails[]).filter((item: GroceryItemWithDetails) => item.category === category);
+  const toggleAllergyFilter = (allergy: string) => {
+    setActiveAllergyFilters((previous) =>
+      previous.includes(allergy)
+        ? previous.filter((value) => value !== allergy)
+        : [...previous, allergy],
+    );
   };
+
+  const clearAllergyFilters = () => setActiveAllergyFilters([]);
+
+  const getItemsByCategory = (category: string) => {
+    return groceryItems
+      .filter((item) => item.category === category)
+      .filter((item) => {
+        if (activeAllergyFilters.length === 0) {
+          return true;
+        }
+        const normalized = toStructuredNotes(item.notes)
+          .allergies.map((value) => value.toLowerCase());
+        return activeAllergyFilters.every(
+          (filter) => !normalized.includes(filter.toLowerCase()),
+        );
+      });
+  };
+
+  const allergyOptions = useMemo(() => {
+    const unique = new Map<string, string>();
+    for (const item of groceryItems) {
+      for (const allergy of toStructuredNotes(item.notes).allergies) {
+        const key = allergy.toLowerCase();
+        if (!unique.has(key)) {
+          unique.set(key, allergy);
+        }
+      }
+    }
+    return Array.from(unique.values()).sort((a, b) => a.localeCompare(b));
+  }, [groceryItems]);
 
   const isUserParticipating = (item: GroceryItemWithDetails) => {
     return item.participants.some(p => p.userId === user?.id);
@@ -172,8 +309,8 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                 <Label htmlFor="item-name">Item Name</Label>
                 <Input
                   id="item-name"
-                  value={newItem.name}
-                  onChange={(e) => setNewItem({ ...newItem, name: e.target.value })}
+                  value={newItem.item}
+                  onChange={(e) => setNewItem({ ...newItem, item: e.target.value })}
                   placeholder="e.g., Milk, Bread, Apples"
                 />
               </div>
@@ -199,7 +336,7 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                   type="number"
                   min="1"
                   value={newItem.quantity}
-                  onChange={(e) => setNewItem({ ...newItem, quantity: parseInt(e.target.value) || 1 })}
+                  onChange={(e) => setNewItem({ ...newItem, quantity: e.target.value })}
                 />
               </div>
               <div>
@@ -221,6 +358,26 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                   onChange={(e) => setNewItem({ ...newItem, notes: e.target.value })}
                   placeholder="Brand preference, dietary restrictions, etc."
                 />
+              </div>
+              <div>
+                <Label htmlFor="allergy-list">Allergies (comma separated)</Label>
+                <Input
+                  id="allergy-list"
+                  value={newItem.allergies}
+                  onChange={(e) => setNewItem({ ...newItem, allergies: e.target.value })}
+                  placeholder="e.g., peanuts, shellfish"
+                />
+                {renderTagBadges(allergyPreview, "Allergy: ", "destructive")}
+              </div>
+              <div>
+                <Label htmlFor="exclusion-list">Preferences / Exclusions</Label>
+                <Input
+                  id="exclusion-list"
+                  value={newItem.exclusions}
+                  onChange={(e) => setNewItem({ ...newItem, exclusions: e.target.value })}
+                  placeholder="e.g., vegetarian"
+                />
+                {renderTagBadges(exclusionPreview, "Exclude: ", "outline")}
               </div>
               <Button onClick={handleAddItem} disabled={addItemMutation.isPending}>
                 {addItemMutation.isPending ? "Adding..." : "Add Item"}
@@ -247,6 +404,26 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
         </TabsList>
 
         <TabsContent value="list" className="space-y-4">
+          {allergyOptions.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm text-gray-600">Filter allergies:</span>
+              {allergyOptions.map((allergy) => (
+                <Badge
+                  key={allergy}
+                  variant={activeAllergyFilters.includes(allergy) ? "destructive" : "outline"}
+                  className="cursor-pointer"
+                  onClick={() => toggleAllergyFilter(allergy)}
+                >
+                  {allergy}
+                </Badge>
+              ))}
+              {activeAllergyFilters.length > 0 && (
+                <Button variant="ghost" size="sm" className="h-7" onClick={clearAllergyFilters}>
+                  Clear
+                </Button>
+              )}
+            </div>
+          )}
           {categories.map((category) => {
             const items = getItemsByCategory(category);
             if (items.length === 0) return null;
@@ -258,7 +435,7 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
-                    {items.map((item: GroceryItemWithDetails) => (
+                    {items.map((item) => (
                       <div key={item.id} className="flex items-center justify-between p-3 border rounded-lg">
                         <div className="flex items-center space-x-3">
                           <Checkbox
@@ -268,9 +445,9 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                           <div className="flex-1">
                             <div className="flex items-center space-x-2">
                               <span className={`font-medium ${item.isPurchased ? 'line-through text-gray-500' : ''}`}>
-                                {(item as any).name}
+                                {item.item}
                               </span>
-                              {(item.quantity ?? 1) > 1 && (
+                              {Number(item.quantity ?? 1) > 1 && (
                                 <Badge variant="secondary">x{item.quantity}</Badge>
                               )}
                               {item.isPurchased && (
@@ -279,13 +456,64 @@ export function GroceryList({ tripId, user }: GroceryListProps) {
                                 </Badge>
                               )}
                             </div>
-                            {item.notes && (
-                              <p className="text-sm text-gray-600 mt-1">{item.notes}</p>
-                            )}
+                            {renderNotesSection(item.notes)}
                             <div className="flex items-center space-x-2 mt-1">
-                              <span className="text-sm text-gray-500">
-                                {item.participantCount} participant(s)
-                              </span>
+                              <Popover>
+                                <PopoverTrigger asChild>
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 px-2 text-sm font-normal"
+                                  >
+                                    <Users className="h-4 w-4 mr-1" />
+                                    {item.participantCount} participant{item.participantCount === 1 ? "" : "s"}
+                                  </Button>
+                                </PopoverTrigger>
+                                <PopoverContent className="w-72 p-0" align="start">
+                                  <div className="max-h-64 overflow-y-auto divide-y">
+                                    {members.length === 0 ? (
+                                      <div className="p-4 text-sm text-gray-500">
+                                        No trip members available yet.
+                                      </div>
+                                    ) : (
+                                      members.map((member) => {
+                                        const memberUser = member.user;
+                                        const displayName = memberUser.firstName || memberUser.email || "Unknown";
+                                        const isParticipating = item.participants.some(
+                                          (participant) => participant.userId === member.userId,
+                                        );
+
+                                        return (
+                                          <label
+                                            key={member.userId}
+                                            className="flex items-center justify-between px-3 py-2 text-sm hover:bg-gray-100"
+                                          >
+                                            <div className="flex items-center space-x-2">
+                                              <Avatar className="h-8 w-8">
+                                                <AvatarFallback>
+                                                  {(memberUser.firstName?.charAt(0) || memberUser.email?.charAt(0) || "U").toUpperCase()}
+                                                </AvatarFallback>
+                                              </Avatar>
+                                              <div className="flex flex-col">
+                                                <span className="font-medium leading-tight">{displayName}</span>
+                                                {memberUser.email && (
+                                                  <span className="text-xs text-gray-500 truncate max-w-[160px]">
+                                                    {memberUser.email}
+                                                  </span>
+                                                )}
+                                              </div>
+                                            </div>
+                                            <Checkbox
+                                              checked={isParticipating}
+                                              onCheckedChange={() => handleParticipate(item.id, member.userId)}
+                                            />
+                                          </label>
+                                        );
+                                      })
+                                    )}
+                                  </div>
+                                </PopoverContent>
+                              </Popover>
                               <span className="text-sm text-gray-500">•</span>
                               <span className="text-sm text-gray-500">
                                 Added by {item.addedBy.firstName || item.addedBy.email}

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -628,7 +628,11 @@ export default function Trip() {
                 )}
 
                 {activeTab === "groceries" && (
-                  <GroceryList tripId={parseInt(id || "0")} user={user} />
+                  <GroceryList
+                    tripId={parseInt(id || "0")}
+                    user={user}
+                    members={trip?.members ?? []}
+                  />
                 )}
 
                 {activeTab === "proposals" && (

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -260,6 +260,16 @@ export const insertNotificationSchema = z.object({
 
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;
 
+const groceryNoteDetailsSchema = z.object({
+  text: z.string().nullable().optional(),
+  allergies: z.array(z.string()).optional(),
+  exclusions: z.array(z.string()).optional(),
+});
+
+export const groceryNotesSchema = z.union([z.string(), groceryNoteDetailsSchema]);
+
+export type GroceryNotes = z.infer<typeof groceryNotesSchema>;
+
 export interface GroceryItem {
   id: number;
   tripId: number;
@@ -268,7 +278,7 @@ export interface GroceryItem {
   category: string;
   quantity: string | null;
   estimatedCost: string | null;
-  notes: string | null;
+  notes: GroceryNotes | null;
   isPurchased: boolean;
   actualCost: string | null;
   receiptLineItem: string | null;
@@ -282,7 +292,7 @@ export const insertGroceryItemSchema = z.object({
   category: z.string().min(1, "Category is required"),
   quantity: z.string().nullable().optional(),
   estimatedCost: z.union([z.string(), z.number()]).nullable().optional(),
-  notes: z.string().nullable().optional(),
+  notes: groceryNotesSchema.nullable().optional(),
   isPurchased: z.boolean().optional(),
   actualCost: z.union([z.string(), z.number()]).nullable().optional(),
   receiptLineItem: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary
- allow grocery item notes to include structured text, allergy, and exclusion tags in the shared schema. 【F:shared/schema.ts†L263-L299】
- parse and serialize structured grocery notes when mapping, creating, or updating grocery items so JSON payloads persist cleanly. 【F:server/storage.ts†L734-L800】【F:server/storage.ts†L3333-L3585】
- extend the grocery list UI to collect allergy/exclusion tags, preview them as chips, and let shoppers filter out items by selected allergies. 【F:client/src/components/grocery-list.tsx†L37-L520】

## Testing
- npm run check *(fails: existing repository TypeScript errors)* 【69abed†L1-L102】

------
https://chatgpt.com/codex/tasks/task_e_68d2f1923cd4832e8ad2dcd5c1e9f591