### PR TITLE
Fix expense modal scroll and wire expense APIs

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -33,7 +33,7 @@ import {
 import { CurrencyConverter } from "@/components/currency-converter";
 import { useToast } from "@/hooks/use-toast";
 import { insertExpenseSchema, type TripWithDetails } from "@shared/schema";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { DollarSign, Smartphone } from "lucide-react";
 
 interface AddExpenseModalProps {
@@ -91,18 +91,6 @@ export function AddExpenseModal({
   const { data: trip } = useQuery<TripWithDetails>({
     queryKey: [`/api/trips/${tripId}`],
   });
-
-  // Get current user
-  useEffect(() => {
-    if (!open) return;
-
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
-  }, [open]);
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),


### PR DESCRIPTION
## Summary
- remove the manual body overflow locking from the add expense modal so the dialog can scroll correctly on mobile
- add REST endpoints to delete expenses and mark them as paid so the client calls succeed
- send notifications to tagged members after an expense is created so they are alerted to new charges

## Testing
- npm run check *(fails: existing TypeScript errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3269b823c832ea8cab26f663328de