### PR TITLE
Add attendee selection and notifications for trip activities

### DIFF
--- a/client/src/components/activity-card.tsx
+++ b/client/src/components/activity-card.tsx
@@ -38,6 +38,21 @@ const categoryIcons = {
   other: "📍",
 };
 
+const getUserDisplayName = (user: User) => {
+  const first = user.firstName?.trim();
+  const last = user.lastName?.trim();
+  if (first && last) {
+    return `${first} ${last}`;
+  }
+  if (first) {
+    return first;
+  }
+  if (user.username) {
+    return user.username;
+  }
+  return user.email || "Trip member";
+};
+
 export function ActivityCard({
   activity,
   currentUser,
@@ -162,7 +177,7 @@ export function ActivityCard({
                 </span>
               </div>
             </div>
-            
+
             <div className="flex items-center space-x-2">
               {activity.isAccepted ? (
                 <>
@@ -206,6 +221,25 @@ export function ActivityCard({
               )}
             </div>
           </div>
+
+          {activity.acceptances.length > 0 && (
+            <div className="mt-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-neutral-500 mb-2">
+                Attending
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {activity.acceptances.map((acceptance) => (
+                  <Badge
+                    key={acceptance.id}
+                    variant="outline"
+                    className="border-neutral-200 bg-white text-neutral-700"
+                  >
+                    {getUserDisplayName(acceptance.user)}
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/booking-confirmation-modal.tsx
+++ b/client/src/components/booking-confirmation-modal.tsx
@@ -15,6 +15,7 @@ import { CalendarIcon, Plane, Hotel, MapPin, CheckCircle, X, Utensils, Star, Pho
 import { cn } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useAuth } from "@/hooks/useAuth";
 
 interface BookingConfirmationModalProps {
   isOpen: boolean;
@@ -86,6 +87,7 @@ export function BookingConfirmationModal({
   const [confirmed, setConfirmed] = useState<boolean | null>(null);
   const [proposing, setProposing] = useState(false);
   const { toast } = useToast();
+  const { user } = useAuth();
 
   const form = useForm<BookingFormData>({
     resolver: zodResolver(bookingSchema),
@@ -178,7 +180,8 @@ export function BookingConfirmationModal({
             partySize: data.partySize || 2,
             specialRequests: data.additionalDetails || ''
           }
-        })
+        }),
+        attendeeIds: user ? [user.id] : [],
       };
 
       await apiRequest(`/api/trips/${tripId}/activities`, {

--- a/client/src/pages/activities.tsx
+++ b/client/src/pages/activities.tsx
@@ -204,6 +204,7 @@ export default function Activities() {
           cost: activity.price ? parseFloat(activity.price) : null,
           maxCapacity: 10,
           tripCalendarId: parseInt(tripId!),
+          attendeeIds: user ? [user.id] : [],
         }),
       });
 

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -759,6 +759,7 @@ export default function Trip() {
           }}
           tripId={parseInt(id || "0")}
           selectedDate={selectedDate}
+          members={trip?.members ?? []}
         />
 
         {trip && (

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -170,6 +170,14 @@ export const insertActivitySchema = z.object({
 
 export type InsertActivity = z.infer<typeof insertActivitySchema>;
 
+export const createActivityWithAttendeesSchema = insertActivitySchema.extend({
+  attendeeIds: z.array(z.string()).optional(),
+});
+
+export type CreateActivityWithAttendees = z.infer<
+  typeof createActivityWithAttendeesSchema
+>;
+
 export interface ActivityAcceptance {
   id: number;
   activityId: number;


### PR DESCRIPTION
## Summary
- add attendee selection controls to the activity creation modal and default selections from current trip members
- include attendee identifiers when creating activities from quick propose and booking confirmation flows so participants see the event on their schedules
- update the backend activity creation route to store attendee acceptances, broadcast updates, and notify selected members while exposing attendee names on activity cards

## Testing
- `npm run check` *(fails: existing TypeScript errors across client and server code)*

------
https://chatgpt.com/codex/tasks/task_e_68d33b2e572c832e8696e0dca5587dd9