### PR TITLE
Sort daily activities chronologically

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -61,9 +61,12 @@ export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onD
   const days = eachDayOfInterval({ start: monthStart, end: monthEnd });
 
   const getActivitiesForDay = (day: Date) => {
-    return activities.filter(activity => 
-      isSameDay(new Date(activity.startTime), day)
-    );
+    return activities
+      .filter(activity => isSameDay(new Date(activity.startTime), day))
+      .sort(
+        (a, b) =>
+          new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+      );
   };
 
   const isTripDay = (day: Date) => {


### PR DESCRIPTION
## Summary
- sort the activities within each day cell of the calendar grid by their start times so they render in chronological order

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d34c9cec34832eb51d8f61843ec122