### PR TITLE
Fix expense modal select interactions

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -209,6 +209,7 @@ export function AddExpenseModal({
                       Request payment in:
                     </label>
                     <Select
+                      modal={false}
                       value={requestCurrency}
                       onValueChange={setRequestCurrency}
                     >
@@ -278,6 +279,7 @@ export function AddExpenseModal({
                   <FormItem>
                     <FormLabel>Category</FormLabel>
                     <Select
+                      modal={false}
                       onValueChange={field.onChange}
                       defaultValue={field.value}
                     >
@@ -549,6 +551,7 @@ export function AddExpenseModal({
                   <FormItem className="hidden">
                     <FormLabel>Split Type</FormLabel>
                     <Select
+                      modal={false}
                       onValueChange={field.onChange}
                       defaultValue={field.value}
                     >

--- a/client/src/components/currency-converter.tsx
+++ b/client/src/components/currency-converter.tsx
@@ -172,7 +172,11 @@ export function CurrencyConverter({
             className="text-lg font-semibold"
           />
         </div>
-        <Select value={currency} onValueChange={onCurrencyChange}>
+        <Select
+          value={currency}
+          onValueChange={onCurrencyChange}
+          modal={false}
+        >
           <SelectTrigger className="w-24">
             <SelectValue />
           </SelectTrigger>
@@ -223,7 +227,11 @@ export function CurrencyConverter({
             {/* Target Currency Selector */}
             <div className="flex items-center gap-2">
               <span className="text-sm text-gray-600">Convert to:</span>
-              <Select value={targetCurrency} onValueChange={setTargetCurrency}>
+              <Select
+                value={targetCurrency}
+                onValueChange={setTargetCurrency}
+                modal={false}
+              >
                 <SelectTrigger className="w-32">
                   <SelectValue />
                 </SelectTrigger>


### PR DESCRIPTION
## Summary
- disable modal behavior on the expense form's Select components so nested dropdowns no longer lock pointer/scroll when opened inside the dialog
- apply the same non-modal Select configuration to the currency converter to keep scrolling and the create button accessible after changing currencies

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d3572a79d0832e9f544ab2156f0d93