### PR TITLE
Fix Add Expense modal scroll locking and dropdown layering

### DIFF
--- a/client/src/components/currency-converter.tsx
+++ b/client/src/components/currency-converter.tsx
@@ -37,6 +37,7 @@ interface CurrencyConverterProps {
   className?: string;
   onConversionChange?: (conversion: CurrencyConversion | null) => void;
   targetCurrency?: string;
+  portalContainer?: HTMLElement | null;
 }
 
 export function CurrencyConverter({
@@ -48,7 +49,8 @@ export function CurrencyConverter({
   showConversion = true,
   className = "",
   onConversionChange,
-  targetCurrency: propTargetCurrency
+  targetCurrency: propTargetCurrency,
+  portalContainer,
 }: CurrencyConverterProps) {
   const [targetCurrency, setTargetCurrency] = useState<string>(propTargetCurrency || "USD");
   const [conversionResult, setConversionResult] = useState<CurrencyConversion | null>(null);
@@ -180,7 +182,7 @@ export function CurrencyConverter({
           <SelectTrigger className="w-24">
             <SelectValue />
           </SelectTrigger>
-          <SelectContent>
+          <SelectContent container={portalContainer ?? undefined}>
             {currencies.map((curr) => (
               <SelectItem key={curr.code} value={curr.code}>
                 <div className="flex items-center gap-2">
@@ -235,7 +237,7 @@ export function CurrencyConverter({
                 <SelectTrigger className="w-32">
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent container={portalContainer ?? undefined}>
                   {currencies
                     .filter(curr => curr.code !== currency)
                     .map((curr) => (

--- a/client/src/components/ui/select.tsx
+++ b/client/src/components/ui/select.tsx
@@ -67,11 +67,17 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName
 
+type SelectContentProps = React.ComponentPropsWithoutRef<
+  typeof SelectPrimitive.Content
+> & {
+  container?: HTMLElement | null;
+};
+
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = "popper", ...props }, ref) => (
-  <SelectPrimitive.Portal>
+  SelectContentProps
+>(({ className, children, position = "popper", container, ...props }, ref) => (
+  <SelectPrimitive.Portal container={container}>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(


### PR DESCRIPTION
## Summary
- rework the Add Expense modal structure to use a dedicated scroll region with a persistent footer and lock background scrolling while the dialog is open
- keep currency and request selectors portaled inside the modal so dropdown overlays do not block interaction
- extend the shared SelectContent helper to accept a portal container used by the currency converter

## Testing
- npm run check *(fails: repository currently has pre-existing TypeScript errors in multiple files outside the touched components)*

------
https://chatgpt.com/codex/tasks/task_e_68d35c8fdbe8832ebceac4f14a9c8609