### PR TITLE
Remove Add Activity button from trip dashboard header

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -824,14 +824,6 @@ export default function Trip() {
                                 Invite
                               </Button>
                             </div>
-                            <Button
-                              onClick={() => openAddActivityModal()}
-                              size="lg"
-                              className="w-full justify-center bg-primary text-white shadow-md hover:bg-red-600"
-                            >
-                              <Plus className="mr-2 h-4 w-4" />
-                              Add Activity
-                            </Button>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
## Summary
- remove the Add Activity call-to-action from the trip dashboard header card
- keep only overview-oriented quick actions like Weather, Edit Trip, and Invite to reduce redundancy

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d40446cae4832e999b4c2ab432a568