### PR TITLE
Fix profile default location search and prefill messaging

### DIFF
--- a/client/src/pages/flights.tsx
+++ b/client/src/pages/flights.tsx
@@ -947,14 +947,19 @@ export default function FlightsPage() {
             </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
-              <div>
-                <Label htmlFor="departure">From</Label>
-                <SmartLocationSearch
-                  placeholder="Departure city or airport"
-                  value={searchFormData.departure}
-                  onLocationSelect={(location) => setSearchFormData(prev => ({ ...prev, departure: location.displayName }))}
-                />
-              </div>
+                <div>
+                  <Label htmlFor="departure">From</Label>
+                  <SmartLocationSearch
+                    placeholder="Departure city or airport"
+                    value={searchFormData.departure}
+                    onLocationSelect={(location) => setSearchFormData(prev => ({ ...prev, departure: location.displayName }))}
+                  />
+                  {!user?.defaultLocation && !user?.defaultLocationCode && !searchFormData.departure && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Save a default departure location in your profile to fill this automatically next time.
+                    </p>
+                  )}
+                </div>
               <div>
                 <Label htmlFor="arrival">To</Label>
                 <SmartLocationSearch


### PR DESCRIPTION
## Summary
- use the shared LocationUtils search results in the profile to capture airport and city metadata when storing a default departure location
- add richer UI feedback for profile location search including loading state, type badges, and automatic clearing of stale values
- surface a reminder on the flights search form when no default location exists so the departing field stays empty until the user sets one

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d3f6391114832e9da056860ab7816a