### PR TITLE
Apply landing page theme across application

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ function Router() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-neutral-100 flex items-center justify-center">
+      <div className="page-shell flex min-h-screen items-center justify-center">
         <TravelLoading size="lg" text="Welcome to your travel planning adventure..." />
       </div>
     );
@@ -43,7 +43,7 @@ function Router() {
   const isDevelopment = import.meta.env.DEV;
 
   if (!isAuthenticated && !isDevelopment) {
-    return (
+    const guestRoutes = (
       <Switch>
         <Route path="/login" component={Login} />
         <Route path="/register" component={Register} />
@@ -56,37 +56,45 @@ function Router() {
         <Route path="*" component={Landing} />
       </Switch>
     );
+
+    if (location === "/") {
+      return guestRoutes;
+    }
+
+    return <div className="page-shell">{guestRoutes}</div>;
   }
 
   return (
-    <Switch>
-      <Route path="/" component={Home} />
-      <Route path="/login" component={Login} />
-      <Route path="/register" component={Register} />
-      <Route path="/trip/:id" component={Trip} />
-      <Route path="/trip/:tripId/members" component={MemberSchedule} />
-      <Route path="/trip/:tripId/flights" component={Flights} />
-      <Route path="/trips/:tripId/flights" component={Flights} />
-      <Route path="/trip/:tripId/hotels" component={Hotels} />
-      <Route path="/trips/:tripId/hotels" component={Hotels} />
-      <Route path="/trip/:tripId/activities" component={Activities} />
-      <Route path="/trips/:tripId/activities" component={Activities} />
-      <Route path="/trip/:tripId/restaurants" component={Restaurants} />
-      <Route path="/trips/:tripId/restaurants" component={Restaurants} />
-      <Route path="/trip/:tripId/proposals" component={ProposalsRoute} />
-      <Route path="/trips/:tripId/proposals" component={ProposalsRoute} />
-      <Route path="/flights" component={Flights} />
-      <Route path="/restaurants" component={Restaurants} />
-      <Route path="/hotels" component={Hotels} />
-      <Route path="/join/:shareCode" component={Join} />
-      <Route path="/profile" component={Profile} />
-      <Route path="/currency-converter" component={CurrencyConverter} />
-      <Route path="/how-it-works" component={HowItWorks} />
-      <Route path="/amadeus-test" component={AmadeusTest} />
-      <Route path="/location-database" component={LocationDatabase} />
-      <Route path="/api/logout" component={Logout} />
-      <Route path="*" component={NotFound} />
-    </Switch>
+    <div className="page-shell">
+      <Switch>
+        <Route path="/" component={Home} />
+        <Route path="/login" component={Login} />
+        <Route path="/register" component={Register} />
+        <Route path="/trip/:id" component={Trip} />
+        <Route path="/trip/:tripId/members" component={MemberSchedule} />
+        <Route path="/trip/:tripId/flights" component={Flights} />
+        <Route path="/trips/:tripId/flights" component={Flights} />
+        <Route path="/trip/:tripId/hotels" component={Hotels} />
+        <Route path="/trips/:tripId/hotels" component={Hotels} />
+        <Route path="/trip/:tripId/activities" component={Activities} />
+        <Route path="/trips/:tripId/activities" component={Activities} />
+        <Route path="/trip/:tripId/restaurants" component={Restaurants} />
+        <Route path="/trips/:tripId/restaurants" component={Restaurants} />
+        <Route path="/trip/:tripId/proposals" component={ProposalsRoute} />
+        <Route path="/trips/:tripId/proposals" component={ProposalsRoute} />
+        <Route path="/flights" component={Flights} />
+        <Route path="/restaurants" component={Restaurants} />
+        <Route path="/hotels" component={Hotels} />
+        <Route path="/join/:shareCode" component={Join} />
+        <Route path="/profile" component={Profile} />
+        <Route path="/currency-converter" component={CurrencyConverter} />
+        <Route path="/how-it-works" component={HowItWorks} />
+        <Route path="/amadeus-test" component={AmadeusTest} />
+        <Route path="/location-database" component={LocationDatabase} />
+        <Route path="/api/logout" component={Logout} />
+        <Route path="*" component={NotFound} />
+      </Switch>
+    </div>
   );
 }
 

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -9,15 +9,16 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "sunset-gradient text-white shadow-[0_20px_60px_-25px_rgba(244,114,182,0.55)] transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[0_32px_90px_-32px_rgba(244,114,182,0.55)] ring-offset-slate-900",
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-white/20 bg-white/10 text-white hover:bg-white/16 hover:text-white backdrop-blur-md",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "border border-white/10 bg-slate-900/60 text-white hover:bg-slate-900/70 backdrop-blur-md",
+        ghost: "text-white/80 hover:bg-white/10 hover:text-white",
+        link: "text-emerald-300 underline-offset-4 hover:text-emerald-200 hover:underline",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-3xl border border-white/10 bg-card text-card-foreground shadow-[0_35px_80px_-40px_rgba(15,23,42,0.85)] backdrop-blur-xl transition-colors duration-300",
       className
     )}
     {...props}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -3,61 +3,73 @@
 @tailwind utilities;
 
 :root {
-  /* Modern Travel Theme - Light Mode */
-  --background: hsl(220, 20%, 97%);
-  --foreground: hsl(220, 15%, 15%);
-  --muted: hsl(220, 15%, 95%);
-  --muted-foreground: hsl(220, 10%, 45%);
-  --popover: hsl(0, 0%, 100%);
-  --popover-foreground: hsl(220, 15%, 15%);
-  --card: hsl(0, 0%, 100%);
-  --card-foreground: hsl(220, 15%, 15%);
-  --border: hsl(220, 15%, 88%);
-  --input: hsl(220, 15%, 92%);
-  
-  /* Vibrant Travel Colors */
-  --primary: hsl(203, 89%, 53%); /* Ocean Blue */
-  --primary-foreground: hsl(0, 0%, 100%);
-  --secondary: hsl(25, 95%, 95%); /* Light Sunset */
-  --secondary-foreground: hsl(25, 85%, 35%);
-  --accent: hsl(174, 72%, 56%); /* Tropical Teal */
-  --accent-foreground: hsl(0, 0%, 100%);
-  
-  --destructive: hsl(0, 84%, 60%);
-  --destructive-foreground: hsl(0, 0%, 100%);
-  --ring: hsl(203, 89%, 53%);
+  /* TripSync brand palette */
+  --background: hsl(222 47% 6%);
+  --foreground: hsl(210 40% 96%);
+  --muted: hsl(222 36% 12%);
+  --muted-foreground: hsl(214 20% 70%);
+  --popover: hsl(222 47% 10%);
+  --popover-foreground: hsl(210 40% 96%);
+  --card: hsla(223 47% 12% / 0.85);
+  --card-foreground: hsl(210 40% 96%);
+  --border: hsla(215 32% 22% / 0.65);
+  --input: hsla(215 32% 18% / 0.9);
+
+  --primary: hsl(199 89% 58%);
+  --primary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(25 95% 62%);
+  --secondary-foreground: hsl(222 47% 10%);
+  --accent: hsl(162 84% 60%);
+  --accent-foreground: hsl(222 47% 10%);
+
+  --destructive: hsl(0 76% 58%);
+  --destructive-foreground: hsl(210 40% 98%);
+  --ring: hsl(199 89% 58%);
   --radius: 0.875rem;
-  
-  /* Neutral colors matching the design */
-  --neutral-900: hsl(0, 0%, 13%);
-  --neutral-600: hsl(0, 0%, 45%);
-  --neutral-100: hsl(0, 0%, 97%);
+
+  --sidebar-background: hsla(223 47% 8% / 0.9);
+  --sidebar-foreground: hsl(210 40% 96%);
+  --sidebar-primary: hsl(199 89% 58%);
+  --sidebar-primary-foreground: hsl(210 40% 98%);
+  --sidebar-accent: hsla(199 89% 58% / 0.2);
+  --sidebar-accent-foreground: hsl(210 40% 96%);
+  --sidebar-border: hsla(215 32% 22% / 0.65);
+  --sidebar-ring: hsl(199 89% 58%);
+
+  --chart-1: hsl(199 89% 58%);
+  --chart-2: hsl(162 84% 60%);
+  --chart-3: hsl(25 95% 62%);
+  --chart-4: hsl(340 75% 60%);
+  --chart-5: hsl(226 83% 67%);
+
+  /* Neutral tokens tuned for dark UI */
+  --neutral-900: hsl(220 13% 12%);
+  --neutral-600: hsl(215 20% 65%);
+  --neutral-100: hsl(215 30% 18%);
 }
 
 .dark {
-  /* Modern Travel Theme - Dark Mode */
-  --background: hsl(220, 20%, 8%);
-  --foreground: hsl(220, 15%, 92%);
-  --muted: hsl(220, 15%, 15%);
-  --muted-foreground: hsl(220, 10%, 60%);
-  --popover: hsl(220, 15%, 12%);
-  --popover-foreground: hsl(220, 15%, 92%);
-  --card: hsl(220, 15%, 12%);
-  --card-foreground: hsl(220, 15%, 92%);
-  --border: hsl(220, 15%, 20%);
-  --input: hsl(220, 15%, 18%);
-  
-  /* Dark mode travel colors */
-  --primary: hsl(203, 85%, 60%);
-  --primary-foreground: hsl(220, 20%, 8%);
-  --secondary: hsl(220, 15%, 18%);
-  --secondary-foreground: hsl(25, 85%, 70%);
-  --accent: hsl(174, 65%, 50%);
-  --accent-foreground: hsl(220, 20%, 8%);
-  
-  --destructive: hsl(0, 75%, 55%);
-  --destructive-foreground: hsl(220, 15%, 92%);
-  --ring: hsl(203, 85%, 60%);
+  --background: hsl(222 47% 4%);
+  --foreground: hsl(210 40% 96%);
+  --muted: hsl(222 38% 10%);
+  --muted-foreground: hsl(214 18% 70%);
+  --popover: hsla(223 47% 8% / 0.95);
+  --popover-foreground: hsl(210 40% 96%);
+  --card: hsla(223 47% 10% / 0.92);
+  --card-foreground: hsl(210 40% 96%);
+  --border: hsla(215 32% 20% / 0.75);
+  --input: hsla(215 32% 18% / 0.9);
+
+  --primary: hsl(199 89% 62%);
+  --primary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(25 95% 65%);
+  --secondary-foreground: hsl(222 47% 10%);
+  --accent: hsl(162 84% 62%);
+  --accent-foreground: hsl(222 47% 10%);
+
+  --destructive: hsl(0 76% 64%);
+  --destructive-foreground: hsl(210 40% 96%);
+  --ring: hsl(199 89% 62%);
   --radius: 0.875rem;
 }
 
@@ -68,8 +80,161 @@
 
   body {
     @apply font-sans antialiased bg-background text-foreground;
-    font-family: 'Inter', system-ui, sans-serif;
+    font-family: "Inter", system-ui, sans-serif;
+    min-height: 100vh;
+    background-color: #020617;
+    background-image:
+      radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.16), transparent 55%),
+      radial-gradient(circle at 80% 0%, rgba(168, 85, 247, 0.14), transparent 55%),
+      radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.14), transparent 60%);
+    background-attachment: fixed;
+    color-scheme: dark;
   }
+
+  .page-shell {
+    position: relative;
+    min-height: 100vh;
+    width: 100%;
+    isolation: isolate;
+    overflow: hidden;
+    color: var(--foreground);
+    background-color: #020617;
+  }
+
+  .page-shell::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+      radial-gradient(circle at 15% 20%, rgba(56, 189, 248, 0.18), transparent 55%),
+      radial-gradient(circle at 85% 15%, rgba(244, 114, 182, 0.18), transparent 55%),
+      radial-gradient(circle at 50% 80%, rgba(34, 197, 94, 0.16), transparent 60%),
+      linear-gradient(145deg, rgba(2, 6, 23, 0.95), rgba(15, 23, 42, 0.92));
+    opacity: 0.96;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .page-shell::after {
+    content: "";
+    position: absolute;
+    inset: -15% -30% auto -30%;
+    height: 45%;
+    background: radial-gradient(circle, rgba(250, 204, 21, 0.12), transparent 65%);
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  .page-shell > * {
+    position: relative;
+    z-index: 1;
+  }
+}
+
+.page-shell .bg-white,
+.page-shell .bg-slate-50,
+.page-shell .bg-neutral-50,
+.page-shell .bg-neutral-100,
+.page-shell .bg-slate-100 {
+  background-color: rgba(15, 23, 42, 0.65);
+  color: var(--foreground);
+  backdrop-filter: blur(18px);
+}
+
+.page-shell [class*="bg-white/"],
+.page-shell [class*="bg-slate-50/"],
+.page-shell [class*="bg-neutral-100/"],
+.page-shell [class*="bg-neutral-50/"] {
+  background-color: rgba(15, 23, 42, 0.5);
+  color: var(--foreground);
+}
+
+.page-shell .bg-slate-200,
+.page-shell .bg-neutral-200,
+.page-shell .bg-gray-200 {
+  background-color: rgba(148, 163, 184, 0.2);
+  color: var(--foreground);
+}
+
+.page-shell .border-slate-200,
+.page-shell .border-neutral-200,
+.page-shell .border-neutral-300,
+.page-shell .border-slate-300,
+.page-shell .border-white {
+  border-color: rgba(148, 163, 184, 0.25);
+}
+
+.page-shell .divide-slate-200,
+.page-shell .divide-neutral-200 {
+  border-color: rgba(148, 163, 184, 0.2);
+}
+
+.page-shell .text-slate-900,
+.page-shell .text-neutral-900,
+.page-shell .text-slate-800,
+.page-shell .text-neutral-800 {
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.page-shell .text-slate-700,
+.page-shell .text-neutral-700 {
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.page-shell .text-slate-600,
+.page-shell .text-neutral-600,
+.page-shell .text-gray-600 {
+  color: rgba(203, 213, 225, 0.82);
+}
+
+.page-shell .text-slate-500,
+.page-shell .text-neutral-500,
+.page-shell .text-gray-500 {
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.page-shell .text-slate-400,
+.page-shell .text-neutral-400,
+.page-shell .text-gray-400 {
+  color: rgba(148, 163, 184, 0.65);
+}
+
+.page-shell .shadow-sm,
+.page-shell .shadow-md,
+.page-shell .shadow-lg,
+.page-shell .shadow-xl,
+.page-shell .shadow-2xl {
+  --tw-shadow: 0 35px 80px -35px rgba(15, 23, 42, 0.85);
+  --tw-shadow-colored: 0 35px 80px -35px rgba(15, 23, 42, 0.85);
+}
+
+.page-shell .ring-1,
+.page-shell .ring-2,
+.page-shell .ring {
+  --tw-ring-color: rgba(148, 163, 184, 0.25);
+}
+
+.page-shell .hover\:bg-slate-50:hover,
+.page-shell .hover\:bg-neutral-50:hover {
+  background-color: rgba(148, 163, 184, 0.12);
+}
+
+.page-shell .hover\:text-slate-900:hover,
+.page-shell .hover\:text-slate-800:hover {
+  color: rgba(226, 232, 240, 0.96);
+}
+
+.page-shell .from-sky-50 {
+  --tw-gradient-from: rgba(56, 189, 248, 0.22);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to, rgba(56, 189, 248, 0));
+}
+
+.page-shell .via-white {
+  --tw-gradient-stops: var(--tw-gradient-from), rgba(15, 23, 42, 0.75), var(--tw-gradient-to, rgba(15, 23, 42, 0));
+}
+
+.page-shell .to-rose-100 {
+  --tw-gradient-to: rgba(244, 114, 182, 0.25);
 }
 
 /* Travel-themed animations and patterns */

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -93,16 +93,16 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen animated-gradient flex items-center justify-center px-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex items-center justify-center mb-4">
-            <div className="w-12 h-12 travel-gradient rounded-full flex items-center justify-center">
-              <Plane className="text-white w-6 h-6" />
+    <div className="flex min-h-screen items-center justify-center px-4 py-12">
+      <Card className="w-full max-w-md border-white/15 bg-white/10 shadow-[0_32px_90px_-32px_rgba(2,6,23,0.9)]">
+        <CardHeader className="text-center space-y-4">
+          <div className="flex items-center justify-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-[0_20px_60px_-30px_rgba(56,189,248,0.6)]">
+              <Plane className="h-6 w-6 text-white" />
             </div>
           </div>
-          <CardTitle className="text-2xl font-bold">Welcome Back</CardTitle>
-          <CardDescription>
+          <CardTitle className="text-3xl font-semibold text-white">Welcome back</CardTitle>
+          <CardDescription className="text-white/70">
             Sign in to your TripSync account to continue planning
           </CardDescription>
         </CardHeader>
@@ -117,10 +117,10 @@ export default function Login() {
                     <FormLabel>Username or Email</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                        <User className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
                         <Input
                           placeholder="john@example.com or johndoe"
-                          className="pl-10"
+                          className="pl-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
                           {...field}
                         />
                       </div>
@@ -138,24 +138,24 @@ export default function Login() {
                     <FormLabel>Password</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
+                        <Lock className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
                         <Input
                           type={showPassword ? "text" : "password"}
                           placeholder="••••••••"
-                          className="pl-10 pr-10"
+                          className="pl-11 pr-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
                           {...field}
                         />
                         <Button
                           type="button"
                           variant="ghost"
-                          size="sm"
-                          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                          size="icon"
+                          className="absolute right-1.5 top-1.5 h-7 w-7 rounded-full bg-white/5 text-white/60 hover:bg-white/10"
                           onClick={() => setShowPassword(!showPassword)}
                         >
                           {showPassword ? (
-                            <EyeOff className="h-4 w-4 text-gray-400" />
+                            <EyeOff className="h-4 w-4" />
                           ) : (
-                            <Eye className="h-4 w-4 text-gray-400" />
+                            <Eye className="h-4 w-4" />
                           )}
                         </Button>
                       </div>
@@ -165,22 +165,18 @@ export default function Login() {
                 )}
               />
 
-              <Button
-                type="submit"
-                className="w-full bg-primary hover:bg-red-600 text-white"
-                disabled={loginMutation.isPending}
-              >
+              <Button type="submit" className="w-full" disabled={loginMutation.isPending}>
                 {loginMutation.isPending ? "Signing in..." : "Sign In"}
               </Button>
             </form>
           </Form>
 
           <div className="mt-6 text-center">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-white/70">
               Don't have an account?{" "}
               <Link
                 href="/register"
-                className="text-primary hover:underline font-medium"
+                className="font-medium text-emerald-300 hover:text-emerald-200"
               >
                 Create one here
               </Link>
@@ -190,7 +186,7 @@ export default function Login() {
           <div className="mt-4 text-center">
             <Link
               href="/forgot-password"
-              className="text-sm text-gray-500 hover:underline"
+              className="text-sm text-white/60 hover:text-white"
             >
               Forgot your password?
             </Link>

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -92,17 +92,17 @@ export default function Register() {
   };
 
   return (
-    <div className="min-h-screen animated-gradient flex items-center justify-center px-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="flex items-center justify-center mb-4">
-            <div className="w-12 h-12 travel-gradient rounded-full flex items-center justify-center">
-              <Plane className="text-white w-6 h-6" />
+    <div className="flex min-h-screen items-center justify-center px-4 py-12">
+      <Card className="w-full max-w-2xl border-white/15 bg-white/10 shadow-[0_32px_90px_-32px_rgba(2,6,23,0.9)]">
+        <CardHeader className="text-center space-y-4">
+          <div className="flex items-center justify-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-[0_20px_60px_-30px_rgba(56,189,248,0.6)]">
+              <Plane className="h-6 w-6 text-white" />
             </div>
           </div>
-          <CardTitle className="text-2xl font-bold">Create Account</CardTitle>
-          <CardDescription>
-            Join TripSync to start planning amazing group adventures
+          <CardTitle className="text-3xl font-semibold text-white">Create your account</CardTitle>
+          <CardDescription className="text-white/70">
+            Join TripSync to start planning unforgettable group adventures together
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -116,7 +116,11 @@ export default function Register() {
                     <FormItem>
                       <FormLabel>First Name</FormLabel>
                       <FormControl>
-                        <Input placeholder="John" {...field} />
+                        <Input
+                          placeholder="John"
+                          className="bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -129,7 +133,11 @@ export default function Register() {
                     <FormItem>
                       <FormLabel>Last Name</FormLabel>
                       <FormControl>
-                        <Input placeholder="Doe" {...field} />
+                        <Input
+                          placeholder="Doe"
+                          className="bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
+                        />
                       </FormControl>
                       <FormMessage />
                     </FormItem>
@@ -145,8 +153,12 @@ export default function Register() {
                     <FormLabel>Email</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <Mail className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                        <Input placeholder="john@example.com" className="pl-10" {...field} />
+                        <Mail className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
+                        <Input
+                          placeholder="john@example.com"
+                          className="pl-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
+                        />
                       </div>
                     </FormControl>
                     <FormMessage />
@@ -162,16 +174,16 @@ export default function Register() {
                     <FormLabel>Phone Number</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <Phone className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                        <Input 
+                        <Phone className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
+                        <Input
                           type="tel"
-                          placeholder="+1 (555) 123-4567" 
-                          className="pl-10" 
-                          {...field} 
+                          placeholder="+1 (555) 123-4567"
+                          className="pl-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
                         />
                       </div>
                     </FormControl>
-                    <p className="text-xs text-gray-600 mt-1">
+                    <p className="mt-1 text-xs text-white/60">
                       Used for CashApp and Venmo payment integration
                     </p>
                     <FormMessage />
@@ -187,8 +199,12 @@ export default function Register() {
                     <FormLabel>Username</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <User className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                        <Input placeholder="johndoe" className="pl-10" {...field} />
+                        <User className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
+                        <Input
+                          placeholder="johndoe"
+                          className="pl-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
+                        />
                       </div>
                     </FormControl>
                     <FormMessage />
@@ -204,24 +220,24 @@ export default function Register() {
                     <FormLabel>Password</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                        <Input 
+                        <Lock className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
+                        <Input
                           type={showPassword ? "text" : "password"}
-                          placeholder="••••••••" 
-                          className="pl-10 pr-10" 
-                          {...field} 
+                          placeholder="••••••••"
+                          className="pl-11 pr-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
                         />
                         <Button
                           type="button"
                           variant="ghost"
-                          size="sm"
-                          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                          size="icon"
+                          className="absolute right-1.5 top-1.5 h-7 w-7 rounded-full bg-white/5 text-white/60 hover:bg-white/10"
                           onClick={() => setShowPassword(!showPassword)}
                         >
                           {showPassword ? (
-                            <EyeOff className="h-4 w-4 text-gray-400" />
+                            <EyeOff className="h-4 w-4" />
                           ) : (
-                            <Eye className="h-4 w-4 text-gray-400" />
+                            <Eye className="h-4 w-4" />
                           )}
                         </Button>
                       </div>
@@ -239,24 +255,24 @@ export default function Register() {
                     <FormLabel>Confirm Password</FormLabel>
                     <FormControl>
                       <div className="relative">
-                        <Lock className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-                        <Input 
+                        <Lock className="absolute left-4 top-3.5 h-4 w-4 text-white/40" />
+                        <Input
                           type={showConfirmPassword ? "text" : "password"}
-                          placeholder="••••••••" 
-                          className="pl-10 pr-10" 
-                          {...field} 
+                          placeholder="••••••••"
+                          className="pl-11 pr-11 bg-white/5 border-white/20 text-white placeholder:text-white/40 focus-visible:ring-primary"
+                          {...field}
                         />
                         <Button
                           type="button"
                           variant="ghost"
-                          size="sm"
-                          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                          size="icon"
+                          className="absolute right-1.5 top-1.5 h-7 w-7 rounded-full bg-white/5 text-white/60 hover:bg-white/10"
                           onClick={() => setShowConfirmPassword(!showConfirmPassword)}
                         >
                           {showConfirmPassword ? (
-                            <EyeOff className="h-4 w-4 text-gray-400" />
+                            <EyeOff className="h-4 w-4" />
                           ) : (
-                            <Eye className="h-4 w-4 text-gray-400" />
+                            <Eye className="h-4 w-4" />
                           )}
                         </Button>
                       </div>
@@ -266,20 +282,19 @@ export default function Register() {
                 )}
               />
 
-              <Button 
-                type="submit" 
-                className="w-full bg-primary hover:bg-red-600 text-white"
-                disabled={registerMutation.isPending}
-              >
+              <Button type="submit" className="w-full" disabled={registerMutation.isPending}>
                 {registerMutation.isPending ? "Creating Account..." : "Create Account"}
               </Button>
             </form>
           </Form>
 
           <div className="mt-6 text-center">
-            <p className="text-sm text-gray-600">
+            <p className="text-sm text-white/70">
               Already have an account?{" "}
-              <Link href="/login" className="text-primary hover:underline font-medium">
+              <Link
+                href="/login"
+                className="font-medium text-emerald-300 hover:text-emerald-200"
+              >
                 Sign in here
               </Link>
             </p>


### PR DESCRIPTION
## Summary
- replace the global design tokens with the landing-page palette and add the reusable page-shell background treatment
- refresh shared UI components (buttons, cards) so default surfaces and actions follow the TripSync gradient/glass aesthetic
- wrap authenticated routes with the new shell and restyle the login/register forms to match the landing presentation

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d40da6478c832e8fdc1d695b6ed79c