### PR TITLE
Revamp home dashboard with dynamic insights

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -74,6 +74,25 @@ import {
   differenceInCalendarDays,
 } from "date-fns";
 
+const TRIP_TAB_KEYS = [
+  "calendar",
+  "schedule",
+  "proposals",
+  "packing",
+  "flights",
+  "hotels",
+  "activities",
+  "restaurants",
+  "groceries",
+  "expenses",
+  "wish-list",
+] as const;
+
+type TripTab = (typeof TRIP_TAB_KEYS)[number];
+
+const isTripTab = (value: string): value is TripTab =>
+  TRIP_TAB_KEYS.includes(value as TripTab);
+
 interface DayViewProps {
   date: Date;
   activities: ActivityWithDetails[];
@@ -260,7 +279,7 @@ export default function Trip() {
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showMembersModal, setShowMembersModal] = useState(false);
   const [showWeatherModal, setShowWeatherModal] = useState(false);
-  const [activeTab, setActiveTab] = useState("calendar");
+  const [activeTab, setActiveTab] = useState<TripTab>("calendar");
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [categoryFilter, setCategoryFilter] = useState("all");
   const [peopleFilter, setPeopleFilter] = useState("all");
@@ -269,6 +288,17 @@ export default function Trip() {
   const [scheduleCalendarView, setScheduleCalendarView] = useState<"month" | "day">("month");
   const [groupViewDate, setGroupViewDate] = useState<Date | null>(null);
   const [scheduleViewDate, setScheduleViewDate] = useState<Date | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const params = new URLSearchParams(window.location.search);
+    const viewParam = params.get("view");
+    if (viewParam && isTripTab(viewParam)) {
+      setActiveTab(viewParam);
+    }
+  }, []);
 
   // Redirect if not authenticated
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add rotating fun facts, countdown messaging, and contextual CTAs to the dashboard hero while modernizing the quick actions panel
- enrich stats, upcoming adventures, and helpful insights with previews, planning progress, and a swipeable carousel of suggestions
- allow trip deep links to open specific sections such as packing, activities, or expenses via the `view` query parameter

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d40e6fb800832e9f5be61d266a959c