### PR TITLE
feat: expose manual hotel form inside trip dashboard

### DIFF
--- a/client/src/components/hotels/hotel-form-fields.tsx
+++ b/client/src/components/hotels/hotel-form-fields.tsx
@@ -1,0 +1,415 @@
+import { useEffect } from "react";
+import type { InputHTMLAttributes } from "react";
+import type { DateRange } from "react-day-picker";
+import { differenceInCalendarDays, format } from "date-fns";
+import type { UseFormReturn } from "react-hook-form";
+import { CalendarIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { FormField, FormItem, FormLabel, FormMessage, FormControl } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import {
+  HOTEL_FIELD_LABELS,
+  type HotelFormValues,
+} from "@/lib/hotel-form";
+
+const requiredFields: Array<keyof HotelFormValues> = [
+  "hotelName",
+  "address",
+  "city",
+  "country",
+  "checkInDate",
+  "checkOutDate",
+  "currency",
+  "status",
+];
+
+const integerFields = new Set<keyof HotelFormValues>(["guestCount", "roomCount"]);
+
+const selectFieldOptions: Record<string, Array<{ label: string; value: string }>> = {
+  currency: [
+    { label: "USD", value: "USD" },
+    { label: "EUR", value: "EUR" },
+    { label: "GBP", value: "GBP" },
+    { label: "CAD", value: "CAD" },
+    { label: "AUD", value: "AUD" },
+    { label: "JPY", value: "JPY" },
+    { label: "MXN", value: "MXN" },
+  ],
+  status: [
+    { label: "Confirmed", value: "confirmed" },
+    { label: "Pending", value: "pending" },
+    { label: "Cancelled", value: "cancelled" },
+    { label: "On Hold", value: "on-hold" },
+  ],
+  bookingPlatform: [
+    { label: "Booking.com", value: "booking.com" },
+    { label: "Expedia", value: "expedia" },
+    { label: "Hotels.com", value: "hotels.com" },
+    { label: "Airbnb", value: "airbnb" },
+    { label: "VRBO", value: "vrbo" },
+    { label: "Direct", value: "direct" },
+    { label: "Other", value: "other" },
+  ],
+};
+
+interface HotelFormFieldsProps {
+  form: UseFormReturn<HotelFormValues>;
+  isSubmitting: boolean;
+  submitLabel: string;
+  onCancel?: () => void;
+  showCancelButton?: boolean;
+}
+
+export function HotelFormFields({
+  form,
+  isSubmitting,
+  submitLabel,
+  onCancel,
+  showCancelButton = false,
+}: HotelFormFieldsProps) {
+  useEffect(() => {
+    form.register("checkOutDate");
+  }, [form]);
+
+  const checkOutValue = form.watch("checkOutDate");
+
+  return (
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextField(form, "hotelName")}
+        {renderTextField(form, "hotelChain", { placeholder: "Hilton Worldwide" })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextField(form, "address", { placeholder: "123 Main St" })}
+        {renderTextField(form, "city", { placeholder: "Austin" })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextField(form, "country", { placeholder: "United States" })}
+        {renderTextField(form, "zipCode", { placeholder: "78701" })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderNumberField(form, "latitude", { step: "0.000001" })}
+        {renderNumberField(form, "longitude", { step: "0.000001" })}
+      </div>
+
+      <div className="grid grid-cols-1">
+        <FormField
+          control={form.control}
+          name="checkInDate"
+          render={({ field }) => {
+            const selectedRange: DateRange | undefined = field.value
+              ? { from: field.value, to: checkOutValue ?? field.value }
+              : undefined;
+
+            const label = HOTEL_FIELD_LABELS.checkInDate;
+            const hasBothDates = Boolean(selectedRange?.from && selectedRange?.to);
+            const nights = hasBothDates
+              ? Math.max(1, differenceInCalendarDays(selectedRange!.to!, selectedRange!.from!))
+              : 0;
+            const description = hasBothDates
+              ? `${format(selectedRange!.from!, "MMM d, yyyy")} → ${format(selectedRange!.to!, "MMM d, yyyy")} • ${nights} night${nights === 1 ? "" : "s"}`
+              : selectedRange?.from
+                ? `Selected ${format(selectedRange.from, "MMM d, yyyy")}. Choose a check-out date.`
+                : "Select your stay dates.";
+
+            return (
+              <FormItem className="flex flex-col">
+                <FormLabel className="mb-1">
+                  {label}
+                  <RequiredMark fieldName="checkInDate" />
+                  <span className="mx-1 text-muted-foreground">/</span>
+                  {HOTEL_FIELD_LABELS.checkOutDate}
+                  <RequiredMark fieldName="checkOutDate" />
+                </FormLabel>
+                <Popover>
+                  <PopoverTrigger asChild>
+                    <FormControl>
+                      <Button
+                        variant="outline"
+                        className={cn(
+                          "w-full justify-start text-left font-normal",
+                          !selectedRange?.from && "text-muted-foreground",
+                          "hover:bg-primary/5 focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                        )}
+                      >
+                        {selectedRange?.from ? (
+                          <span className="flex flex-col">
+                            <span className="font-medium text-neutral-900">
+                              {format(selectedRange.from, "MMM d, yyyy")}
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {hasBothDates
+                                ? `${format(selectedRange!.to!, "MMM d, yyyy")} • ${nights} night${nights === 1 ? "" : "s"}`
+                                : "Select a check-out date"}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">Select check-in and check-out</span>
+                        )}
+                        <CalendarIcon className="ml-auto h-4 w-4 opacity-70" />
+                      </Button>
+                    </FormControl>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-auto p-3" align="start">
+                    <Calendar
+                      mode="range"
+                      defaultMonth={selectedRange?.from}
+                      selected={selectedRange}
+                      onSelect={(range) => {
+                        if (range?.from) {
+                          field.onChange(range.from);
+                        }
+                        if (range?.to) {
+                          form.setValue("checkOutDate", range.to, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          });
+                        } else if (range?.from) {
+                          form.setValue("checkOutDate", range.from, {
+                            shouldDirty: true,
+                            shouldValidate: true,
+                          });
+                        }
+                      }}
+                      numberOfMonths={2}
+                    />
+                  </PopoverContent>
+                </Popover>
+                <p className="text-xs text-muted-foreground mt-2">{description}</p>
+                {(form.formState.errors.checkInDate || form.formState.errors.checkOutDate) && (
+                  <FormMessage>
+                    {form.formState.errors.checkInDate?.message ||
+                      form.formState.errors.checkOutDate?.message}
+                  </FormMessage>
+                )}
+              </FormItem>
+            );
+          }}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {renderNumberField(form, "totalPrice", { min: "0", step: "0.01", placeholder: "299.00" })}
+        {renderNumberField(form, "pricePerNight", { min: "0", step: "0.01", placeholder: "99.00" })}
+        {renderSelectField(form, "currency")}
+        {renderSelectField(form, "status")}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {renderNumberField(form, "guestCount", { min: "1", step: "1" })}
+        {renderNumberField(form, "roomCount", { min: "1", step: "1" })}
+        {renderNumberField(form, "hotelRating", { min: "1", max: "5", step: "1" })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {renderTextField(form, "roomType", { placeholder: "Double Queen" })}
+        {renderTextField(form, "bookingReference", { placeholder: "ABC123" })}
+        {renderTextField(form, "bookingSource", { placeholder: "Travel agent" })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {renderTextField(form, "purchaseUrl", { type: "url", placeholder: "https://portal.example.com" })}
+        {renderSelectField(form, "bookingPlatform", true)}
+        {renderTextField(form, "bookingUrl", { type: "url", placeholder: "https://booking.com/..." })}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextField(form, "cancellationPolicy", { placeholder: "Free cancellation until 48 hours prior" })}
+        {renderTextField(form, "contactInfo", { placeholder: "Front desk: +1 (555) 555-5555" })}
+      </div>
+
+      <Separator />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextareaField(form, "amenities", "Separate amenities with commas or paste JSON.")}
+        {renderTextareaField(form, "policies", "Use JSON or descriptive text for important policies.")}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {renderTextareaField(form, "images", "Provide image URLs separated by commas or JSON array.")}
+        {renderTextareaField(form, "notes", "Share group preferences or special requests.")}
+      </div>
+
+      <div className="flex justify-end gap-3 pt-2">
+        {showCancelButton && (
+          <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? "Saving..." : submitLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function renderTextField(
+  form: UseFormReturn<HotelFormValues>,
+  name: keyof HotelFormValues,
+  inputProps: InputHTMLAttributes<HTMLInputElement> = {},
+) {
+  const label = HOTEL_FIELD_LABELS[name as keyof typeof HOTEL_FIELD_LABELS] ?? name;
+
+  return (
+    <FormField
+      key={String(name)}
+      control={form.control}
+      name={name as any}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>
+            {label}
+            <RequiredMark fieldName={name} />
+          </FormLabel>
+          <FormControl>
+            <Input
+              {...inputProps}
+              {...field}
+              value={field.value ?? ""}
+              onChange={(event) => field.onChange(event.target.value)}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function renderNumberField(
+  form: UseFormReturn<HotelFormValues>,
+  name: keyof HotelFormValues,
+  props: { min?: string; max?: string; step?: string; placeholder?: string } = {},
+) {
+  const label = HOTEL_FIELD_LABELS[name as keyof typeof HOTEL_FIELD_LABELS] ?? name;
+  const isInteger = integerFields.has(name);
+
+  return (
+    <FormField
+      key={String(name)}
+      control={form.control}
+      name={name as any}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>
+            {label}
+            <RequiredMark fieldName={name} />
+          </FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              inputMode="decimal"
+              {...props}
+              value={field.value ?? ""}
+              onChange={(event) => {
+                const value = event.target.value;
+                if (value === "") {
+                  field.onChange(null);
+                  return;
+                }
+                field.onChange(isInteger ? parseInt(value, 10) : parseFloat(value));
+              }}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function renderSelectField(
+  form: UseFormReturn<HotelFormValues>,
+  name: keyof HotelFormValues,
+  isOptional = false,
+) {
+  const options = selectFieldOptions[name as string];
+  const label = HOTEL_FIELD_LABELS[name as keyof typeof HOTEL_FIELD_LABELS] ?? name;
+
+  if (!options) {
+    return renderTextField(form, name);
+  }
+
+  return (
+    <FormField
+      key={String(name)}
+      control={form.control}
+      name={name as any}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>
+            {label}
+            {!isOptional && <RequiredMark fieldName={name} />}
+          </FormLabel>
+          <Select value={field.value ?? undefined} onValueChange={field.onChange}>
+            <FormControl>
+              <SelectTrigger>
+                <SelectValue placeholder={`Select ${label.toLowerCase()}`} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function renderTextareaField(
+  form: UseFormReturn<HotelFormValues>,
+  name: keyof HotelFormValues,
+  helperText?: string,
+) {
+  const label = HOTEL_FIELD_LABELS[name as keyof typeof HOTEL_FIELD_LABELS] ?? name;
+
+  return (
+    <FormField
+      key={String(name)}
+      control={form.control}
+      name={name as any}
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>{label}</FormLabel>
+          <FormControl>
+            <Textarea
+              rows={4}
+              {...field}
+              value={field.value ?? ""}
+              onChange={(event) => field.onChange(event.target.value)}
+            />
+          </FormControl>
+          {helperText && (
+            <p className="text-xs text-muted-foreground">{helperText}</p>
+          )}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}
+
+function RequiredMark({ fieldName }: { fieldName: keyof HotelFormValues }) {
+  const isRequired = requiredFields.includes(fieldName);
+  if (!isRequired) {
+    return null;
+  }
+  return <span className="ml-1 text-destructive">*</span>;
+}

--- a/client/src/components/ui/calendar.tsx
+++ b/client/src/components/ui/calendar.tsx
@@ -34,20 +34,21 @@ function Calendar({
         head_cell:
           "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
-        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        cell:
+          "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/40 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20 focus-within:outline-none focus-within:ring-2 focus-within:ring-primary/50 focus-within:ring-offset-1",
         day: cn(
           buttonVariants({ variant: "ghost" }),
-          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100 hover:bg-primary/10 hover:text-primary focus-visible:bg-primary/10 focus-visible:text-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
         ),
         day_range_end: "day-range-end",
         day_selected:
-          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
-        day_today: "bg-accent text-accent-foreground",
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus-visible:bg-primary focus-visible:text-primary-foreground focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2",
+        day_today: "bg-accent text-accent-foreground font-semibold",
         day_outside:
           "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
         day_disabled: "text-muted-foreground opacity-50",
         day_range_middle:
-          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+          "aria-selected:bg-primary/10 aria-selected:text-primary",
         day_hidden: "invisible",
         ...classNames,
       }}

--- a/client/src/lib/hotel-form.ts
+++ b/client/src/lib/hotel-form.ts
@@ -1,0 +1,182 @@
+import { useMemo } from "react";
+import { z } from "zod";
+import { insertHotelSchema, type InsertHotel } from "@shared/schema";
+
+type TripDates = {
+  startDate?: string | Date | null;
+  endDate?: string | Date | null;
+};
+
+export const hotelFormSchema = insertHotelSchema.extend({
+  checkInDate: z.date(),
+  checkOutDate: z.date(),
+  amenities: z.string().optional().nullable(),
+  notes: z.string().optional().nullable(),
+  contactInfo: z.string().optional().nullable(),
+  images: z.string().optional().nullable(),
+  policies: z.string().optional().nullable(),
+});
+
+export type HotelFormValues = z.infer<typeof hotelFormSchema>;
+
+export const createHotelFormDefaults = (tripId: number, tripDates?: TripDates): HotelFormValues => ({
+  tripId,
+  hotelName: "",
+  hotelChain: null,
+  hotelRating: null,
+  address: "",
+  city: "",
+  country: "",
+  zipCode: null,
+  latitude: null,
+  longitude: null,
+  checkInDate: tripDates?.startDate ? new Date(tripDates.startDate) : new Date(),
+  checkOutDate: tripDates?.endDate ? new Date(tripDates.endDate) : new Date(),
+  roomType: null,
+  roomCount: null,
+  guestCount: null,
+  bookingReference: null,
+  totalPrice: null,
+  pricePerNight: null,
+  currency: "USD",
+  status: "confirmed",
+  bookingSource: null,
+  purchaseUrl: null,
+  amenities: "",
+  images: "",
+  policies: "",
+  contactInfo: "",
+  bookingPlatform: null,
+  bookingUrl: null,
+  cancellationPolicy: null,
+  notes: "",
+});
+
+export const parseJsonInput = (value?: string | null) => {
+  if (!value || value.trim() === "") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+};
+
+export const parseAmenitiesInput = (value?: string | null) => {
+  if (!value || value.trim() === "") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+
+  if (trimmed.startsWith("[") || trimmed.startsWith("{")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      // fall through to comma parsing
+    }
+  }
+
+  const items = trimmed
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  if (items.length === 0) {
+    return trimmed;
+  }
+
+  return items.length === 1 ? items[0] : items;
+};
+
+export const stringifyJsonValue = (value: unknown) => {
+  if (value === null || value === undefined) {
+    return "";
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const transformHotelFormValues = (values: HotelFormValues): InsertHotel => ({
+  tripId: values.tripId,
+  hotelName: values.hotelName.trim(),
+  hotelChain: values.hotelChain?.trim() ? values.hotelChain.trim() : null,
+  hotelRating: values.hotelRating ?? null,
+  address: values.address.trim(),
+  city: values.city.trim(),
+  country: values.country.trim(),
+  zipCode: values.zipCode?.trim() ? values.zipCode.trim() : null,
+  latitude: values.latitude ?? null,
+  longitude: values.longitude ?? null,
+  checkInDate: values.checkInDate.toISOString(),
+  checkOutDate: values.checkOutDate.toISOString(),
+  roomType: values.roomType?.trim() ? values.roomType.trim() : null,
+  roomCount: values.roomCount ?? null,
+  guestCount: values.guestCount ?? null,
+  bookingReference: values.bookingReference?.trim() ? values.bookingReference.trim() : null,
+  totalPrice: values.totalPrice ?? null,
+  pricePerNight: values.pricePerNight ?? null,
+  currency: values.currency?.trim() ? values.currency.trim() : "USD",
+  status: values.status?.trim() ? values.status.trim() : "confirmed",
+  bookingSource: values.bookingSource?.trim() ? values.bookingSource.trim() : null,
+  purchaseUrl: values.purchaseUrl?.trim() ? values.purchaseUrl.trim() : null,
+  amenities: parseAmenitiesInput(values.amenities),
+  images: parseJsonInput(values.images),
+  policies: parseJsonInput(values.policies),
+  contactInfo: values.contactInfo?.trim() ? values.contactInfo.trim() : null,
+  bookingPlatform: values.bookingPlatform?.trim() ? values.bookingPlatform.trim() : null,
+  bookingUrl: values.bookingUrl?.trim() ? values.bookingUrl.trim() : null,
+  cancellationPolicy: values.cancellationPolicy?.trim() ? values.cancellationPolicy.trim() : null,
+  notes: values.notes?.trim() ? values.notes.trim() : null,
+});
+
+export const HOTEL_FIELD_LABELS: Record<
+  keyof Omit<HotelFormValues, "tripId">
+  , string
+> = {
+  hotelName: "Hotel Name",
+  hotelChain: "Hotel Chain",
+  hotelRating: "Hotel Rating",
+  address: "Street Address",
+  city: "City",
+  country: "Country",
+  zipCode: "Postal Code",
+  latitude: "Latitude",
+  longitude: "Longitude",
+  checkInDate: "Check-In Date",
+  checkOutDate: "Check-Out Date",
+  roomType: "Room Type",
+  roomCount: "Number of Rooms",
+  guestCount: "Guest Count",
+  bookingReference: "Booking Reference",
+  totalPrice: "Total Price (USD)",
+  pricePerNight: "Price per Night (USD)",
+  currency: "Currency",
+  status: "Booking Status",
+  bookingSource: "Booking Source",
+  purchaseUrl: "Purchase URL",
+  amenities: "Amenities",
+  images: "Images",
+  policies: "Policies",
+  contactInfo: "Contact Information",
+  bookingPlatform: "Booking Platform",
+  bookingUrl: "Booking Link (optional)",
+  cancellationPolicy: "Cancellation Policy",
+  notes: "Notes / Special Requests",
+};
+
+export const useHotelFieldLabel = (field: keyof typeof HOTEL_FIELD_LABELS) => {
+  return useMemo(() => HOTEL_FIELD_LABELS[field] ?? field, [field]);
+};

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useParams, useLocation, Link } from "wouter";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -49,14 +49,14 @@ import { GroceryList } from "@/components/grocery-list";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogTrigger } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from "@/components/ui/alert-dialog";
-import { CardHeader, CardTitle } from "@/components/ui/card";
+import { CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { NotificationIcon } from "@/components/notification-icon";
 import { LeaveTripButton } from "@/components/leave-trip-button";
 import { TravelLoading } from "@/components/LoadingSpinners";
 import ActivitySearch from "@/components/activity-search";
 import { WishListBoard } from "@/components/wish-list-board";
 import Proposals from "@/pages/proposals";
-import type { TripWithDetails, ActivityWithDetails, User } from "@shared/schema";
+import type { TripWithDetails, ActivityWithDetails, User, InsertHotel } from "@shared/schema";
 import {
   format,
   startOfMonth,
@@ -73,6 +73,17 @@ import {
   formatDistanceToNow,
   differenceInCalendarDays,
 } from "date-fns";
+import { Form } from "@/components/ui/form";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { HotelFormFields } from "@/components/hotels/hotel-form-fields";
+import {
+  createHotelFormDefaults,
+  hotelFormSchema,
+  transformHotelFormValues,
+  type HotelFormValues,
+} from "@/lib/hotel-form";
+import { apiRequest } from "@/lib/queryClient";
 
 const TRIP_TAB_KEYS = [
   "calendar",
@@ -1189,7 +1200,7 @@ export default function Trip() {
                 )}
                 
                 {activeTab === "hotels" && (
-                  <HotelBooking tripId={parseInt(id || "0")} user={user} />
+                  <HotelBooking tripId={parseInt(id || "0")} user={user} trip={trip} />
                 )}
                 
                 {activeTab === "restaurants" && (
@@ -1435,12 +1446,67 @@ function FlightCoordination({ tripId, user }: { tripId: number; user: any }) {
 }
 
 // Hotel Booking Component
-function HotelBooking({ tripId, user }: { tripId: number; user: any }) {
+function HotelBooking({ tripId, user, trip }: { tripId: number; user: any; trip?: TripWithDetails | null }) {
   const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
   const { data: hotels, isLoading } = useQuery({
     queryKey: [`/api/trips/${tripId}/hotels`],
     enabled: !!tripId,
   });
+
+  const formDefaults = useCallback(
+    () => createHotelFormDefaults(tripId, { startDate: trip?.startDate, endDate: trip?.endDate }),
+    [tripId, trip?.startDate, trip?.endDate],
+  );
+
+  const form = useForm<HotelFormValues>({
+    resolver: zodResolver(hotelFormSchema),
+    defaultValues: formDefaults(),
+  });
+
+  useEffect(() => {
+    form.reset(formDefaults());
+  }, [form, formDefaults]);
+
+  const createHotelMutation = useMutation({
+    mutationFn: async (payload: InsertHotel) => {
+      return await apiRequest(`/api/trips/${tripId}/hotels`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotels`] });
+      toast({
+        title: "Hotel added",
+        description: "Your hotel booking has been saved to the trip.",
+      });
+      form.reset(formDefaults());
+    },
+    onError: (error) => {
+      if (isUnauthorizedError(error as Error)) {
+        toast({
+          title: "Unauthorized",
+          description: "You need to be logged in to add hotels.",
+          variant: "destructive",
+        });
+        setTimeout(() => {
+          window.location.href = "/login";
+        }, 500);
+        return;
+      }
+      toast({
+        title: "Error",
+        description: "Failed to add hotel. Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (values: HotelFormValues) => {
+    createHotelMutation.mutate(transformHotelFormValues(values));
+  };
 
   if (isLoading) {
     return (
@@ -1457,7 +1523,7 @@ function HotelBooking({ tripId, user }: { tripId: number; user: any }) {
           <h2 className="text-xl font-semibold">Hotel Booking</h2>
           <p className="text-gray-600">Find and book accommodations</p>
         </div>
-        <Button 
+        <Button
           onClick={() => {
             setLocation(`/trip/${tripId}/hotels`);
           }}
@@ -1467,6 +1533,38 @@ function HotelBooking({ tripId, user }: { tripId: number; user: any }) {
           Manage Hotels
         </Button>
       </div>
+
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Plus className="h-5 w-5 text-primary" />
+            Add a Hotel Booking
+          </CardTitle>
+          <CardDescription>
+            Save a custom stay or confirmed reservation directly to this trip so everyone can view the details.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="rounded-lg bg-neutral-50 px-4 py-3 text-sm text-neutral-600">
+            <p className="font-medium text-neutral-800">Trip snapshot</p>
+            <p>
+              Destination: <span className="font-semibold text-neutral-900">{trip?.destination ?? "TBD"}</span>
+            </p>
+            <p>
+              Dates: <span className="font-semibold text-neutral-900">{trip?.startDate && trip?.endDate ? `${format(new Date(trip.startDate), 'MMM d, yyyy')} – ${format(new Date(trip.endDate), 'MMM d, yyyy')}` : 'Choose trip dates to prefill the form'}</span>
+            </p>
+          </div>
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+              <HotelFormFields
+                form={form}
+                isSubmitting={createHotelMutation.isPending}
+                submitLabel={createHotelMutation.isPending ? "Saving..." : "Save Hotel"}
+              />
+            </form>
+          </Form>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardContent className="p-6">


### PR DESCRIPTION
## Summary
- move the manual hotel booking workflow into the trip Hotels tab with an inline form that refreshes the list after submission
- extract reusable hotel form utilities and componentry to provide friendly labels and validation across the app
- refresh the date-picker styling to better highlight hover, focus, and selected date ranges

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4393b6c888329964845153c3e9038