### PR TITLE
feat: collapse manual hotel form on trip page

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1574,15 +1574,18 @@ function HotelBooking({ tripId, user, trip }: { tripId: number; user: any; trip?
                 </p>
               </div>
               <CollapsibleTrigger asChild>
-                <Button variant="outline" className="w-full sm:w-auto justify-between sm:justify-center">
-                  <span>{isManualHotelFormOpen ? "Hide manual form" : "Add hotel details"}</span>
+                <Button
+                  variant="outline"
+                  className="w-full sm:w-auto justify-between sm:justify-center"
+                >
+                  <span>{isManualHotelFormOpen ? "Close" : "Add a Hotel"}</span>
                   <ChevronDown
                     className={`ml-2 h-4 w-4 transition-transform ${isManualHotelFormOpen ? "rotate-180" : ""}`}
                   />
                 </Button>
               </CollapsibleTrigger>
             </div>
-            <CollapsibleContent className="space-y-6 pt-4">
+            <CollapsibleContent className="space-y-6 pt-4 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
               <Form {...form}>
                 <form onSubmit={form.handleSubmit(onSubmit)}>
                   <HotelFormFields
@@ -1599,16 +1602,6 @@ function HotelBooking({ tripId, user, trip }: { tripId: number; user: any; trip?
               </Form>
             </CollapsibleContent>
           </Collapsible>
-
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
-              <HotelFormFields
-                form={form}
-                isSubmitting={createHotelMutation.isPending}
-                submitLabel={createHotelMutation.isPending ? "Saving..." : "Save Hotel"}
-              />
-            </form>
-          </Form>
 
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- collapse the manual hotel entry form by default on the trip hotels tab and add an Add a Hotel toggle button
- ensure the manual form animates open/closed, provides a close option, and resets after successful saves

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d44368edc483298b9ae8186b2e1dbd