### PR TITLE
Implement activity invite workflows

### DIFF
--- a/client/src/components/activity-card.tsx
+++ b/client/src/components/activity-card.tsx
@@ -2,18 +2,18 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Calendar, MapPin, Users, DollarSign, Check, X } from "lucide-react";
+import { Calendar, MapPin, Users, DollarSign, Clock } from "lucide-react";
 import { format } from "date-fns";
-import type { ActivityWithDetails, User } from "@shared/schema";
-import { formatCurrency } from "@/lib/utils";
+import type { ActivityWithDetails, ActivityInviteStatus, User } from "@shared/schema";
+import { cn, formatCurrency } from "@/lib/utils";
 
 interface ActivityCardProps {
   activity: ActivityWithDetails;
   currentUser?: User;
   onAccept: () => void;
   onDecline: () => void;
+  onMaybe?: () => void;
   isLoading?: boolean;
-  isScheduleView?: boolean;
 }
 
 const categoryColors = {
@@ -58,12 +58,39 @@ export function ActivityCard({
   currentUser,
   onAccept,
   onDecline,
+  onMaybe,
   isLoading = false,
-  isScheduleView = false,
 }: ActivityCardProps) {
   const formatDateTime = (dateTime: ActivityWithDetails["startTime"]) => {
     const date = dateTime instanceof Date ? dateTime : new Date(dateTime);
     return format(date, "MMM d, yyyy 'at' h:mm a");
+  };
+
+  const formatTimeRange = (
+    startTime: ActivityWithDetails["startTime"],
+    endTime?: ActivityWithDetails["endTime"],
+  ) => {
+    const startDate = new Date(startTime);
+
+    if (Number.isNaN(startDate.getTime())) {
+      return "Time TBD";
+    }
+
+    const startLabel = format(startDate, "h:mm a");
+
+    if (!endTime) {
+      return startLabel;
+    }
+
+    const endDate = new Date(endTime);
+
+    if (Number.isNaN(endDate.getTime())) {
+      return startLabel;
+    }
+
+    return format(startDate, "MMM d") === format(endDate, "MMM d")
+      ? `${startLabel} - ${format(endDate, "h:mm a")}`
+      : `${startLabel} - ${format(endDate, "MMM d, h:mm a")}`;
   };
 
   const getCategoryIcon = (category: string) => {
@@ -80,168 +107,220 @@ export function ActivityCard({
     return spotsLeft > 0 ? `${spotsLeft} spots left` : "Full";
   };
 
+  const acceptedInvites = activity.invites.filter((invite) => invite.status === "accepted");
+  const pendingInvites = activity.invites.filter((invite) => invite.status === "pending");
+  const declinedInvites = activity.invites.filter((invite) => invite.status === "declined");
+
+  const currentInvite =
+    activity.currentUserInvite ??
+    activity.invites.find((invite) => invite.userId === currentUser?.id) ??
+    null;
+
+  const currentStatus: ActivityInviteStatus | undefined = currentInvite?.status
+    ?? (activity.isAccepted ? "accepted" : undefined);
+
+  const renderParticipants = (
+    participants: typeof acceptedInvites,
+    emptyLabel?: string,
+  ) => {
+    if (participants.length === 0) {
+      return emptyLabel ? (
+        <p className="text-xs text-neutral-500 italic">{emptyLabel}</p>
+      ) : null;
+    }
+
+    return (
+      <div className="flex flex-wrap gap-2">
+        {participants.map((invite) => (
+          <Badge
+            key={`${invite.activityId}-${invite.userId}-${invite.status}`}
+            variant="outline"
+            className="border-neutral-200 bg-white text-neutral-700"
+          >
+            {getUserDisplayName(invite.user)}
+          </Badge>
+        ))}
+      </div>
+    );
+  };
+
   return (
-    <div className="p-6">
-      <div className="flex items-start space-x-4">
-        <div className="flex-shrink-0">
-          <div className={`w-12 h-12 rounded-xl flex items-center justify-center text-lg ${
-            getCategoryColor(activity.category).replace('text-', 'text-').replace('bg-', 'bg-')
-          }`}>
-            {getCategoryIcon(activity.category)}
-          </div>
-        </div>
-        
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex-1 min-w-0">
-              <h3 className="text-lg font-semibold text-neutral-900 truncate">
-                {activity.name}
-              </h3>
-              <div className="flex items-center mt-1">
-                <Avatar className="w-5 h-5 mr-2">
-                  <AvatarImage 
-                    src={activity.poster.profileImageUrl || undefined} 
-                    alt={activity.poster.firstName || 'User'} 
-                  />
-                  <AvatarFallback className="text-xs">
-                    {(activity.poster.firstName?.[0] || activity.poster.email?.[0] || 'U').toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="text-sm text-neutral-600">
-                  Posted by {activity.poster.firstName || activity.poster.email || 'User'}
-                </span>
-              </div>
-            </div>
-            <Badge 
-              variant="secondary"
-              className={getCategoryColor(activity.category)}
+    <Card className="shadow-sm border border-neutral-200">
+      <div className="p-6">
+        <div className="flex items-start space-x-4">
+          <div className="flex-shrink-0">
+            <div
+              className={`w-12 h-12 rounded-xl flex items-center justify-center text-lg ${
+                getCategoryColor(activity.category)
+              }`}
             >
-              {activity.category.charAt(0).toUpperCase() + activity.category.slice(1)}
-            </Badge>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-2 text-sm text-neutral-600 mb-3">
-            <div className="flex items-center">
-              <Calendar className="w-4 h-4 mr-2 flex-shrink-0" />
-              <span className="truncate">{formatDateTime(activity.startTime)}</span>
-            </div>
-            {activity.location && (
-              <div className="flex items-center">
-                <MapPin className="w-4 h-4 mr-2 flex-shrink-0" />
-                <span className="truncate">{activity.location}</span>
-              </div>
-            )}
-            {typeof activity.cost === "number" && (
-              <div className="flex items-center">
-                <DollarSign className="w-4 h-4 mr-2 flex-shrink-0" />
-                <span>{formatCurrency(activity.cost)} / person</span>
-              </div>
-            )}
-            <div className="flex items-center">
-              <Users className="w-4 h-4 mr-2 flex-shrink-0" />
-              <span>{getSpotsLeftText()}</span>
+              {getCategoryIcon(activity.category)}
             </div>
           </div>
-          
-          {activity.description && (
-            <p className="text-sm text-neutral-600 mb-4 line-clamp-2">
-              {activity.description}
-            </p>
-          )}
-          
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-4">
+
+          <div className="flex-1 min-w-0 space-y-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div className="min-w-0">
+                <h3 className="text-lg font-semibold text-neutral-900 truncate">
+                  {activity.name}
+                </h3>
+                <div className="flex items-center gap-2 text-sm text-neutral-600">
+                  <Avatar className="w-5 h-5">
+                    <AvatarImage
+                      src={activity.poster.profileImageUrl || undefined}
+                      alt={activity.poster.firstName || "User"}
+                    />
+                    <AvatarFallback className="text-xs">
+                      {(activity.poster.firstName?.[0] || activity.poster.email?.[0] || "U").toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span>
+                    Posted by {activity.poster.firstName || activity.poster.email || "User"}
+                  </span>
+                </div>
+              </div>
+              <Badge variant="secondary" className="bg-neutral-100 text-neutral-700">
+                {activity.category.charAt(0).toUpperCase() + activity.category.slice(1)}
+              </Badge>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 text-sm text-neutral-600 md:grid-cols-2 lg:grid-cols-3">
               <div className="flex items-center">
+                <Calendar className="w-4 h-4 mr-2 flex-shrink-0" />
+                <span className="truncate">{formatDateTime(activity.startTime)}</span>
+              </div>
+              <div className="flex items-center">
+                <Clock className="w-4 h-4 mr-2 flex-shrink-0" />
+                <span>{formatTimeRange(activity.startTime, activity.endTime ?? undefined)}</span>
+              </div>
+              {activity.location && (
+                <div className="flex items-center">
+                  <MapPin className="w-4 h-4 mr-2 flex-shrink-0" />
+                  <span className="truncate">{activity.location}</span>
+                </div>
+              )}
+              {typeof activity.cost === "number" && (
+                <div className="flex items-center">
+                  <DollarSign className="w-4 h-4 mr-2 flex-shrink-0" />
+                  <span>{formatCurrency(activity.cost)} / person</span>
+                </div>
+              )}
+              <div className="flex items-center">
+                <Users className="w-4 h-4 mr-2 flex-shrink-0" />
+                <span>{getSpotsLeftText()}</span>
+              </div>
+            </div>
+
+            {activity.description && (
+              <p className="text-sm text-neutral-600 whitespace-pre-line">
+                {activity.description}
+              </p>
+            )}
+
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-center gap-3">
                 <div className="flex -space-x-2">
-                  {activity.acceptances.slice(0, 3).map((acceptance) => (
-                    <Avatar key={acceptance.id} className="w-6 h-6 border-2 border-white">
-                      <AvatarImage 
-                        src={acceptance.user.profileImageUrl || undefined} 
-                        alt={acceptance.user.firstName || 'User'} 
+                  {acceptedInvites.slice(0, 3).map((invite) => (
+                    <Avatar key={`${invite.activityId}-${invite.userId}`} className="w-7 h-7 border-2 border-white">
+                      <AvatarImage
+                        src={invite.user.profileImageUrl || undefined}
+                        alt={invite.user.firstName || "User"}
                       />
                       <AvatarFallback className="text-xs">
-                        {(acceptance.user.firstName?.[0] || acceptance.user.email?.[0] || 'U').toUpperCase()}
+                        {(invite.user.firstName?.[0] || invite.user.email?.[0] || "U").toUpperCase()}
                       </AvatarFallback>
                     </Avatar>
                   ))}
                   {activity.acceptedCount > 3 && (
-                    <div className="w-6 h-6 rounded-full border-2 border-white bg-gray-100 flex items-center justify-center">
-                      <span className="text-xs font-medium text-gray-600">
+                    <div className="w-7 h-7 rounded-full border-2 border-white bg-neutral-100 flex items-center justify-center">
+                      <span className="text-xs font-medium text-neutral-600">
                         +{activity.acceptedCount - 3}
                       </span>
                     </div>
                   )}
                 </div>
-                <span className="ml-3 text-sm text-neutral-600">
-                  {activity.acceptedCount} going{activity.isAccepted ? " (including you)" : ""}
-                </span>
+                <Badge className="bg-primary/10 text-primary" variant="secondary">
+                  {activity.acceptedCount} going
+                  {activity.pendingCount > 0 && ` • ${activity.pendingCount} pending`}
+                </Badge>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onDecline}
+                  disabled={isLoading}
+                  className={cn(
+                    "border-neutral-300",
+                    currentStatus === "declined" &&
+                      "bg-rose-100 text-rose-700 border-rose-200 hover:bg-rose-200",
+                  )}
+                >
+                  Decline
+                </Button>
+                {onMaybe && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={onMaybe}
+                    disabled={isLoading || !onMaybe}
+                    className={cn(
+                      "border-neutral-300",
+                      currentStatus === "pending" &&
+                        "bg-amber-100 text-amber-700 border-amber-200 hover:bg-amber-200",
+                    )}
+                  >
+                    Maybe
+                  </Button>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onAccept}
+                  disabled={isLoading}
+                  className={cn(
+                    "border-neutral-300",
+                    currentStatus === "accepted" &&
+                      "bg-primary text-white border-primary hover:bg-primary/90",
+                  )}
+                >
+                  Accept
+                </Button>
               </div>
             </div>
 
-            <div className="flex items-center space-x-2">
-              {activity.isAccepted ? (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onDecline}
-                    disabled={isLoading}
-                    className="text-red-600 border-red-300 hover:bg-red-50"
-                  >
-                    {isScheduleView ? "Remove" : "Leave"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    disabled
-                    className="bg-secondary text-white"
-                  >
-                    <Check className="w-4 h-4 mr-2" />
-                    Accepted
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={onDecline}
-                    disabled={isLoading}
-                  >
-                    Decline
-                  </Button>
-                  <Button
-                    size="sm"
-                    onClick={onAccept}
-                    disabled={isLoading}
-                    className="bg-primary hover:bg-red-600 text-white"
-                  >
-                    Accept
-                  </Button>
-                </>
+            <div className="space-y-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                  Going
+                </p>
+                {renderParticipants(acceptedInvites, "No one has accepted yet.")}
+              </div>
+              {pendingInvites.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    Awaiting response
+                  </p>
+                  <p className="text-xs text-neutral-600">
+                    {pendingInvites.map((invite) => getUserDisplayName(invite.user)).join(", ")}
+                  </p>
+                </div>
+              )}
+              {declinedInvites.length > 0 && (
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    Not going
+                  </p>
+                  <p className="text-xs text-neutral-500">
+                    {declinedInvites.map((invite) => getUserDisplayName(invite.user)).join(", ")}
+                  </p>
+                </div>
               )}
             </div>
           </div>
-
-          {activity.acceptances.length > 0 && (
-            <div className="mt-4">
-              <p className="text-xs font-medium uppercase tracking-wide text-neutral-500 mb-2">
-                Attending
-              </p>
-              <div className="flex flex-wrap gap-2">
-                {activity.acceptances.map((acceptance) => (
-                  <Badge
-                    key={acceptance.id}
-                    variant="outline"
-                    className="border-neutral-200 bg-white text-neutral-700"
-                  >
-                    {getUserDisplayName(acceptance.user)}
-                  </Badge>
-                ))}
-              </div>
-            </div>
-          )}
         </div>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/client/src/components/activity-details-dialog.tsx
+++ b/client/src/components/activity-details-dialog.tsx
@@ -1,0 +1,252 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Separator } from "@/components/ui/separator";
+import { Calendar, MapPin, DollarSign, Users } from "lucide-react";
+import { format } from "date-fns";
+import type { ActivityInviteStatus, ActivityWithDetails } from "@shared/schema";
+import type { User } from "@shared/schema";
+import { cn } from "@/lib/utils";
+
+interface ActivityDetailsDialogProps {
+  activity: ActivityWithDetails | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRespond: (status: ActivityInviteStatus) => void;
+  isResponding?: boolean;
+  currentUserId?: string;
+}
+
+const statusLabelMap: Record<ActivityInviteStatus, string> = {
+  accepted: "Accepted",
+  pending: "Pending",
+  declined: "Declined",
+};
+
+const statusBadgeClasses: Record<ActivityInviteStatus, string> = {
+  accepted: "bg-green-100 text-green-800 border-green-200",
+  pending: "bg-amber-100 text-amber-800 border-amber-200",
+  declined: "bg-red-100 text-red-800 border-red-200",
+};
+
+const getUserDisplayName = (user: User | undefined): string => {
+  if (!user) {
+    return "Trip member";
+  }
+
+  const first = user.firstName?.trim();
+  const last = user.lastName?.trim();
+
+  if (first && last) {
+    return `${first} ${last}`;
+  }
+
+  if (first) {
+    return first;
+  }
+
+  if (user.username && user.username.trim()) {
+    return user.username;
+  }
+
+  return user.email ?? "Trip member";
+};
+
+const formatDateTime = (value: ActivityWithDetails["startTime"]): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  return format(date, "EEEE, MMM d · h:mm a");
+};
+
+const formatEndTime = (value: ActivityWithDetails["endTime"] | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+  const date = value instanceof Date ? value : new Date(value);
+  return format(date, "h:mm a");
+};
+
+export function ActivityDetailsDialog({
+  activity,
+  open,
+  onOpenChange,
+  onRespond,
+  isResponding = false,
+  currentUserId,
+}: ActivityDetailsDialogProps) {
+  const invites = activity?.invites ?? [];
+  const currentInvite = invites.find((invite) => invite.userId === currentUserId);
+  const currentStatus = currentInvite?.status;
+
+  const handleRespond = (status: ActivityInviteStatus) => {
+    if (!activity || currentStatus === status) {
+      return;
+    }
+    onRespond(status);
+  };
+
+  const endTimeLabel = activity ? formatEndTime(activity.endTime) : null;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold text-neutral-900">
+            {activity?.name ?? "Activity"}
+          </DialogTitle>
+          <DialogDescription className="text-sm text-neutral-600">
+            Review the details and let everyone know if you’re joining.
+          </DialogDescription>
+        </DialogHeader>
+
+        {activity && (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
+                  <Calendar className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">When</p>
+                  <p className="text-sm font-medium text-neutral-900">{formatDateTime(activity.startTime)}</p>
+                  {endTimeLabel && (
+                    <p className="text-xs text-neutral-500">Ends at {endTimeLabel}</p>
+                  )}
+                </div>
+              </div>
+
+              <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
+                  <Users className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">RSVP summary</p>
+                  <p className="text-sm font-medium text-neutral-900">
+                    {activity.acceptedCount} going
+                    {activity.pendingCount > 0 && ` • ${activity.pendingCount} pending`}
+                    {activity.declinedCount > 0 && ` • ${activity.declinedCount} declined`}
+                  </p>
+                </div>
+              </div>
+
+              {activity.location && (
+                <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                  <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
+                    <MapPin className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Where</p>
+                    <p className="text-sm font-medium text-neutral-900">{activity.location}</p>
+                  </div>
+                </div>
+              )}
+
+              {typeof activity.cost === "number" && (
+                <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                  <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
+                    <DollarSign className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Cost per person</p>
+                    <p className="text-sm font-medium text-neutral-900">
+                      ${activity.cost.toFixed(2)}
+                    </p>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {activity.description && (
+              <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">Details</p>
+                <p className="mt-2 text-sm text-neutral-700 whitespace-pre-wrap">{activity.description}</p>
+              </div>
+            )}
+
+            <div className="rounded-lg border border-neutral-200 bg-white p-4">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-neutral-900">Your response</p>
+                  <p className="text-xs text-neutral-500">
+                    {currentStatus ? `Currently marked as ${statusLabelMap[currentStatus]}.` : 'You are not on the invite list for this activity.'}
+                  </p>
+                </div>
+                {currentStatus && (
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button
+                      variant={currentStatus === 'accepted' ? 'default' : 'outline'}
+                      size="sm"
+                      disabled={isResponding}
+                      onClick={() => handleRespond('accepted')}
+                    >
+                      Going
+                    </Button>
+                    <Button
+                      variant={currentStatus === 'pending' ? 'default' : 'outline'}
+                      size="sm"
+                      disabled={isResponding}
+                      onClick={() => handleRespond('pending')}
+                    >
+                      Decide later
+                    </Button>
+                    <Button
+                      variant={currentStatus === 'declined' ? 'default' : 'outline'}
+                      size="sm"
+                      disabled={isResponding}
+                      onClick={() => handleRespond('declined')}
+                    >
+                      Can't make it
+                    </Button>
+                  </div>
+                )}
+              </div>
+              {!currentStatus && (
+                <p className="mt-2 text-sm text-neutral-600">
+                  Ask the activity organizer to add you to the invite list if you want to join.
+                </p>
+              )}
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-semibold text-neutral-900">Invite list</p>
+                <p className="text-xs text-neutral-500">{invites.length} people invited</p>
+              </div>
+              <Separator className="my-3" />
+              <div className="space-y-2">
+                {invites.map((invite) => {
+                  const name = getUserDisplayName(invite.user);
+                  return (
+                    <div
+                      key={invite.id}
+                      className="flex items-center justify-between rounded-lg border border-neutral-200 bg-neutral-50 p-3"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar className="h-8 w-8">
+                          <AvatarImage src={invite.user.profileImageUrl ?? undefined} alt={name} />
+                          <AvatarFallback>{name.charAt(0).toUpperCase()}</AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <p className="text-sm font-medium text-neutral-900">{name}</p>
+                          <p className="text-xs text-neutral-500">
+                            {invite.user.id === activity.postedBy ? 'Organizer' : 'Invitee'}
+                          </p>
+                        </div>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={cn('border', statusBadgeClasses[invite.status])}
+                      >
+                        {statusLabelMap[invite.status]}
+                      </Badge>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -9,6 +9,7 @@ interface CalendarGridProps {
   trip: TripWithDetails;
   selectedDate?: Date | null;
   onDayClick?: (date: Date) => void;
+  onActivityClick?: (activity: ActivityWithDetails) => void;
 }
 
 const categoryColors = {
@@ -55,7 +56,7 @@ const categoryIcons = {
   other: "📍",
 };
 
-export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onDayClick }: CalendarGridProps) {
+export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onDayClick, onActivityClick }: CalendarGridProps) {
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
   const days = eachDayOfInterval({ start: monthStart, end: monthEnd });
@@ -169,12 +170,20 @@ export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onD
                   {dayActivities.slice(0, 3).map(activity => (
                     <div
                       key={activity.id}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onActivityClick?.(activity);
+                      }}
                       className={`text-xs px-2 py-1 rounded-md font-medium shadow-sm border ${
                         categoryColors[activity.category as keyof typeof categoryColors] || categoryColors.other
-                      } truncate`}
+                      } truncate cursor-pointer transition-colors hover:brightness-95`}
                     >
                       {categoryIcons[activity.category as keyof typeof categoryIcons] || categoryIcons.other}{" "}
                       {activity.name.length > 15 ? `${activity.name.substring(0, 12)}...` : activity.name}
+                      <div className="mt-1 flex items-center gap-1 text-[10px] font-medium">
+                        <span>{activity.acceptedCount} going</span>
+                        {activity.pendingCount > 0 && <span>• {activity.pendingCount} pending</span>}
+                      </div>
                     </div>
                   ))}
                   {dayActivities.length > 3 && (

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -185,6 +185,24 @@ export interface ActivityAcceptance {
   acceptedAt: IsoDate | null;
 }
 
+export const activityInviteStatusSchema = z.enum([
+  "pending",
+  "accepted",
+  "declined",
+]);
+
+export type ActivityInviteStatus = z.infer<typeof activityInviteStatusSchema>;
+
+export interface ActivityInvite {
+  id: number;
+  activityId: number;
+  userId: string;
+  status: ActivityInviteStatus;
+  respondedAt: IsoDate | null;
+  createdAt: IsoDate | null;
+  updatedAt: IsoDate | null;
+}
+
 export interface ActivityResponse {
   id: number;
   activityId: number;
@@ -857,9 +875,13 @@ export type RestaurantProposalWithDetails = RestaurantProposal & {
 
 export type ActivityWithDetails = Activity & {
   poster: User;
+  invites: (ActivityInvite & { user: User })[];
   acceptances: (ActivityAcceptance & { user: User })[];
   comments: (ActivityComment & { user: User })[];
   acceptedCount: number;
+  pendingCount: number;
+  declinedCount: number;
+  currentUserInvite?: ActivityInvite & { user: User };
   isAccepted?: boolean;
   hasResponded?: boolean;
 };


### PR DESCRIPTION
## Summary
- add an activity details dialog so travelers can review invite details and respond from the trip calendar
- surface pending invites in the proposals view with accept/decline/maybe controls and invite-specific cards
- update activity cards and member schedules to display invite statuses instead of legacy acceptance fields

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4459eba24832e80e165cd05adf843