### PR TITLE
Restrict packing list personal item visibility

### DIFF
--- a/client/src/components/packing-list.tsx
+++ b/client/src/components/packing-list.tsx
@@ -154,8 +154,11 @@ export function PackingList({ tripId }: PackingListProps) {
     });
   };
 
-  const personalItems = packingItems.filter(item => item.itemType === 'personal');
-  const groupItems = packingItems.filter(item => item.itemType === 'group');
+  const personalItems = packingItems.filter(
+    (item) => item.itemType === "personal" && item.userId === user?.id,
+  );
+  const groupItems = packingItems.filter((item) => item.itemType === "group");
+  const visibleItems = [...personalItems, ...groupItems];
 
   const groupedPersonalItems = personalItems.reduce((acc, item) => {
     if (!acc[item.category || 'general']) {
@@ -177,8 +180,8 @@ export function PackingList({ tripId }: PackingListProps) {
     return categories.find(cat => cat.value === categoryValue) || categories[0];
   };
 
-  const completedCount = packingItems.filter(item => item.isChecked).length;
-  const totalCount = packingItems.length;
+  const completedCount = visibleItems.filter((item) => item.isChecked).length;
+  const totalCount = visibleItems.length;
 
   if (isLoading) {
     return (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1829,7 +1829,7 @@ export function setupRoutes(app: Express) {
         return res.status(401).json({ message: "User ID not found" });
       }
       
-      const packingItems = await storage.getTripPackingItems(tripId);
+      const packingItems = await storage.getTripPackingItems(tripId, userId);
       res.json(packingItems);
     } catch (error: unknown) {
       console.error("Error fetching packing items:", error);
@@ -1882,6 +1882,15 @@ export function setupRoutes(app: Express) {
         return res.status(401).json({ message: "User ID not found" });
       }
       
+      const packingItem = await storage.getPackingItemById(itemId);
+      if (!packingItem) {
+        return res.status(404).json({ message: "Packing item not found" });
+      }
+
+      if (packingItem.itemType === "personal" && packingItem.userId !== userId) {
+        return res.status(403).json({ message: "You are not allowed to update this item" });
+      }
+
       await storage.togglePackingItem(itemId, userId);
       res.json({ success: true });
     } catch (error: unknown) {
@@ -1904,6 +1913,15 @@ export function setupRoutes(app: Express) {
         return res.status(401).json({ message: "User ID not found" });
       }
       
+      const packingItem = await storage.getPackingItemById(itemId);
+      if (!packingItem) {
+        return res.status(404).json({ message: "Packing item not found" });
+      }
+
+      if (packingItem.userId !== userId) {
+        return res.status(403).json({ message: "You are not allowed to delete this item" });
+      }
+
       await storage.deletePackingItem(itemId, userId);
       res.json({ success: true });
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary
- filter trip packing items on the server so users only receive their personal items plus group items
- enforce ownership checks when toggling or deleting packing entries and add a helper to load individual items
- update the client packing list to ignore non-owned personal items and base progress metrics on visible items only

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d479923240832e80c4f9711808bc76