### PR TITLE
Fix paid summary to include settled shares

### DIFF
--- a/client/src/components/expense-tracker.tsx
+++ b/client/src/components/expense-tracker.tsx
@@ -235,9 +235,26 @@ export function ExpenseTracker({ tripId, user }: ExpenseTrackerProps) {
   const summary = useMemo(() => {
     const total = expenses.reduce((sum, expense) => sum + expense.totalAmount, 0);
     const youPaid = expenses.reduce((sum, expense) => {
-      return expense.paidBy.id === user?.id
-        ? sum + expense.totalAmount
-        : sum;
+      let total = sum;
+
+      if (expense.paidBy.id === user?.id) {
+        total += expense.totalAmount;
+        return total;
+      }
+
+      if (!user?.id) {
+        return total;
+      }
+
+      const paidShareForUser = expense.shares.find(
+        (share) => share.userId === user.id && share.isPaid,
+      );
+
+      if (paidShareForUser) {
+        total += paidShareForUser.amount;
+      }
+
+      return total;
     }, 0);
     const owes = Number(balances?.owes ?? 0);
     const owed = Number(balances?.owed ?? 0);


### PR DESCRIPTION
## Summary
- ensure the "You paid" total counts any settled shares for expenses paid by other travelers
- keep expenses you personally logged counted without double-counting your own share

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d47dbbfad4832e90bb378266dda0e0