### PR TITLE
Prevent mobile auto-capitalization on login

### DIFF
--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -119,6 +119,12 @@ export default function Login() {
                       <div className="relative">
                         <User className="absolute left-4 top-3.5 h-4 w-4 text-slate-400" />
                         <Input
+                          type="email"
+                          inputMode="email"
+                          autoCapitalize="none"
+                          autoComplete="email"
+                          autoCorrect="off"
+                          spellCheck={false}
                           placeholder="john@example.com or johndoe"
                           className="pl-11 bg-white text-slate-900 placeholder:text-slate-400 focus-visible:ring-primary"
                           {...field}
@@ -141,6 +147,7 @@ export default function Login() {
                         <Lock className="absolute left-4 top-3.5 h-4 w-4 text-slate-400" />
                         <Input
                           type={showPassword ? "text" : "password"}
+                          autoComplete="current-password"
                           placeholder="••••••••"
                           className="pl-11 pr-11 bg-white text-slate-900 placeholder:text-slate-400 focus-visible:ring-primary"
                           {...field}


### PR DESCRIPTION
## Summary
- set the login identifier field to use email-optimized input attributes so iOS won't auto-capitalize or autocorrect entries
- ensure the password field provides the correct autocomplete hint for credential managers

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d554b995808329880d5d47f2879a89