### PR TITLE
Improve month calendar event layout

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -1,5 +1,5 @@
 import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, isWithinInterval } from "date-fns";
 import type { ActivityWithDetails, TripWithDetails } from "@shared/schema";
 
@@ -56,15 +56,29 @@ const categoryIcons = {
   other: "📍",
 };
 
+const MAX_VISIBLE_EVENTS = 3;
+
+const formatBadgeTime = (dateString: string) => {
+  const dateValue = new Date(dateString);
+  return format(dateValue, "h:mmaaa").toLowerCase().replace("m", "");
+};
+
+const formatActivityAriaLabel = (activity: ActivityWithDetails, day: Date) => {
+  const start = new Date(activity.startTime);
+  const timeLabel = format(start, "h:mm a");
+  const dateLabel = format(day, "MMM d");
+  return `${activity.name} at ${timeLabel} on ${dateLabel}`;
+};
+
 export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onDayClick, onActivityClick }: CalendarGridProps) {
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
   const days = eachDayOfInterval({ start: monthStart, end: monthEnd });
 
   const getActivitiesForDay = (day: Date) => {
-    return activities.filter(activity => 
-      isSameDay(new Date(activity.startTime), day)
-    );
+    return activities
+      .filter(activity => isSameDay(new Date(activity.startTime), day))
+      .sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
   };
 
   const isTripDay = (day: Date) => {
@@ -133,64 +147,103 @@ export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onD
           const isTripActive = isTripDay(day);
           const isSelected = selectedDate && isSameDay(day, selectedDate);
           
+          const visibleActivities = dayActivities.slice(0, MAX_VISIBLE_EVENTS);
+          const hiddenCount = Math.max(dayActivities.length - visibleActivities.length, 0);
+
           return (
             <div
               key={day.toISOString()}
+              role={isTripActive ? "button" : undefined}
+              tabIndex={isTripActive ? 0 : -1}
               onClick={() => isTripActive && onDayClick?.(day)}
-              className={`h-32 lg:h-40 p-2 relative ${
-                isTripActive 
-                  ? `bg-white cursor-pointer hover:bg-blue-50 transition-colors ${
-                      isSelected 
-                        ? "ring-2 ring-primary ring-inset" 
-                        : dayActivities.length > 0 
-                          ? "border-2 border-primary" 
+              onKeyDown={event => {
+                if (!isTripActive) return;
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onDayClick?.(day);
+                }
+              }}
+              aria-label={format(day, "MMMM d, yyyy")}
+              className={`h-32 lg:h-40 p-2 relative flex flex-col ${
+                isTripActive
+                  ? `bg-white cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 ${
+                      isSelected
+                        ? "ring-2 ring-primary ring-inset"
+                        : dayActivities.length > 0
+                          ? "border-2 border-primary"
                           : "border border-gray-200"
-                    }`
+                    } hover:bg-blue-50`
                   : "bg-gray-50"
               }`}
             >
-              <span className={`text-sm font-medium ${
-                isTripActive ? "text-neutral-900" : "text-neutral-400"
-              }`}>
-                {format(day, 'd')}
+              <span
+                className={`text-sm font-medium ${
+                  isTripActive ? "text-neutral-900" : "text-neutral-400"
+                }`}
+              >
+                {format(day, "d")}
               </span>
-              
+
               {isSelected && (
                 <div className="absolute top-1 right-1 w-3 h-3 bg-primary rounded-full border-2 border-white"></div>
               )}
-              
+
               {isTripActive && dayActivities.length === 0 && (
                 <div className="absolute bottom-1 left-1/2 transform -translate-x-1/2 text-xs text-gray-400 opacity-0 hover:opacity-100 transition-opacity">
                   Click to add
                 </div>
               )}
-              
+
               {dayActivities.length > 0 && (
-                <div className="mt-1 space-y-1">
-                  {dayActivities.slice(0, 3).map(activity => (
-                    <div
-                      key={activity.id}
-                      onClick={(event) => {
-                        event.stopPropagation();
-                        onActivityClick?.(activity);
-                      }}
-                      className={`text-xs px-2 py-1 rounded-md font-medium shadow-sm border ${
-                        categoryColors[activity.category as keyof typeof categoryColors] || categoryColors.other
-                      } truncate cursor-pointer transition-colors hover:brightness-95`}
-                    >
-                      {categoryIcons[activity.category as keyof typeof categoryIcons] || categoryIcons.other}{" "}
-                      {activity.name.length > 15 ? `${activity.name.substring(0, 12)}...` : activity.name}
-                      <div className="mt-1 flex items-center gap-1 text-[10px] font-medium">
-                        <span>{activity.acceptedCount} going</span>
-                        {activity.pendingCount > 0 && <span>• {activity.pendingCount} pending</span>}
-                      </div>
-                    </div>
-                  ))}
-                  {dayActivities.length > 3 && (
-                    <div className="text-xs text-neutral-600 px-2">
-                      +{dayActivities.length - 3} more
-                    </div>
-                  )}
+                <div className="mt-1 flex-1 min-h-0 overflow-hidden">
+                  <div className="flex h-full flex-col gap-1 overflow-hidden">
+                    {visibleActivities.map(activity => (
+                      <Tooltip key={activity.id}>
+                        <TooltipTrigger asChild>
+                          <button
+                            type="button"
+                            onClick={event => {
+                              event.stopPropagation();
+                              onActivityClick?.(activity);
+                            }}
+                            className={`group flex w-full items-center gap-2 rounded-md border px-2 py-1 text-[12px] leading-5 font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${
+                              categoryColors[activity.category as keyof typeof categoryColors] || categoryColors.other
+                            }`}
+                            aria-label={formatActivityAriaLabel(activity, day)}
+                          >
+                            <span className="shrink-0 text-sm">
+                              {categoryIcons[activity.category as keyof typeof categoryIcons] || categoryIcons.other}
+                            </span>
+                            <span className="flex-1 truncate text-left">
+                              {activity.name}
+                            </span>
+                            <span className="shrink-0 rounded-sm bg-white/20 px-1 text-[10px] uppercase tracking-tight">
+                              {formatBadgeTime(activity.startTime)}
+                            </span>
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent className="text-xs" side="top" align="start">
+                          <div className="font-medium text-neutral-900">{activity.name}</div>
+                          <div className="text-[11px] text-neutral-600">
+                            {format(new Date(activity.startTime), "h:mm a")}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    ))}
+                    {hiddenCount > 0 && (
+                      <button
+                        type="button"
+                        onClick={event => {
+                          event.stopPropagation();
+                          onDayClick?.(day);
+                        }}
+                        className="mt-auto w-full truncate rounded-md border border-dashed border-neutral-300 bg-white/70 px-2 py-1 text-left text-xs font-medium text-neutral-600 transition-colors hover:bg-neutral-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1"
+                        aria-label={`${hiddenCount} more activities on ${format(day, "MMMM d")}`}
+                      >
+                        +{hiddenCount} more
+                      </button>
+                    )}
+                  </div>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- sort month view activities by start time before rendering
- clamp month cells to a compact, accessible pill layout with tooltips and keyboard focus
- add a +N more control that opens the day view when events exceed the visible limit

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d57b84a688832e907c6dea21e9f24e