### PR TITLE
Fix trip day view date handling

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, isSameDay, isWithinInterval } from "date-fns";
+import { parseDateValue } from "@/lib/utils";
 import type { ActivityWithDetails, TripWithDetails } from "@shared/schema";
 
 interface CalendarGridProps {
@@ -60,6 +60,8 @@ export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onD
   const monthStart = startOfMonth(currentMonth);
   const monthEnd = endOfMonth(currentMonth);
   const days = eachDayOfInterval({ start: monthStart, end: monthEnd });
+  const tripStart = parseDateValue(trip.startDate) ?? new Date(trip.startDate);
+  const tripEnd = parseDateValue(trip.endDate) ?? new Date(trip.endDate);
 
   const getActivitiesForDay = (day: Date) => {
     return activities.filter(activity => 
@@ -68,9 +70,18 @@ export function CalendarGrid({ currentMonth, activities, trip, selectedDate, onD
   };
 
   const isTripDay = (day: Date) => {
+    if (
+      !tripStart ||
+      !tripEnd ||
+      Number.isNaN(tripStart.getTime()) ||
+      Number.isNaN(tripEnd.getTime())
+    ) {
+      return false;
+    }
+
     return isWithinInterval(day, {
-      start: new Date(trip.startDate),
-      end: new Date(trip.endDate)
+      start: tripStart,
+      end: tripEnd,
     });
   };
 

--- a/client/src/components/edit-trip-modal.tsx
+++ b/client/src/components/edit-trip-modal.tsx
@@ -13,6 +13,7 @@ import { apiRequest } from "@/lib/queryClient";
 import SmartLocationSearch from "@/components/SmartLocationSearch";
 import type { TripWithDetails } from "@shared/schema";
 import { format } from "date-fns";
+import { parseDateValue } from "@/lib/utils";
 
 interface EditTripModalProps {
   open: boolean;
@@ -42,14 +43,16 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [selectedDestination, setSelectedDestination] = useState<any>(null);
+  const parsedTripStartDate = parseDateValue(trip.startDate) ?? new Date(trip.startDate);
+  const parsedTripEndDate = parseDateValue(trip.endDate) ?? new Date(trip.endDate);
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
     defaultValues: {
       name: trip.name,
       destination: trip.destination,
-      startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
-      endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+      startDate: format(parsedTripStartDate, "yyyy-MM-dd"),
+      endDate: format(parsedTripEndDate, "yyyy-MM-dd"),
     },
   });
 
@@ -59,8 +62,8 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
       form.reset({
         name: trip.name,
         destination: trip.destination,
-        startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
-        endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+        startDate: format(parsedTripStartDate, "yyyy-MM-dd"),
+        endDate: format(parsedTripEndDate, "yyyy-MM-dd"),
       });
       // Set destination for SmartLocationSearch
       setSelectedDestination({ 
@@ -138,8 +141,8 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
     form.reset({
       name: trip.name,
       destination: trip.destination,
-      startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
-      endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+      startDate: format(parsedTripStartDate, "yyyy-MM-dd"),
+      endDate: format(parsedTripEndDate, "yyyy-MM-dd"),
     });
     // Reset selected destination to original
     setSelectedDestination({ 

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -52,3 +52,43 @@ export function formatCurrency(
     return `${currency} ${amount.toFixed(fractionDigits)}`;
   }
 }
+
+export function parseDateValue(
+  value: string | Date | null | undefined,
+): Date | null {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return new Date(value.getTime());
+  }
+
+  if (typeof value === "string") {
+    const trimmedValue = value.trim();
+    if (!trimmedValue) {
+      return null;
+    }
+
+    const dateOnlyMatch = trimmedValue.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (dateOnlyMatch) {
+      const [, year, month, day] = dateOnlyMatch;
+      const parsedDate = new Date(
+        Number(year),
+        Number(month) - 1,
+        Number(day),
+      );
+
+      if (!Number.isNaN(parsedDate.getTime())) {
+        return parsedDate;
+      }
+    }
+
+    const parsedDate = new Date(trimmedValue);
+    if (!Number.isNaN(parsedDate.getTime())) {
+      return parsedDate;
+    }
+  }
+
+  return null;
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -48,6 +48,7 @@ import { TravelMascot } from "@/components/TravelMascot";
 import { ManualRefreshButton } from "@/components/manual-refresh-button";
 import { Link } from "wouter";
 import { apiRequest, queryClient } from "@/lib/queryClient";
+import { parseDateValue } from "@/lib/utils";
 import { useToast } from "@/hooks/use-toast";
 import type { TripWithDetails } from "@shared/schema";
 import { Progress } from "@/components/ui/progress";
@@ -408,21 +409,32 @@ export default function Home() {
     endDate: string | Date,
   ) => {
     const start =
-      typeof startDate === "string" ? new Date(startDate) : startDate;
-    const end = typeof endDate === "string" ? new Date(endDate) : endDate;
+      typeof startDate === "string"
+        ? parseDateValue(startDate) ?? new Date(startDate)
+        : startDate;
+    const end =
+      typeof endDate === "string"
+        ? parseDateValue(endDate) ?? new Date(endDate)
+        : endDate;
     return `${start.toLocaleDateString()} - ${end.toLocaleDateString()}`;
   };
 
   const getUpcomingTrips = () => {
     if (!trips) return [];
     const now = new Date();
-    return trips.filter((trip) => new Date(trip.startDate) >= now);
+    return trips.filter((trip) => {
+      const tripStart = parseDateValue(trip.startDate) ?? new Date(trip.startDate);
+      return tripStart >= now;
+    });
   };
 
   const getPastTrips = () => {
     if (!trips) return [];
     const now = new Date();
-    return trips.filter((trip) => new Date(trip.endDate) < now);
+    return trips.filter((trip) => {
+      const tripEnd = parseDateValue(trip.endDate) ?? new Date(trip.endDate);
+      return tripEnd < now;
+    });
   };
 
   const handleStatClick = (statType: StatType) => {
@@ -623,7 +635,7 @@ export default function Home() {
         : "Destination TBA";
     const mapKey = rawDestination || "Destination TBA";
     const existingDestination = destinationMap.get(mapKey);
-    const tripStart = new Date(trip.startDate);
+    const tripStart = parseDateValue(trip.startDate) ?? new Date(trip.startDate);
     const isUpcoming = tripStart >= currentDate;
 
     if (existingDestination) {

--- a/client/src/pages/member-schedule.tsx
+++ b/client/src/pages/member-schedule.tsx
@@ -24,6 +24,7 @@ import { MobileNav } from "@/components/mobile-nav";
 import type { TripWithDetails, ActivityWithDetails, User as UserType } from "@shared/schema";
 import { format, startOfMonth, endOfMonth, addMonths, subMonths, isSameMonth } from "date-fns";
 import { Badge } from "@/components/ui/badge";
+import { parseDateValue } from "@/lib/utils";
 
 const getParticipantDisplayName = (user: UserType) => {
   const first = user.firstName?.trim();
@@ -141,14 +142,14 @@ export default function MemberSchedule() {
 
   // Auto-navigate calendar to trip dates when trip loads
   useEffect(() => {
-    if (trip?.startDate) {
-      const tripStartDate = new Date(trip.startDate);
+    const parsedStartDate = parseDateValue(trip?.startDate ?? null);
+    if (parsedStartDate) {
       const currentMonthStart = startOfMonth(currentMonth);
-      const tripMonthStart = startOfMonth(tripStartDate);
-      
+      const tripMonthStart = startOfMonth(parsedStartDate);
+
       // Only update if we're not already showing the correct month
       if (!isSameMonth(currentMonthStart, tripMonthStart)) {
-        setCurrentMonth(tripStartDate);
+        setCurrentMonth(parsedStartDate);
       }
     }
   }, [trip?.startDate]);
@@ -159,7 +160,7 @@ export default function MemberSchedule() {
   };
 
   const parseIsoDate = (value: TripWithDetails["startDate"]) =>
-    value instanceof Date ? value : new Date(value);
+    parseDateValue(value) ?? new Date(value);
 
   const formatDateRange = (
     startDate: TripWithDetails["startDate"],


### PR DESCRIPTION
## Summary
- add a shared `parseDateValue` helper to interpret trip date strings in local time
- update the trip page to use normalized dates when clamping views, computing durations, and formatting weather data so day view opens on the real start date
- align other trip-aware views (member schedule, calendar grid, hotels, home stats, edit modal) with the new date parsing to keep ranges consistent

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d57cac4e70832ea4bbc310a7394121