### PR TITLE
Make group packing item statuses user-specific

### DIFF
--- a/client/src/components/packing-list.tsx
+++ b/client/src/components/packing-list.tsx
@@ -288,7 +288,7 @@ export function PackingList({ tripId }: PackingListProps) {
               <Users className="w-5 h-5 text-blue-600" />
               <h3 className="text-lg font-medium text-gray-900">Personal Items</h3>
               <Badge variant="outline">
-                {personalItems.filter(item => item.isChecked).length}/{personalItems.length} packed
+                You: {personalItems.filter(item => item.isChecked).length}/{personalItems.length} packed
               </Badge>
             </div>
             
@@ -311,7 +311,7 @@ export function PackingList({ tripId }: PackingListProps) {
                           {category.label}
                         </Badge>
                         <span className="text-sm text-gray-500">
-                          {items.filter(item => item.isChecked).length}/{items.length} packed
+                          You: {items.filter(item => item.isChecked).length}/{items.length} packed
                         </span>
                       </div>
                       <div className="space-y-2">
@@ -381,7 +381,7 @@ export function PackingList({ tripId }: PackingListProps) {
               <Package className="w-5 h-5 text-green-600" />
               <h3 className="text-lg font-medium text-gray-900">Group Items</h3>
               <Badge variant="outline">
-                {groupItems.filter(item => item.isChecked).length}/{groupItems.length} handled
+                You: {groupItems.filter(item => item.isChecked).length}/{groupItems.length} handled
               </Badge>
             </div>
             
@@ -407,7 +407,7 @@ export function PackingList({ tripId }: PackingListProps) {
                           {category.label}
                         </Badge>
                         <span className="text-sm text-gray-500">
-                          {items.filter(item => item.isChecked).length}/{items.length} handled
+                          You: {items.filter(item => item.isChecked).length}/{items.length} handled
                         </span>
                       </div>
                       <div className="space-y-2">
@@ -432,15 +432,22 @@ export function PackingList({ tripId }: PackingListProps) {
                               </div>
                               <div className="flex-1">
                                 <span className={`font-medium block transition-colors ${
-                                  item.isChecked 
-                                    ? 'line-through text-blue-600' 
+                                  item.isChecked
+                                    ? 'line-through text-blue-600'
                                     : 'text-gray-900'
                                 }`}>
                                   {item.item}
                                 </span>
-                                {item.isChecked && (
-                                  <span className="text-sm text-blue-600 font-medium">✓ Handled</span>
-                                )}
+                                <div className="mt-1 flex flex-wrap items-center gap-2">
+                                  {item.isChecked && (
+                                    <span className="text-sm text-blue-600 font-medium">✓ Handled</span>
+                                  )}
+                                  {item.groupStatus && item.groupStatus.memberCount > 0 && (
+                                    <Badge variant="secondary" className="text-xs font-normal px-2 py-0.5">
+                                      Group: {item.groupStatus.checkedCount}/{item.groupStatus.memberCount} handled
+                                    </Badge>
+                                  )}
+                                </div>
                               </div>
                             </div>
                             <div className="flex items-center space-x-2">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1933,7 +1933,7 @@ export function setupRoutes(app: Express) {
         return res.status(403).json({ message: "You are not allowed to update this item" });
       }
 
-      await storage.togglePackingItem(itemId, userId);
+      await storage.togglePackingItem(itemId, userId, packingItem.itemType);
       res.json({ success: true });
     } catch (error: unknown) {
       console.error("Error toggling packing item:", error);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -226,6 +226,11 @@ export const insertActivityCommentSchema = z.object({
 
 export type InsertActivityComment = z.infer<typeof insertActivityCommentSchema>;
 
+export interface PackingItemGroupStatus {
+  checkedCount: number;
+  memberCount: number;
+}
+
 export interface PackingItem {
   id: number;
   tripId: number;
@@ -236,6 +241,7 @@ export interface PackingItem {
   isChecked: boolean;
   assignedUserId: string | null;
   createdAt: IsoDate | null;
+  groupStatus?: PackingItemGroupStatus;
 }
 
 export const insertPackingItemSchema = z.object({


### PR DESCRIPTION
## Summary
- add persistent per-user status tracking for group packing items and expose aggregate counts
- update packing list API response and shared types to include group progress metadata
- refresh the packing list UI to show personal progress labels and optional group chips

## Testing
- npm run check *(fails: existing IsoDate values passed where strings are expected in calendar-grid.tsx and trip.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ad68f8a8832eaca9e1fa8b27ba8f