### PR TITLE
Fix expense split selection and requests UI

### DIFF
--- a/client/src/components/ui/helper-text.tsx
+++ b/client/src/components/ui/helper-text.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface HelperTextProps
+  extends React.HTMLAttributes<HTMLParagraphElement> {}
+
+const HelperText = React.forwardRef<HTMLParagraphElement, HelperTextProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <p
+        ref={ref}
+        className={cn("text-sm text-muted-foreground", className)}
+        {...props}
+      />
+    );
+  },
+);
+
+HelperText.displayName = "HelperText";
+
+export { HelperText };


### PR DESCRIPTION
## Summary
- update the add expense modal to hide the payer from the split list, compute per-person requests that include the payer in the math, and show the summary with new helper text styling
- add front-end validation that surfaces API errors inline, builds the payload without the payer, and disables the submit action until the form is valid
- add a reusable HelperText UI component for consistent helper copy

## Testing
- npm run check *(fails: existing TypeScript errors in calendar-grid.tsx and trip.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ba77e660832eb5041d0d07625ab0