### PR TITLE
Implement currency-aware shared expense splits

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -58,8 +58,8 @@ const categoryIcons = {
 
 const MAX_VISIBLE_EVENTS = 3;
 
-const formatBadgeTime = (dateString: string) => {
-  const dateValue = new Date(dateString);
+const formatBadgeTime = (dateInput: string | Date) => {
+  const dateValue = typeof dateInput === "string" ? new Date(dateInput) : dateInput;
   return format(dateValue, "h:mmaaa").toLowerCase().replace("m", "");
 };
 

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -145,12 +145,14 @@ const MOBILE_TAB_ITEMS: { key: TripTab; label: string; icon: LucideIcon }[] = [
   { key: "groceries", label: "Groceries", icon: ShoppingCart },
 ];
 
-const parseTripDateToLocal = (value?: string | null): Date | null => {
+const parseTripDateToLocal = (value?: string | Date | null): Date | null => {
   if (!value) {
     return null;
   }
 
-  const [datePart] = value.split("T");
+  const dateString = value instanceof Date ? value.toISOString() : value;
+
+  const [datePart] = dateString.split("T");
 
   if (datePart) {
     const parts = datePart.split("-");
@@ -166,7 +168,7 @@ const parseTripDateToLocal = (value?: string | null): Date | null => {
     }
   }
 
-  const fallback = new Date(value);
+  const fallback = value instanceof Date ? value : new Date(value);
   return Number.isNaN(fallback.getTime()) ? null : fallback;
 };
 

--- a/shared/__tests__/computeSplits.test.ts
+++ b/shared/__tests__/computeSplits.test.ts
@@ -3,68 +3,173 @@ import { computeSplits } from '../expenses';
 
 describe('computeSplits', () => {
   it('throws when amount is not positive', () => {
-    expect(() => computeSplits(0, ['a'])).toThrow('Amount must be > 0');
-    expect(() => computeSplits(-100, ['a'])).toThrow('Amount must be > 0');
+    const baseInput = {
+      debtorIds: ['a'],
+      sourceCurrency: 'USD',
+      targetCurrency: 'USD',
+      conversionRate: 1,
+    };
+    expect(() =>
+      computeSplits({ ...baseInput, totalSourceMinorUnits: 0 }),
+    ).toThrow('Amount must be > 0');
+    expect(() =>
+      computeSplits({ ...baseInput, totalSourceMinorUnits: -100 }),
+    ).toThrow('Amount must be > 0');
   });
 
   it('throws when no debtors provided', () => {
-    expect(() => computeSplits(1000, [])).toThrow(
-      'Choose at least one person to split with',
-    );
+    expect(() =>
+      computeSplits({
+        totalSourceMinorUnits: 1000,
+        debtorIds: [],
+        sourceCurrency: 'USD',
+        targetCurrency: 'USD',
+        conversionRate: 1,
+      }),
+    ).toThrow('Choose at least one person to split with');
   });
 
   it('splits evenly when divisible', () => {
-    const result = computeSplits(10000, ['a', 'b', 'c']);
-    expect(result).toEqual([
-      { userId: 'a', amountCents: 2500 },
-      { userId: 'b', amountCents: 2500 },
-      { userId: 'c', amountCents: 2500 },
+    const result = computeSplits({
+      totalSourceMinorUnits: 10000,
+      debtorIds: ['a', 'b', 'c'],
+      sourceCurrency: 'USD',
+      targetCurrency: 'USD',
+      conversionRate: 1,
+    });
+    expect(result.shares).toEqual([
+      { userId: 'a', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
+      { userId: 'b', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
+      { userId: 'c', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
     ]);
+    expect(result.totalSourceMinorUnits).toBe(10000);
+    expect(result.totalTargetMinorUnits).toBe(10000);
   });
 
   it('distributes remainder cents to earliest debtors', () => {
-    const result = computeSplits(1000, ['a', 'b']);
-    expect(result).toEqual([
-      { userId: 'a', amountCents: 334 },
-      { userId: 'b', amountCents: 333 },
+    const result = computeSplits({
+      totalSourceMinorUnits: 1000,
+      debtorIds: ['a', 'b'],
+      sourceCurrency: 'USD',
+      targetCurrency: 'USD',
+      conversionRate: 1,
+    });
+    expect(result.shares).toEqual([
+      { userId: 'a', sourceMinorUnits: 334, targetMinorUnits: 334 },
+      { userId: 'b', sourceMinorUnits: 333, targetMinorUnits: 333 },
     ]);
   });
 
   it('sums of debtor amounts equal the total', () => {
     const amountCents = 12345;
     const debtors = ['a', 'b', 'c'];
-    const result = computeSplits(amountCents, debtors);
-    const sum = result.reduce((total, split) => total + split.amountCents, 0);
+    const result = computeSplits({
+      totalSourceMinorUnits: amountCents,
+      debtorIds: debtors,
+      sourceCurrency: 'USD',
+      targetCurrency: 'USD',
+      conversionRate: 1,
+    });
+    const sum = result.shares.reduce(
+      (total, split) => total + split.sourceMinorUnits,
+      0,
+    );
 
     expect(sum).toBe(amountCents);
+    expect(result.totalSourceMinorUnits).toBe(amountCents);
   });
 
   it('is deterministic for the same debtor ordering', () => {
     const debtors = ['x', 'y', 'z'];
-    const firstRun = computeSplits(101, debtors);
-    const secondRun = computeSplits(101, debtors);
+    const baseInput = {
+      totalSourceMinorUnits: 101,
+      debtorIds: debtors,
+      sourceCurrency: 'USD',
+      targetCurrency: 'USD',
+      conversionRate: 1,
+    };
+    const firstRun = computeSplits(baseInput);
+    const secondRun = computeSplits(baseInput);
 
     expect(secondRun).toEqual(firstRun);
   });
 
   it('supports all prompt examples', () => {
-    expect(computeSplits(2500, ['patrick'])).toEqual([
-      { userId: 'patrick', amountCents: 1250 },
+    expect(
+      computeSplits({
+        totalSourceMinorUnits: 2500,
+        debtorIds: ['patrick'],
+        sourceCurrency: 'USD',
+        targetCurrency: 'USD',
+        conversionRate: 1,
+      }).shares,
+    ).toEqual([{ userId: 'patrick', sourceMinorUnits: 1250, targetMinorUnits: 1250 }]);
+
+    expect(
+      computeSplits({
+        totalSourceMinorUnits: 10000,
+        debtorIds: ['jake', 'patch', 'eric'],
+        sourceCurrency: 'USD',
+        targetCurrency: 'USD',
+        conversionRate: 1,
+      }).shares,
+    ).toEqual([
+      { userId: 'jake', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
+      { userId: 'patch', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
+      { userId: 'eric', sourceMinorUnits: 2500, targetMinorUnits: 2500 },
     ]);
 
-    expect(computeSplits(10000, ['jake', 'patch', 'eric'])).toEqual([
-      { userId: 'jake', amountCents: 2500 },
-      { userId: 'patch', amountCents: 2500 },
-      { userId: 'eric', amountCents: 2500 },
+    expect(
+      computeSplits({
+        totalSourceMinorUnits: 1000,
+        debtorIds: ['a', 'b'],
+        sourceCurrency: 'USD',
+        targetCurrency: 'USD',
+        conversionRate: 1,
+      }).shares,
+    ).toEqual([
+      { userId: 'a', sourceMinorUnits: 334, targetMinorUnits: 334 },
+      { userId: 'b', sourceMinorUnits: 333, targetMinorUnits: 333 },
     ]);
 
-    expect(computeSplits(1000, ['a', 'b'])).toEqual([
-      { userId: 'a', amountCents: 334 },
-      { userId: 'b', amountCents: 333 },
-    ]);
+    expect(
+      computeSplits({
+        totalSourceMinorUnits: 100,
+        debtorIds: ['alpha'],
+        sourceCurrency: 'USD',
+        targetCurrency: 'USD',
+        conversionRate: 1,
+      }).shares,
+    ).toEqual([{ userId: 'alpha', sourceMinorUnits: 50, targetMinorUnits: 50 }]);
+  });
 
-    expect(computeSplits(100, ['alpha'])).toEqual([
-      { userId: 'alpha', amountCents: 50 },
-    ]);
+  it('converts using different currencies and rounds half up', () => {
+    const result = computeSplits({
+      totalSourceMinorUnits: 1099,
+      debtorIds: ['debtor'],
+      sourceCurrency: 'USD',
+      targetCurrency: 'JPY',
+      conversionRate: 150.555,
+    });
+
+    expect(result.totalTargetMinorUnits).toBeGreaterThan(0);
+    expect(result.shares[0].targetMinorUnits).toBe(result.totalTargetMinorUnits);
+  });
+
+  it('adjusts converted remainders so the total matches', () => {
+    const result = computeSplits({
+      totalSourceMinorUnits: 100,
+      debtorIds: ['a', 'b', 'c'],
+      sourceCurrency: 'USD',
+      targetCurrency: 'EUR',
+      conversionRate: 0.3333,
+    });
+
+    const totalShares = result.shares.reduce(
+      (sum, share) => sum + share.targetMinorUnits,
+      0,
+    );
+
+    expect(totalShares).toBe(result.totalTargetMinorUnits);
   });
 });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -264,6 +264,11 @@ export interface Expense {
   exchangeRate: number | null;
   originalCurrency: string | null;
   convertedAmounts: Record<string, JsonValue> | null;
+  targetCurrency?: string | null;
+  sourceAmountMinorUnits?: number | null;
+  targetAmountMinorUnits?: number | null;
+  exchangeRateLockedAt?: IsoDate | null;
+  exchangeRateProvider?: string | null;
   description: string;
   category: string;
   activityId: number | null;
@@ -306,6 +311,10 @@ export interface ExpenseShare {
   status: ExpenseParticipantStatus;
   paidAt: IsoDate | null;
   createdAt: IsoDate | null;
+  amountSourceMinorUnits?: number | null;
+  amountTargetMinorUnits?: number | null;
+  targetCurrency?: string | null;
+  sourceCurrency?: string | null;
 }
 
 export const insertExpenseShareSchema = z.object({


### PR DESCRIPTION
## Summary
- add currency conversion helpers and updated split computation to shared expenses utilities and tests
- extend client expense modal and tracker to support separate pay/request currencies with locked rates and payer-excluded selections
- update server routes, storage, and schema to persist conversion metadata for split expenses

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5bf464d04832e97f4b917d065b899