### PR TITLE
Use sticky sidebar layout for trip dashboards

### DIFF
--- a/client/src/components/sidebar.tsx
+++ b/client/src/components/sidebar.tsx
@@ -12,8 +12,8 @@ interface SidebarProps {
 
 export function Sidebar({ trip, user, activeTab, onTabChange }: SidebarProps) {
   return (
-    <div className="hidden lg:flex lg:w-64 lg:flex-col lg:fixed lg:inset-y-0 lg:bg-white lg:border-r lg:border-gray-200">
-      <div className="flex flex-col h-full">
+    <aside className="hidden lg:flex w-[240px] shrink-0 flex-col bg-white border-r border-gray-200 lg:sticky lg:top-0 lg:h-screen lg:overflow-y-auto lg:overflow-x-hidden lg:z-20">
+      <div className="flex h-full flex-col">
         {/* Logo */}
         <div className="flex items-center px-6 py-4 border-b border-gray-200">
           <div className="w-10 h-10 bg-primary rounded-xl flex items-center justify-center">
@@ -195,6 +195,6 @@ export function Sidebar({ trip, user, activeTab, onTabChange }: SidebarProps) {
           </div>
         </div>
       </div>
-    </div>
+    </aside>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -96,7 +96,8 @@
     min-height: 100vh;
     width: 100%;
     isolation: isolate;
-    overflow: hidden;
+    overflow-x: hidden;
+    overflow-y: visible;
     color: var(--foreground);
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(241, 245, 249, 0.94) 100%);
   }

--- a/client/src/pages/member-schedule.tsx
+++ b/client/src/pages/member-schedule.tsx
@@ -220,23 +220,24 @@ export default function MemberSchedule() {
   }, [activities, selectedMemberId]);
 
   return (
-    <div className="min-h-screen bg-neutral-100">
+    <div className="min-h-dvh lg:min-h-screen bg-neutral-100">
       {/* Mobile Navigation */}
       <MobileNav
         trip={trip}
         user={currentUser}
       />
 
-      {/* Desktop Sidebar */}
-      <Sidebar 
-        trip={trip}
-        user={currentUser}
-        activeTab="members"
-        onTabChange={() => {}}
-      />
+      <div className="lg:flex lg:h-screen">
+        {/* Desktop Sidebar */}
+        <Sidebar
+          trip={trip}
+          user={currentUser}
+          activeTab="members"
+          onTabChange={() => {}}
+        />
 
-      {/* Main Content */}
-      <div className="lg:pl-64">
+        {/* Main Content */}
+        <main className="flex-1 min-w-0 lg:h-screen lg:overflow-x-auto lg:overflow-y-auto">
         {/* Header */}
         <div className="bg-white border-b border-gray-200 px-4 lg:px-8 py-6">
           <div className="max-w-7xl mx-auto">
@@ -482,7 +483,8 @@ export default function MemberSchedule() {
             )}
           </div>
         </div>
-      </div>
+      </main>
     </div>
+  </div>
   );
 }

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -875,9 +875,12 @@ export default function Trip() {
         {/* Main Content Container */}
         {/* // MOBILE-ONLY: Provide breathing room for bottom nav & safe area. */}
         <div className="relative pb-[calc(env(safe-area-inset-bottom)+6rem)] md:pb-0">
-          <div className="md:flex">
+          <div className="md:flex md:h-screen">
             {/* Vertical Tab Navigation */}
-            <div className="hidden md:flex md:w-64 md:flex-col bg-white border-r border-gray-200 min-h-dvh md:fixed md:left-0 md:top-0 md:z-40" data-tutorial="trip-navigation">
+            <aside
+              className="hidden md:flex w-[240px] shrink-0 flex-col border-r border-gray-200 bg-white md:sticky md:top-0 md:h-screen md:overflow-y-auto md:overflow-x-hidden md:self-start md:z-20"
+              data-tutorial="trip-navigation"
+            >
               <div className="p-6">
                 <h2 className="text-lg font-semibold text-neutral-900 mb-4">Trip Sections</h2>
                 <nav className="space-y-2">
@@ -1022,10 +1025,10 @@ export default function Trip() {
                   </button>
                 </nav>
               </div>
-            </div>
+            </aside>
 
             {/* Main Content */}
-            <div className="flex-1 md:ml-64">
+            <main className="flex-1 min-w-0 md:h-screen md:overflow-x-auto md:overflow-y-auto">
               <div className="p-4 lg:p-8">
                 {/* Back to Dashboard Button */}
                 <Link href="/">
@@ -1516,7 +1519,7 @@ export default function Trip() {
                   </div>
                 )}
               </div>
-            </div>
+            </main>
           </div>
 
           {/* // MOBILE-ONLY floating action button */}


### PR DESCRIPTION
## Summary
- adjust the shared page shell overflow so sticky sidebars can work
- switch the trip and member schedule screens to a two-column flex layout with a 240px sticky sidebar
- update the shared sidebar component to use the sticky rail with its own scroll area and hide horizontal overflow

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d5f3947cb4832ea664cbdb33994b27