### PR TITLE
Redesign currency conversion workflow in expense modal

### DIFF
--- a/client/src/lib/fx.ts
+++ b/client/src/lib/fx.ts
@@ -1,0 +1,56 @@
+export interface LiveFxRateRequest {
+  src: string;
+  tgt: string;
+}
+
+export interface LiveFxRateResponse {
+  rate: number;
+  provider: string;
+  timestamp: string;
+}
+
+const baseRates: Record<string, number> = {
+  USD: 1,
+  EUR: 0.92,
+  GBP: 0.79,
+  CAD: 1.34,
+  AUD: 1.51,
+  JPY: 155.11,
+};
+
+function normalizeCurrency(code: string): string {
+  return code?.trim().toUpperCase();
+}
+
+export async function getLiveFxRate({
+  src,
+  tgt,
+}: LiveFxRateRequest): Promise<LiveFxRateResponse> {
+  const source = normalizeCurrency(src);
+  const target = normalizeCurrency(tgt);
+
+  await new Promise((resolve) => setTimeout(resolve, 450));
+
+  if (!source || !target) {
+    throw new Error("Source and target currencies are required");
+  }
+
+  if (source === target) {
+    return {
+      rate: 1,
+      provider: "MockRates",
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  const sourceBase = baseRates[source] ?? baseRates.USD;
+  const targetBase = baseRates[target] ?? baseRates.USD;
+
+  const rate = targetBase / sourceBase;
+
+  return {
+    rate,
+    provider: "MockRates",
+    timestamp: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
## Summary
- redesign the expense modal currency conversion experience with a live-rate card, manual override toggle, and target currency selector
- derive converted totals, show debtor shares in the target currency, and send detailed participant share data with the expense payload
- add a mocked getLiveFxRate helper to retrieve live exchange rates for the UI

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d5f501ce30832eb43a50c166c94f4b