### PR TITLE
Add inline flight search panel to flights page

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect, useRef } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
+import type { MutableRefObject } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -23,19 +24,28 @@ interface SmartLocationSearchProps {
   className?: string;
 }
 
-export default function SmartLocationSearch({ 
-  placeholder = "Enter city, airport, or state...", 
-  value = "", 
+const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProps>(function SmartLocationSearch({
+  placeholder = "Enter city, airport, or state...",
+  value = "",
   onLocationSelect,
   className = ""
-}: SmartLocationSearchProps) {
+}, ref) {
   const [query, setQuery] = useState(value);
   const [results, setResults] = useState<LocationResult[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [showResults, setShowResults] = useState(false);
   const [selectedLocation, setSelectedLocation] = useState<LocationResult | null>(null);
   const debounceRef = useRef<NodeJS.Timeout>();
-  const inputRef = useRef<HTMLInputElement>(null);
+  const internalInputRef = useRef<HTMLInputElement | null>(null);
+
+  const setInputRef = (node: HTMLInputElement | null) => {
+    internalInputRef.current = node;
+    if (typeof ref === "function") {
+      ref(node);
+    } else if (ref) {
+      (ref as MutableRefObject<HTMLInputElement | null>).current = node;
+    }
+  };
 
   // ROOT CAUSE 1 FIX: Sync value prop changes to internal query state
   useEffect(() => {
@@ -122,7 +132,7 @@ export default function SmartLocationSearch({
     <div className={`relative ${className}`}>
       <div className="relative">
         <Input
-          ref={inputRef}
+          ref={setInputRef}
           type="text"
           placeholder={placeholder}
           value={query}
@@ -213,4 +223,6 @@ export default function SmartLocationSearch({
       )}
     </div>
   );
-}
+});
+
+export default SmartLocationSearch;

--- a/client/src/pages/flights.tsx
+++ b/client/src/pages/flights.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
 import { useParams, useLocation, Link } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -14,11 +15,18 @@ import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { format } from "date-fns";
-import { Plane, Clock, MapPin, User, Users, Edit, Trash2, Plus, Search, Filter, ArrowUpDown, SlidersHorizontal, ChevronDown, Share2, ArrowLeft, Check, X, PlaneTakeoff, PlaneLanding, ArrowRight, ExternalLink } from "lucide-react";
+import { Plane, Clock, MapPin, Users, Edit, Trash2, Plus, Search, Filter, ArrowUpDown, SlidersHorizontal, ChevronDown, Share2, ArrowLeft, Check, X, PlaneTakeoff, PlaneLanding, ArrowRight, ExternalLink } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { TravelLoading } from "@/components/LoadingSpinners";
 import SmartLocationSearch from "@/components/SmartLocationSearch";
-import type { FlightWithDetails, InsertFlight, FlightProposalWithDetails, InsertFlightRanking } from "@shared/schema";
+import type {
+  FlightWithDetails,
+  InsertFlight,
+  FlightProposalWithDetails,
+  InsertFlightRanking,
+  TripWithDetails,
+  User,
+} from "@shared/schema";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { formatCurrency } from "@/lib/utils";
 
@@ -155,6 +163,900 @@ function getAirlineName(airlineCode: string): string {
   return airlineMap[airlineCode] || airlineCode;
 }
 
+interface FlightFormState {
+  flightNumber: string;
+  airline: string;
+  airlineCode: string;
+  departureAirport: string;
+  departureCode: string;
+  departureTime: string;
+  arrivalAirport: string;
+  arrivalCode: string;
+  arrivalTime: string;
+  price: string;
+  seatClass: string;
+  flightType: string;
+  bookingReference: string;
+  aircraft: string;
+  status: string;
+}
+
+interface FlightSearchFormState {
+  departure: string;
+  arrival: string;
+  departureDate: string;
+  returnDate: string;
+  passengers: string;
+  airline: string;
+}
+
+type FlightFilterKey = "best" | "cheapest" | "fastest";
+type FlightSearchTrigger = "manual" | "auto";
+
+interface FlightFilterCounts {
+  best: number;
+  cheapest: number;
+  fastest: number;
+}
+
+interface FlightSearchFilterResults {
+  best: any[];
+  cheapest: any[];
+  fastest: any[];
+}
+
+interface CachedFlightSearchParams {
+  origin: string;
+  destination: string;
+  departureDate: string;
+  returnDate?: string;
+  passengers: number;
+  originCode?: string;
+  destinationCode?: string;
+}
+
+interface FlightSearchPanelProps {
+  searchFormData: FlightSearchFormState;
+  setSearchFormData: Dispatch<SetStateAction<FlightSearchFormState>>;
+  onSearch: (trigger?: FlightSearchTrigger) => Promise<void>;
+  isSearching: boolean;
+  activeFilter: FlightFilterKey;
+  filterLoading: boolean;
+  filterResultCounts: FlightFilterCounts;
+  filterResults: FlightSearchFilterResults;
+  searchResults: any[];
+  onFilterChange: (filter: FlightFilterKey) => void;
+  cachedSearchParams: CachedFlightSearchParams | null;
+  onShareFlight: (flight: any) => Promise<void>;
+  onPrefillFlight: (flightData: Partial<FlightFormState>) => void;
+  onOpenManualFlight: () => void;
+  flights: FlightWithDetails[];
+  onEditFlight: (flight: FlightWithDetails) => void;
+  onDeleteFlight: (id: number) => void;
+  flightProposals: FlightProposalWithDetails[];
+  onClose: () => void;
+  user?: User | null;
+  trip?: TripWithDetails | null;
+  autoSearch?: boolean;
+  onSubmitRanking: (proposalId: number, ranking: number) => void;
+}
+
+function FlightSearchPanel({
+  searchFormData,
+  setSearchFormData,
+  onSearch,
+  isSearching,
+  activeFilter,
+  filterLoading,
+  filterResultCounts,
+  filterResults,
+  searchResults,
+  onFilterChange,
+  cachedSearchParams,
+  onShareFlight,
+  onPrefillFlight,
+  onOpenManualFlight,
+  flights,
+  onEditFlight,
+  onDeleteFlight,
+  flightProposals,
+  onClose,
+  user,
+  trip,
+  autoSearch = false,
+  onSubmitRanking,
+}: FlightSearchPanelProps) {
+  const fromInputRef = useRef<HTMLInputElement>(null);
+  const hasAutoSearchedRef = useRef(false);
+
+  useEffect(() => {
+    fromInputRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    if (!autoSearch || hasAutoSearchedRef.current) {
+      return;
+    }
+
+    if (searchFormData.departure && searchFormData.arrival && searchFormData.departureDate) {
+      hasAutoSearchedRef.current = true;
+      void onSearch("auto");
+    }
+  }, [autoSearch, onSearch, searchFormData.arrival, searchFormData.departure, searchFormData.departureDate]);
+
+  return (
+    <div className="mb-6 rounded-2xl border bg-background p-4 shadow-sm sm:p-6">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-foreground">Add or propose a flight</h2>
+          <p className="text-sm text-muted-foreground">
+            {trip?.name
+              ? `Search for flights to share with ${trip.name}.`
+              : "Search flights for your group and add them to the plan."}
+          </p>
+        </div>
+        <Button variant="ghost" size="sm" onClick={onClose} className="self-start">
+          <X className="mr-2 h-4 w-4" />
+          Close search
+        </Button>
+      </div>
+
+      <div className="mt-6">
+        <Tabs defaultValue="search" className="w-full">
+          <TabsList className="grid w-full grid-cols-3">
+            <TabsTrigger value="search">Search & Propose Flights</TabsTrigger>
+            <TabsTrigger value="voting" className="relative">
+              Group Voting
+              {flightProposals.length > 0 && (
+                <Badge variant="secondary" className="ml-2 text-xs">
+                  {flightProposals.length}
+                </Badge>
+              )}
+            </TabsTrigger>
+            <TabsTrigger value="bookings">My Flight Bookings</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="search" className="mt-6 space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Search className="h-5 w-5" />
+                  Search Flights
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+                  <div>
+                    <Label htmlFor="departure">From</Label>
+                    <SmartLocationSearch
+                      ref={fromInputRef}
+                      placeholder="Departure city or airport"
+                      value={searchFormData.departure}
+                      onLocationSelect={(location) =>
+                        setSearchFormData((prev) => ({ ...prev, departure: location.displayName }))
+                      }
+                    />
+                    {!user?.defaultLocation && !user?.defaultLocationCode && !searchFormData.departure && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Save a default departure location in your profile to fill this automatically next time.
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <Label htmlFor="arrival">To</Label>
+                    <SmartLocationSearch
+                      placeholder="Arrival city or airport"
+                      value={searchFormData.arrival}
+                      onLocationSelect={(location) =>
+                        setSearchFormData((prev) => ({ ...prev, arrival: location.displayName }))
+                      }
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="departureDate">Departure</Label>
+                    <Input
+                      id="departureDate"
+                      type="date"
+                      value={searchFormData.departureDate}
+                      onChange={(e) => setSearchFormData((prev) => ({ ...prev, departureDate: e.target.value }))}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="returnDate">Return (Optional)</Label>
+                    <Input
+                      id="returnDate"
+                      type="date"
+                      value={searchFormData.returnDate}
+                      onChange={(e) => setSearchFormData((prev) => ({ ...prev, returnDate: e.target.value }))}
+                    />
+                  </div>
+                </div>
+                <div className="mt-4 flex flex-wrap items-end gap-4">
+                  <div>
+                    <Label htmlFor="passengers">Passengers</Label>
+                    <Select
+                      value={searchFormData.passengers}
+                      onValueChange={(value) => setSearchFormData((prev) => ({ ...prev, passengers: value }))}
+                    >
+                      <SelectTrigger className="w-32">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {[1, 2, 3, 4, 5, 6, 7, 8].map((num) => (
+                          <SelectItem key={num} value={num.toString()}>
+                            {num} {num === 1 ? "passenger" : "passengers"}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div>
+                    <Label htmlFor="airline">Airline</Label>
+                    <Select
+                      value={searchFormData.airline}
+                      onValueChange={(value) => setSearchFormData((prev) => ({ ...prev, airline: value }))}
+                    >
+                      <SelectTrigger className="w-40">
+                        <SelectValue placeholder="Any airline" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="any">Any Airline</SelectItem>
+                        <SelectItem value="AA">American Airlines</SelectItem>
+                        <SelectItem value="DL">Delta Air Lines</SelectItem>
+                        <SelectItem value="UA">United Airlines</SelectItem>
+                        <SelectItem value="SW">Southwest Airlines</SelectItem>
+                        <SelectItem value="AS">Alaska Airlines</SelectItem>
+                        <SelectItem value="B6">JetBlue Airways</SelectItem>
+                        <SelectItem value="F9">Frontier Airlines</SelectItem>
+                        <SelectItem value="NK">Spirit Airlines</SelectItem>
+                        <SelectItem value="G4">Allegiant Air</SelectItem>
+                        <SelectItem value="VS">Virgin Atlantic</SelectItem>
+                        <SelectItem value="BA">British Airways</SelectItem>
+                        <SelectItem value="LH">Lufthansa</SelectItem>
+                        <SelectItem value="AF">Air France</SelectItem>
+                        <SelectItem value="KL">KLM</SelectItem>
+                        <SelectItem value="IB">Iberia</SelectItem>
+                        <SelectItem value="OS">Austrian Airlines</SelectItem>
+                        <SelectItem value="EY">Etihad Airways</SelectItem>
+                        <SelectItem value="QR">Qatar Airways</SelectItem>
+                        <SelectItem value="EK">Emirates</SelectItem>
+                        <SelectItem value="TK">Turkish Airlines</SelectItem>
+                        <SelectItem value="JL">Japan Airlines</SelectItem>
+                        <SelectItem value="NH">All Nippon Airways</SelectItem>
+                        <SelectItem value="CX">Cathay Pacific</SelectItem>
+                        <SelectItem value="SQ">Singapore Airlines</SelectItem>
+                        <SelectItem value="AC">Air Canada</SelectItem>
+                        <SelectItem value="WS">WestJet</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <Button
+                    onClick={() => onSearch("manual")}
+                    disabled={isSearching}
+                    className="px-8"
+                  >
+                    {isSearching ? (
+                      <>
+                        <div className="mr-2 h-4 w-4 animate-spin rounded-full border-b-2 border-white" />
+                        Searching...
+                      </>
+                    ) : (
+                      <>
+                        <Search className="mr-2 h-4 w-4" />
+                        Search Flights
+                      </>
+                    )}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+
+            {searchResults.length > 0 && (
+              <div className="max-h-[60vh] overflow-auto pr-1">
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      <CardTitle className="flex items-center gap-2">
+                        <Search className="h-5 w-5" />
+                        Flight Search Results
+                      </CardTitle>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          variant={activeFilter === "best" ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => onFilterChange("best")}
+                          disabled={filterLoading}
+                          className={`relative ${activeFilter === "best" ? "bg-blue-600 text-white" : "hover:bg-blue-50"}`}
+                          data-testid="filter-best"
+                        >
+                          {filterLoading && activeFilter === "best" && (
+                            <div className="absolute inset-0 flex items-center justify-center rounded bg-blue-600">
+                              <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white" />
+                            </div>
+                          )}
+                          🏆 Best
+                          {filterResultCounts.best > 0 && (
+                            <Badge variant="secondary" className="ml-1 text-xs">
+                              {filterResultCounts.best}
+                            </Badge>
+                          )}
+                        </Button>
+                        <Button
+                          variant={activeFilter === "cheapest" ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => onFilterChange("cheapest")}
+                          disabled={filterLoading}
+                          className={`relative ${activeFilter === "cheapest" ? "bg-green-600 text-white" : "hover:bg-green-50"}`}
+                          data-testid="filter-cheapest"
+                        >
+                          {filterLoading && activeFilter === "cheapest" && (
+                            <div className="absolute inset-0 flex items-center justify-center rounded bg-green-600">
+                              <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white" />
+                            </div>
+                          )}
+                          💰 Cheapest
+                          {filterResultCounts.cheapest > 0 && (
+                            <Badge variant="secondary" className="ml-1 text-xs">
+                              {filterResultCounts.cheapest}
+                            </Badge>
+                          )}
+                        </Button>
+                        <Button
+                          variant={activeFilter === "fastest" ? "default" : "outline"}
+                          size="sm"
+                          onClick={() => onFilterChange("fastest")}
+                          disabled={filterLoading}
+                          className={`relative ${activeFilter === "fastest" ? "bg-purple-600 text-white" : "hover:bg-purple-50"}`}
+                          data-testid="filter-fastest"
+                        >
+                          {filterLoading && activeFilter === "fastest" && (
+                            <div className="absolute inset-0 flex items-center justify-center rounded bg-purple-600">
+                              <div className="h-4 w-4 animate-spin rounded-full border-b-2 border-white" />
+                            </div>
+                          )}
+                          ⚡ Fastest
+                          {filterResultCounts.fastest > 0 && (
+                            <Badge variant="secondary" className="ml-1 text-xs">
+                              {filterResultCounts.fastest}
+                            </Badge>
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    {(() => {
+                      const currentResults =
+                        filterResults[activeFilter].length > 0 ? filterResults[activeFilter] : searchResults;
+                      if (currentResults.length === 0) return null;
+
+                      const flightCount = currentResults.length;
+                      const prices = currentResults
+                        .map((f: any) => f.price || f.totalPrice || 0)
+                        .filter((p: number) => p > 0);
+                      const minPrice = prices.length > 0 ? Math.min(...prices) : 0;
+                      const maxPrice = prices.length > 0 ? Math.max(...prices) : 0;
+
+                      const durations = currentResults
+                        .map((f: any) => {
+                          if (!f.duration) return 0;
+                          const hours = f.duration.match(/(\d+)h/)?.[1] || "0";
+                          const minutes = f.duration.match(/(\d+)m/)?.[1] || "0";
+                          return parseInt(hours) * 60 + parseInt(minutes);
+                        })
+                        .filter((d: number) => d > 0);
+
+                      const avgDuration =
+                        durations.length > 0 ? Math.round(durations.reduce((sum, d) => sum + d, 0) / durations.length) : 0;
+                      const avgHours = Math.floor(avgDuration / 60);
+                      const avgMinutes = avgDuration % 60;
+
+                      return (
+                        <div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-950/20">
+                          <div className="flex flex-wrap items-center justify-between gap-4">
+                            <div className="flex flex-wrap items-center gap-6 text-sm text-gray-700 dark:text-gray-300">
+                              <div className="flex items-center gap-2">
+                                <span className="font-semibold text-blue-600 dark:text-blue-400">{flightCount}</span>
+                                <span>flights found</span>
+                              </div>
+                              {prices.length > 0 && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-gray-500">Price range:</span>
+                                  <span className="font-medium">
+                                    ${minPrice}
+                                    {minPrice !== maxPrice && ` - $${maxPrice}`}
+                                  </span>
+                                </div>
+                              )}
+                              {avgDuration > 0 && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-gray-500">Avg. flight time:</span>
+                                  <span className="font-medium">{avgHours}h {avgMinutes}m</span>
+                                </div>
+                              )}
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400">
+                              Filter: {activeFilter.charAt(0).toUpperCase() + activeFilter.slice(1)}
+                              {activeFilter === "best" && " (balanced price & time)"}
+                              {activeFilter === "cheapest" && " (lowest price first)"}
+                              {activeFilter === "fastest" && " (shortest duration first)"}
+                            </div>
+                          </div>
+                        </div>
+                      );
+                    })()}
+
+                    <div className="space-y-4">
+                      {(filterResults[activeFilter].length > 0 ? filterResults[activeFilter] : searchResults).map(
+                        (flight: any, index: number) => {
+                          const normalizedPriceSource = flight.price ?? flight.totalPrice;
+                          const priceLabel = formatPriceDisplay(normalizedPriceSource, flight.currency);
+                          const hasNumericPrice = parseNumericAmount(normalizedPriceSource) !== null;
+
+                          return (
+                            <div key={index} className="rounded-lg border p-4 transition-colors hover:bg-gray-50">
+                              <div className="mb-3 flex items-center justify-between">
+                                <div className="flex items-center gap-3">
+                                  <div className="flex items-center gap-2">
+                                    <Plane className="h-4 w-4 text-blue-600" />
+                                    <span className="font-semibold">{getFlightAirlineName(flight)}</span>
+                                    <span className="text-gray-500">{flight.flightNumber || `Flight ${index + 1}`}</span>
+                                  </div>
+                                  <Badge className="bg-green-100 text-green-800">Available</Badge>
+                                </div>
+                                <div className="text-right">
+                                  <div className="text-2xl font-bold text-green-600">{priceLabel}</div>
+                                  {hasNumericPrice && <div className="text-sm text-gray-500">per person</div>}
+                                </div>
+                              </div>
+
+                              <div className="mb-4 grid grid-cols-1 gap-4 text-sm md:grid-cols-3">
+                                <div className="flex items-center gap-2">
+                                  <PlaneTakeoff className="h-4 w-4 text-green-600" />
+                                  <div>
+                                    <div className="font-medium">
+                                      {flight.departure?.airport || flight.departureAirport || searchFormData.departure}
+                                    </div>
+                                    <div className="text-gray-500">
+                                      {flight.departure?.time
+                                        ? new Date(flight.departure.time).toLocaleTimeString("en-US", {
+                                            hour: "2-digit",
+                                            minute: "2-digit",
+                                          })
+                                        : "Departure time varies"}
+                                    </div>
+                                  </div>
+                                </div>
+                                <div className="flex items-center justify-center">
+                                  <ArrowRight className="h-4 w-4 text-gray-400" />
+                                  <div className="mx-2 text-xs text-gray-500">
+                                    {flight.duration
+                                      ? flight.duration.replace("PT", "").replace("H", "h ").replace("M", "m")
+                                      : "Duration varies"}
+                                  </div>
+                                  <ArrowRight className="h-4 w-4 text-gray-400" />
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  <PlaneLanding className="h-4 w-4 text-red-600" />
+                                  <div>
+                                    <div className="font-medium">
+                                      {flight.arrival?.airport || flight.arrivalAirport || searchFormData.arrival}
+                                    </div>
+                                    <div className="text-gray-500">
+                                      {flight.arrival?.time
+                                        ? new Date(flight.arrival.time).toLocaleTimeString("en-US", {
+                                            hour: "2-digit",
+                                            minute: "2-digit",
+                                          })
+                                        : "Arrival time varies"}
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+
+                              <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-4 text-sm text-gray-600">
+                                  {flight.stops !== undefined && (
+                                    <span>
+                                      {flight.stops === 0 ? "Non-stop" : `${flight.stops} stop${flight.stops > 1 ? "s" : ""}`}
+                                    </span>
+                                  )}
+                                  {flight.class && <span className="capitalize">{flight.class}</span>}
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                  <Button
+                                    size="sm"
+                                    variant="default"
+                                    className="bg-blue-600 text-white hover:bg-blue-700"
+                                    asChild
+                                    data-testid={`button-book-kayak-${index}`}
+                                  >
+                                    <a
+                                      href={`https://www.kayak.com/flights/${cachedSearchParams?.originCode || "ATL"}-${
+                                        cachedSearchParams?.destinationCode || "MIA"
+                                      }/${searchFormData.departureDate}${
+                                        searchFormData.returnDate ? `/${searchFormData.returnDate}` : ""
+                                      }?sort=bestflight_a`}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      <ExternalLink className="mr-1 h-3 w-3" />
+                                      Book on Kayak
+                                    </a>
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    asChild
+                                    data-testid={`button-book-expedia-${index}`}
+                                  >
+                                    <a
+                                      href={`https://www.expedia.com/Flights-Search?trip=${
+                                        searchFormData.returnDate ? "roundtrip" : "oneway"
+                                      }&leg1=from:${cachedSearchParams?.originCode || "ATL"},to:${
+                                        cachedSearchParams?.destinationCode || "MIA"
+                                      },departure:${searchFormData.departureDate}TANYT${
+                                        searchFormData.returnDate
+                                          ? `&leg2=from:${cachedSearchParams?.destinationCode || "MIA"},to:${
+                                              cachedSearchParams?.originCode || "ATL"
+                                            },departure:${searchFormData.returnDate}TANYT`
+                                          : ""
+                                      }`}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                    >
+                                      Book on Expedia
+                                    </a>
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => onShareFlight(flight)}
+                                    data-testid={`button-propose-flight-${index}`}
+                                  >
+                                    <Users className="mr-2 h-4 w-4" />
+                                    Propose to Group
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="outline"
+                                    onClick={() => {
+                                      onPrefillFlight({
+                                        flightNumber: flight.flightNumber || "",
+                                        airline: getFlightAirlineName(flight),
+                                        airlineCode: flight.airlineCode || "",
+                                        departureAirport:
+                                          flight.departure?.airport || flight.departureAirport || searchFormData.departure,
+                                        departureCode: flight.departure?.iataCode || flight.departureCode || "",
+                                        departureTime: flight.departure?.time || flight.departureTime || "",
+                                        arrivalAirport:
+                                          flight.arrival?.airport || flight.arrivalAirport || searchFormData.arrival,
+                                        arrivalCode: flight.arrival?.iataCode || flight.arrivalCode || "",
+                                        arrivalTime: flight.arrival?.time || flight.arrivalTime || "",
+                                        price: flight.price?.toString() || flight.totalPrice?.toString() || "",
+                                        seatClass: flight.class || "economy",
+                                        flightType: "outbound",
+                                        bookingReference: "",
+                                        aircraft: flight.aircraft || "",
+                                        status: "confirmed",
+                                      });
+                                    }}
+                                    data-testid={`button-add-to-trip-${index}`}
+                                  >
+                                    <Plus className="mr-2 h-4 w-4" />
+                                    Add to Trip
+                                  </Button>
+                                </div>
+                              </div>
+                            </div>
+                          );
+                        },
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              </div>
+            )}
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Users className="h-5 w-5" />
+                  Group Flights
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                {flights.length === 0 ? (
+                  <div className="py-8 text-center">
+                    <Plane className="mx-auto mb-4 h-12 w-12 text-gray-400" />
+                    <h3 className="mb-2 text-lg font-medium text-gray-900">No flights added yet</h3>
+                    <p className="mb-4 text-gray-500">Start by adding flight information for your group members.</p>
+                    <Button onClick={onOpenManualFlight}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      Add First Flight
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="space-y-4">
+                    {flights.map((flight) => (
+                      <div key={flight.id} className="rounded-lg border p-4 transition-colors hover:bg-gray-50">
+                        <div className="mb-2 flex items-center justify-between">
+                          <div className="flex items-center gap-3">
+                            <div className="flex items-center gap-2">
+                              <Plane className="h-4 w-4 text-blue-600" />
+                              <span className="font-semibold">{flight.airline}</span>
+                              <span className="text-gray-500">{flight.flightNumber}</span>
+                            </div>
+                            <Badge className={getFlightStatusColor(flight.status)}>{flight.status}</Badge>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <Button variant="ghost" size="sm" onClick={() => onEditFlight(flight)}>
+                              <Edit className="h-4 w-4" />
+                            </Button>
+                            <Button variant="ghost" size="sm" onClick={() => onDeleteFlight(flight.id)}>
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-3">
+                          <div className="flex items-center gap-2">
+                            <PlaneTakeoff className="h-4 w-4 text-green-600" />
+                            <div>
+                              <div className="font-medium">{flight.departureAirport}</div>
+                              <div className="text-gray-500">
+                                {flight.departureTime ? format(new Date(flight.departureTime), "MMM d, h:mm a") : "Time TBD"}
+                              </div>
+                            </div>
+                          </div>
+                          <div className="flex items-center justify-center">
+                            <ArrowRight className="h-4 w-4 text-gray-400" />
+                            <div className="mx-2 text-xs text-gray-500">
+                              {flight.flightDuration ? formatDuration(flight.flightDuration) : "Duration TBD"}
+                            </div>
+                            <ArrowRight className="h-4 w-4 text-gray-400" />
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <PlaneLanding className="h-4 w-4 text-red-600" />
+                            <div>
+                              <div className="font-medium">{flight.arrivalAirport}</div>
+                              <div className="text-gray-500">
+                                {flight.arrivalTime ? format(new Date(flight.arrivalTime), "MMM d, h:mm a") : "Time TBD"}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        {flight.price != null && (
+                          <div className="mt-2 text-sm text-gray-600">
+                            Price: {formatPriceDisplay(flight.price, flight.currency)}
+                            {flight.seatClass && ` • ${flight.seatClass}`}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="voting" className="mt-6 space-y-6">
+            {flightProposals.length > 0 ? (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Users className="h-5 w-5" />
+                    Group Flight Proposals ({flightProposals.length})
+                  </CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Rank these flights from 1 (most preferred) to help your group decide
+                  </p>
+                </CardHeader>
+                <CardContent>
+                  <div className="grid gap-4">
+                    {flightProposals.map((proposal) => (
+                      <Card key={proposal.id} className="relative">
+                        <CardHeader className="pb-3">
+                          <div className="flex items-start justify-between">
+                            <div className="flex-1">
+                              <CardTitle className="flex items-center gap-2 text-lg font-semibold">
+                                <PlaneTakeoff className="h-5 w-5 text-blue-600" />
+                                {proposal.airline} {proposal.flightNumber}
+                              </CardTitle>
+                              <div className="mt-2 flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
+                                <div className="flex items-center gap-1">
+                                  <MapPin className="h-3 w-3" />
+                                  {proposal.departureAirport} → {proposal.arrivalAirport}
+                                </div>
+                                <div className="flex items-center gap-1">
+                                  <Clock className="h-3 w-3" />
+                                  {proposal.duration}
+                                </div>
+                                {proposal.stops > 0 && (
+                                  <div className="rounded bg-yellow-100 px-2 py-1 text-xs text-yellow-800">
+                                    {proposal.stops} stop{proposal.stops > 1 ? "s" : ""}
+                                  </div>
+                                )}
+                              </div>
+                              <p className="mt-1 text-xs text-muted-foreground">
+                                Proposed by {proposal.proposer?.firstName || "Group Member"}
+                              </p>
+                            </div>
+                            <div className="text-right">
+                              <div className="text-lg font-bold text-blue-600">${proposal.price}</div>
+                              {proposal.averageRanking != null && (
+                                <div className="text-sm text-muted-foreground">Avg: #{proposal.averageRanking}</div>
+                              )}
+                            </div>
+                          </div>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                          <div className="rounded-lg bg-blue-50 p-3">
+                            <div className="grid grid-cols-2 gap-4 text-sm">
+                              <div>
+                                <div className="flex items-center gap-1 text-muted-foreground">
+                                  <PlaneTakeoff className="h-3 w-3" />
+                                  Departure:
+                                </div>
+                                <div className="font-medium">
+                                  {new Date(proposal.departureTime).toLocaleString()}
+                                </div>
+                              </div>
+                              <div>
+                                <div className="flex items-center gap-1 text-muted-foreground">
+                                  <PlaneLanding className="h-3 w-3" />
+                                  Arrival:
+                                </div>
+                                <div className="font-medium">
+                                  {new Date(proposal.arrivalTime).toLocaleString()}
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          <div className="flex items-center justify-between">
+                            <div className="space-y-1">
+                              <div className="text-sm font-medium text-muted-foreground">Your Ranking:</div>
+                              <div className="flex gap-1">
+                                {[1, 2, 3, 4, 5].map((rank) => (
+                                  <Button
+                                    key={rank}
+                                    size="sm"
+                                    variant={proposal.currentUserRanking?.ranking === rank ? "default" : "outline"}
+                                    onClick={() => onSubmitRanking(proposal.id, rank)}
+                                    className="px-3 text-xs"
+                                    data-testid={`button-rank-flight-${proposal.id}-${rank}`}
+                                  >
+                                    #{rank}
+                                  </Button>
+                                ))}
+                              </div>
+                            </div>
+
+                            <div className="flex gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => window.open(proposal.bookingUrl, "_blank")}
+                              >
+                                <ExternalLink className="mr-1 h-3 w-3" />
+                                View Details
+                              </Button>
+                            </div>
+                          </div>
+
+                          {proposal.rankings && proposal.rankings.length > 0 && (
+                            <div className="space-y-2">
+                              <div className="text-sm font-medium text-muted-foreground">Group Rankings:</div>
+                              <div className="grid gap-2">
+                                {proposal.rankings.map((ranking: any) => (
+                                  <div
+                                    key={ranking.id}
+                                    className="flex items-center justify-between rounded bg-gray-50 p-2 text-sm"
+                                  >
+                                    <span>{ranking.user?.firstName || "Member"}</span>
+                                    <Badge variant="secondary">#{ranking.ranking}</Badge>
+                                  </div>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            ) : (
+              <Card>
+                <CardContent className="flex flex-col items-center justify-center py-12">
+                  <Users className="mb-4 h-12 w-12 text-muted-foreground" />
+                  <h3 className="mb-2 text-lg font-semibold">No flight proposals yet</h3>
+                  <p className="mb-4 text-center text-muted-foreground">
+                    Search for flights and propose them to your group to start the voting process.
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+          </TabsContent>
+
+          <TabsContent value="bookings" className="mt-6 space-y-6">
+            {flights.length === 0 ? (
+              <Card>
+                <CardContent className="flex flex-col items-center justify-center py-12">
+                  <Plane className="mb-4 h-12 w-12 text-muted-foreground" />
+                  <h3 className="mb-2 text-lg font-semibold">No flights added yet</h3>
+                  <p className="mb-4 text-center text-muted-foreground">
+                    Add your flight bookings to keep your group informed of travel plans.
+                  </p>
+                  <Button onClick={onOpenManualFlight}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Add Flight
+                  </Button>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid gap-4">
+                {flights.map((flight) => (
+                  <Card key={flight.id} className="relative">
+                    <CardHeader className="pb-3">
+                      <div className="flex items-start justify-between">
+                        <div className="flex-1">
+                          <CardTitle className="text-lg">
+                            {flight.airline} {flight.flightNumber}
+                          </CardTitle>
+                          <p className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+                            <MapPin className="h-3 w-3" />
+                            {flight.departureAirport} → {flight.arrivalAirport}
+                          </p>
+                        </div>
+                        <Badge className={getFlightStatusColor(flight.status || "confirmed")}>
+                          {flight.status || "confirmed"}
+                        </Badge>
+                      </div>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <div className="text-sm text-muted-foreground">Departure</div>
+                          <div className="font-medium">
+                            {format(new Date(flight.departureTime), "MMM d, h:mm a")}
+                          </div>
+                        </div>
+                        <div>
+                          <div className="text-sm text-muted-foreground">Arrival</div>
+                          <div className="font-medium">
+                            {format(new Date(flight.arrivalTime), "MMM d, h:mm a")}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center justify-between pt-2">
+                        <div className="flex items-center gap-2">
+                          <Button variant="outline" size="sm" onClick={() => onEditFlight(flight)}>
+                            <Edit className="h-3 w-3" />
+                          </Button>
+                          <Button variant="outline" size="sm" onClick={() => onDeleteFlight(flight.id)}>
+                            <Trash2 className="h-3 w-3" />
+                          </Button>
+                        </div>
+                        {flight.price != null && (
+                          <div className="text-lg font-semibold text-green-600">
+                            {formatPriceDisplay(flight.price, flight.currency)}
+                          </div>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}
+
+
 // Helper function to extract airline display name from flight data
 function getFlightAirlineName(flight: any): string {
   // Handle different possible formats of airline data from API
@@ -194,9 +1096,12 @@ function getFlightAirlineName(flight: any): string {
 
 export default function FlightsPage() {
   const { tripId } = useParams<{ tripId: string }>();
-  const [, setLocation] = useLocation();
+  const [location, setLocation] = useLocation();
   const [isAddFlightOpen, setIsAddFlightOpen] = useState(false);
   const [editingFlight, setEditingFlight] = useState<FlightWithDetails | null>(null);
+  const addFlightButtonRef = useRef<HTMLButtonElement>(null);
+  const [showSearchPanel, setShowSearchPanel] = useState(false);
+  const [autoSearchRequested, setAutoSearchRequested] = useState(false);
   const [searchResults, setSearchResults] = useState<any[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [searchFormData, setSearchFormData] = useState({
@@ -207,16 +1112,6 @@ export default function FlightsPage() {
     passengers: '1',
     airline: ''
   });
-  const [filters, setFilters] = useState({
-    maxPrice: '',
-    maxStops: '',
-    airlines: [] as string[],
-    departureTimeRange: '',
-    duration: '',
-    sortBy: 'duration' as 'price' | 'duration' | 'departure' | 'arrival',
-    sortOrder: 'asc' as 'asc' | 'desc'
-  });
-  
   // Store cached search parameters to avoid re-triggering location searches
   const [cachedSearchParams, setCachedSearchParams] = useState<{
     origin: string;
@@ -264,6 +1159,170 @@ export default function FlightsPage() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
   const { user } = useAuth();
+
+  const handleFlightSearch = useCallback(async (trigger: FlightSearchTrigger = "manual") => {
+    if (!searchFormData.departure || !searchFormData.arrival || !searchFormData.departureDate) {
+      if (trigger === "manual") {
+        toast({
+          title: "Missing Information",
+          description: "Please fill in departure, arrival, and departure date",
+          variant: "destructive",
+        });
+      }
+      return;
+    }
+
+    setIsSearching(true);
+
+    try {
+      const response = await apiRequest("/api/search/flights", {
+        method: "POST",
+        body: {
+          origin: searchFormData.departure,
+          destination: searchFormData.arrival,
+          departureDate: searchFormData.departureDate,
+          returnDate: searchFormData.returnDate || undefined,
+          passengers: parseInt(searchFormData.passengers),
+          airline: searchFormData.airline && searchFormData.airline !== "any" ? searchFormData.airline : undefined,
+          provider: "both",
+          page: 1,
+          limit: 50,
+        },
+      });
+
+      const searchResponse = await response.json();
+
+      if (searchResponse && Array.isArray(searchResponse.flights) && searchResponse.flights.length > 0) {
+        setSearchResults(searchResponse.flights);
+        setCachedSearchParams({
+          origin: searchFormData.departure,
+          destination: searchFormData.arrival,
+          departureDate: searchFormData.departureDate,
+          returnDate: searchFormData.returnDate,
+          passengers: parseInt(searchFormData.passengers),
+          originCode: searchFormData.departure.length === 3 ? searchFormData.departure : undefined,
+          destinationCode: searchFormData.arrival.length === 3 ? searchFormData.arrival : undefined,
+        });
+
+        setFilterResults({
+          best: searchResponse.flights,
+          cheapest: [],
+          fastest: [],
+        });
+
+        if (searchResponse.filters) {
+          setFilterResultCounts(searchResponse.filters);
+        } else {
+          setFilterResultCounts({
+            best: searchResponse.flights.length,
+            cheapest: 0,
+            fastest: 0,
+          });
+        }
+
+        setActiveFilter("best");
+
+        const totalFromSources =
+          (searchResponse.sources?.amadeus || 0) +
+          (searchResponse.sources?.duffel || 0) +
+          (searchResponse.sources?.kayak || 0);
+
+        if (trigger === "manual") {
+          toast({
+            title: "Flight Search Complete",
+            description: `Found ${searchResponse.pagination?.total || searchResponse.flights.length} flights from ${totalFromSources} total sources - Amadeus: ${searchResponse.sources?.amadeus || 0}, Duffel: ${searchResponse.sources?.duffel || 0}, Kayak: ${searchResponse.sources?.kayak || 0}`,
+          });
+        }
+      } else {
+        setSearchResults([]);
+        setFilterResults({
+          best: [],
+          cheapest: [],
+          fastest: [],
+        });
+        setFilterResultCounts({
+          best: 0,
+          cheapest: 0,
+          fastest: 0,
+        });
+
+        if (trigger === "manual") {
+          toast({
+            title: "No Flights Found",
+            description: "Try adjusting your search criteria or dates",
+            variant: "destructive",
+          });
+        }
+      }
+    } catch (error: any) {
+      console.error("Flight search error:", error);
+      setSearchResults([]);
+      if (trigger === "manual") {
+        toast({
+          title: "Search Failed",
+          description: error?.message || "Unable to search flights. Please try again.",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setIsSearching(false);
+
+      if (trigger === "auto") {
+        const [basePath, searchParams] = location.split("?");
+        const params = new URLSearchParams(searchParams ?? "");
+        params.delete("auto");
+        const next = params.toString();
+        setLocation(next ? `${basePath}?${next}` : basePath, { replace: true });
+        setAutoSearchRequested(false);
+      }
+    }
+  }, [location, searchFormData, setLocation, toast]);
+
+  const handleOpenSearchPanel = useCallback(
+    (shouldAuto = false) => {
+      const [basePath, searchParams] = location.split("?");
+      const params = new URLSearchParams(searchParams ?? "");
+      params.set("panel", "search");
+      if (shouldAuto) {
+        params.set("auto", "1");
+      } else {
+        params.delete("auto");
+      }
+
+      const next = params.toString();
+      setLocation(next ? `${basePath}?${next}` : basePath, { replace: true });
+      setShowSearchPanel(true);
+      setAutoSearchRequested(shouldAuto);
+    },
+    [location, setLocation],
+  );
+
+  const handleCloseSearchPanel = useCallback(() => {
+    const [basePath, searchParams] = location.split("?");
+    const params = new URLSearchParams(searchParams ?? "");
+    params.delete("panel");
+    params.delete("auto");
+
+    const next = params.toString();
+    setLocation(next ? `${basePath}?${next}` : basePath, { replace: true });
+    setShowSearchPanel(false);
+    setAutoSearchRequested(false);
+
+    requestAnimationFrame(() => {
+      addFlightButtonRef.current?.focus();
+    });
+  }, [location, setLocation]);
+
+  useEffect(() => {
+    const [, searchParams] = location.split("?");
+    const params = new URLSearchParams(searchParams ?? "");
+    const panelParam = params.get("panel");
+    const shouldShow = panelParam === "search";
+    const shouldAutoSearch = shouldShow && params.get("auto") === "1";
+
+    setShowSearchPanel(shouldShow);
+    setAutoSearchRequested(shouldAutoSearch);
+  }, [location]);
 
   // Handle filter switching with loading states - FIXED to prevent location searches
   const handleFilterChange = async (newFilter: 'best' | 'cheapest' | 'fastest') => {
@@ -673,6 +1732,18 @@ export default function FlightsPage() {
     });
   };
 
+  const openManualFlightDialog = () => {
+    resetFlightForm();
+    setEditingFlight(null);
+    setIsAddFlightOpen(true);
+  };
+
+  const prefillManualFlight = (flightData: Partial<FlightFormState>) => {
+    setFlightFormData((prev) => ({ ...prev, ...flightData }));
+    setEditingFlight(null);
+    setIsAddFlightOpen(true);
+  };
+
   const populateFlightForm = (flight: any) => {
     setFlightFormData({
       flightNumber: flight.flightNumber || '',
@@ -763,1004 +1834,284 @@ export default function FlightsPage() {
               Manage flights for {(trip as any)?.name || 'your trip'}
             </p>
           </div>
-          <Dialog open={isAddFlightOpen} onOpenChange={setIsAddFlightOpen}>
-            <DialogTrigger asChild>
-              <Button>
-                <Plus className="h-4 w-4 mr-2" />
-                Add Flight
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>{editingFlight ? 'Edit Flight Information' : 'Add Flight Information'}</DialogTitle>
-              </DialogHeader>
-              <div className="space-y-4">
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="flightNumber">Flight Number *</Label>
-                    <Input 
-                      id="flightNumber" 
-                      placeholder="e.g., AA123" 
-                      value={flightFormData.flightNumber}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, flightNumber: e.target.value }))}
-                    />
+          <div className="flex items-center gap-2">
+            <Button ref={addFlightButtonRef} onClick={() => handleOpenSearchPanel()}>
+              <Search className="mr-2 h-4 w-4" />
+              Add Flight
+            </Button>
+            <Dialog open={isAddFlightOpen} onOpenChange={setIsAddFlightOpen}>
+              <DialogTrigger asChild>
+                <Button variant="outline" onClick={openManualFlightDialog}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  Log Flight Manually
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle>
+                    {editingFlight ? "Edit Flight Information" : "Add Flight Information"}
+                  </DialogTitle>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="flightNumber">Flight Number *</Label>
+                      <Input
+                        id="flightNumber"
+                        placeholder="e.g., AA123"
+                        value={flightFormData.flightNumber}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, flightNumber: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="airline">Airline *</Label>
+                      <Input
+                        id="airline"
+                        placeholder="e.g., American Airlines"
+                        value={flightFormData.airline}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, airline: e.target.value }))}
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <Label htmlFor="airline">Airline *</Label>
-                    <Input 
-                      id="airline" 
-                      placeholder="e.g., American Airlines" 
-                      value={flightFormData.airline}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, airline: e.target.value }))}
-                    />
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="departureAirport">From *</Label>
+                      <SmartLocationSearch
+                        placeholder="Departure airport (e.g., JFK, New York)"
+                        value={flightFormData.departureAirport}
+                        onLocationSelect={(location) =>
+                          setFlightFormData((prev) => ({
+                            ...prev,
+                            departureAirport: location.displayName,
+                            departureCode: location.code,
+                          }))
+                        }
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="arrivalAirport">To *</Label>
+                      <SmartLocationSearch
+                        placeholder="Arrival airport (e.g., LAX, Los Angeles)"
+                        value={flightFormData.arrivalAirport}
+                        onLocationSelect={(location) =>
+                          setFlightFormData((prev) => ({
+                            ...prev,
+                            arrivalAirport: location.displayName,
+                            arrivalCode: location.code,
+                          }))
+                        }
+                      />
+                    </div>
                   </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="departureAirport">From *</Label>
-                    <SmartLocationSearch
-                      placeholder="Departure airport (e.g., JFK, New York)"
-                      value={flightFormData.departureAirport}
-                      onLocationSelect={(location) => setFlightFormData(prev => ({ 
-                        ...prev, 
-                        departureAirport: location.displayName,
-                        departureCode: location.code 
-                      }))}
-                    />
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="departureTime">Departure Time *</Label>
+                      <Input
+                        id="departureTime"
+                        type="datetime-local"
+                        value={flightFormData.departureTime}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, departureTime: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="arrivalTime">Arrival Time *</Label>
+                      <Input
+                        id="arrivalTime"
+                        type="datetime-local"
+                        value={flightFormData.arrivalTime}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, arrivalTime: e.target.value }))}
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <Label htmlFor="arrivalAirport">To *</Label>
-                    <SmartLocationSearch
-                      placeholder="Arrival airport (e.g., LAX, Los Angeles)"
-                      value={flightFormData.arrivalAirport}
-                      onLocationSelect={(location) => setFlightFormData(prev => ({ 
-                        ...prev, 
-                        arrivalAirport: location.displayName,
-                        arrivalCode: location.code 
-                      }))}
-                    />
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="price">Price ($)</Label>
+                      <Input
+                        id="price"
+                        type="number"
+                        placeholder="0.00"
+                        value={flightFormData.price}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, price: e.target.value }))}
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="seatClass">Seat Class</Label>
+                      <Select
+                        value={flightFormData.seatClass}
+                        onValueChange={(value) => setFlightFormData((prev) => ({ ...prev, seatClass: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select class" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="economy">Economy</SelectItem>
+                          <SelectItem value="premium">Premium Economy</SelectItem>
+                          <SelectItem value="business">Business</SelectItem>
+                          <SelectItem value="first">First</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
                   </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="departureTime">Departure Time *</Label>
-                    <Input 
-                      id="departureTime" 
-                      type="datetime-local" 
-                      value={flightFormData.departureTime}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, departureTime: e.target.value }))}
-                    />
+                  <div className="grid grid-cols-2 gap-4">
+                    <div>
+                      <Label htmlFor="flightType">Flight Type</Label>
+                      <Select
+                        value={flightFormData.flightType}
+                        onValueChange={(value) => setFlightFormData((prev) => ({ ...prev, flightType: value }))}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="outbound">Outbound</SelectItem>
+                          <SelectItem value="return">Return</SelectItem>
+                          <SelectItem value="connecting">Connecting</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                    <div>
+                      <Label htmlFor="bookingReference">Booking Reference</Label>
+                      <Input
+                        id="bookingReference"
+                        placeholder="e.g., ABC123"
+                        value={flightFormData.bookingReference}
+                        onChange={(e) => setFlightFormData((prev) => ({ ...prev, bookingReference: e.target.value }))}
+                      />
+                    </div>
                   </div>
-                  <div>
-                    <Label htmlFor="arrivalTime">Arrival Time *</Label>
-                    <Input 
-                      id="arrivalTime" 
-                      type="datetime-local" 
-                      value={flightFormData.arrivalTime}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, arrivalTime: e.target.value }))}
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="price">Price ($)</Label>
-                    <Input 
-                      id="price" 
-                      type="number" 
-                      placeholder="0.00" 
-                      value={flightFormData.price}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, price: e.target.value }))}
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="seatClass">Seat Class</Label>
-                    <Select 
-                      value={flightFormData.seatClass} 
-                      onValueChange={(value) => setFlightFormData(prev => ({ ...prev, seatClass: value }))}
+                  <div className="flex justify-end gap-2">
+                    <Button variant="outline" onClick={handleCancelEdit}>
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={handleFlightSubmit}
+                      disabled={createFlightMutation.isPending || updateFlightMutation.isPending}
                     >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select class" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="economy">Economy</SelectItem>
-                        <SelectItem value="premium">Premium Economy</SelectItem>
-                        <SelectItem value="business">Business</SelectItem>
-                        <SelectItem value="first">First</SelectItem>
-                      </SelectContent>
-                    </Select>
+                      {createFlightMutation.isPending || updateFlightMutation.isPending ? (
+                        <>
+                          <div className="mr-2 h-4 w-4 animate-spin rounded-full border-b-2 border-white" />
+                          {editingFlight ? "Updating..." : "Adding..."}
+                        </>
+                      ) : (
+                        editingFlight ? "Update Flight" : "Add Flight"
+                      )}
+                    </Button>
                   </div>
                 </div>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <Label htmlFor="flightType">Flight Type</Label>
-                    <Select 
-                      value={flightFormData.flightType} 
-                      onValueChange={(value) => setFlightFormData(prev => ({ ...prev, flightType: value }))}
-                    >
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="outbound">Outbound</SelectItem>
-                        <SelectItem value="return">Return</SelectItem>
-                        <SelectItem value="connecting">Connecting</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div>
-                    <Label htmlFor="bookingReference">Booking Reference</Label>
-                    <Input 
-                      id="bookingReference" 
-                      placeholder="e.g., ABC123" 
-                      value={flightFormData.bookingReference}
-                      onChange={(e) => setFlightFormData(prev => ({ ...prev, bookingReference: e.target.value }))}
-                    />
-                  </div>
-                </div>
-                <div className="flex justify-end gap-2">
-                  <Button variant="outline" onClick={handleCancelEdit}>
-                    Cancel
-                  </Button>
-                  <Button 
-                    onClick={handleFlightSubmit}
-                    disabled={createFlightMutation.isPending || updateFlightMutation.isPending}
-                  >
-                    {createFlightMutation.isPending || updateFlightMutation.isPending ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                        {editingFlight ? 'Updating...' : 'Adding...'}
-                      </>
-                    ) : (
-                      editingFlight ? 'Update Flight' : 'Add Flight'
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </DialogContent>
-          </Dialog>
+              </DialogContent>
+            </Dialog>
+          </div>
         </div>
       </div>
 
-      {/* Tabs for Flight Search vs Group Voting */}
-      <Tabs defaultValue="search" className="w-full">
-        <TabsList className="grid w-full grid-cols-3">
-          <TabsTrigger value="search">Search & Propose Flights</TabsTrigger>
-          <TabsTrigger value="voting" className="relative">
-            Group Voting
-            {(flightProposals as FlightProposalWithDetails[]).length > 0 && (
-              <Badge variant="secondary" className="ml-2 text-xs">
-                {(flightProposals as FlightProposalWithDetails[]).length}
-              </Badge>
-            )}
-          </TabsTrigger>
-          <TabsTrigger value="bookings">My Flight Bookings</TabsTrigger>
-        </TabsList>
+      {showSearchPanel && (
+        <FlightSearchPanel
+          searchFormData={searchFormData}
+          setSearchFormData={setSearchFormData}
+          onSearch={handleFlightSearch}
+          isSearching={isSearching}
+          activeFilter={activeFilter}
+          filterLoading={filterLoading}
+          filterResultCounts={filterResultCounts}
+          filterResults={filterResults}
+          searchResults={searchResults}
+          onFilterChange={handleFilterChange}
+          cachedSearchParams={cachedSearchParams}
+          onShareFlight={shareFlightWithGroup}
+          onPrefillFlight={prefillManualFlight}
+          onOpenManualFlight={openManualFlightDialog}
+          flights={flightsArray}
+          onEditFlight={handleEditFlight}
+          onDeleteFlight={(id) => deleteFlightMutation.mutate(id)}
+          flightProposals={flightProposals as FlightProposalWithDetails[]}
+          onClose={handleCloseSearchPanel}
+          user={user}
+          trip={trip as TripWithDetails | null}
+          autoSearch={autoSearchRequested}
+          onSubmitRanking={(proposalId, ranking) => submitFlightRanking(proposalId, ranking)}
+        />
+      )}
 
-        <TabsContent value="search" className="space-y-6 mt-6">
-          {/* Flight Search Section */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Search className="h-5 w-5" />
-                Search Flights
-              </CardTitle>
-            </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-4">
-                <div>
-                  <Label htmlFor="departure">From</Label>
-                  <SmartLocationSearch
-                    placeholder="Departure city or airport"
-                    value={searchFormData.departure}
-                    onLocationSelect={(location) => setSearchFormData(prev => ({ ...prev, departure: location.displayName }))}
-                  />
-                  {!user?.defaultLocation && !user?.defaultLocationCode && !searchFormData.departure && (
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      Save a default departure location in your profile to fill this automatically next time.
-                    </p>
-                  )}
-                </div>
-              <div>
-                <Label htmlFor="arrival">To</Label>
-                <SmartLocationSearch
-                  placeholder="Arrival city or airport"
-                  value={searchFormData.arrival}
-                  onLocationSelect={(location) => setSearchFormData(prev => ({ ...prev, arrival: location.displayName }))}
-                />
-              </div>
-              <div>
-                <Label htmlFor="departureDate">Departure</Label>
-                <Input
-                  id="departureDate"
-                  type="date"
-                  value={searchFormData.departureDate}
-                  onChange={(e) => setSearchFormData(prev => ({ ...prev, departureDate: e.target.value }))}
-                />
-              </div>
-              <div>
-                <Label htmlFor="returnDate">Return (Optional)</Label>
-                <Input
-                  id="returnDate"
-                  type="date"
-                  value={searchFormData.returnDate}
-                  onChange={(e) => setSearchFormData(prev => ({ ...prev, returnDate: e.target.value }))}
-                />
-              </div>
-            </div>
-            <div className="flex gap-4 items-end">
-              <div>
-                <Label htmlFor="passengers">Passengers</Label>
-                <Select value={searchFormData.passengers} onValueChange={(value) => setSearchFormData(prev => ({ ...prev, passengers: value }))}>
-                  <SelectTrigger className="w-32">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {[1,2,3,4,5,6,7,8].map(num => (
-                      <SelectItem key={num} value={num.toString()}>{num} {num === 1 ? 'passenger' : 'passengers'}</SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div>
-                <Label htmlFor="airline">Airline</Label>
-                <Select value={searchFormData.airline} onValueChange={(value) => setSearchFormData(prev => ({ ...prev, airline: value }))}>
-                  <SelectTrigger className="w-40">
-                    <SelectValue placeholder="Any airline" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="any">Any Airline</SelectItem>
-                    <SelectItem value="AA">American Airlines</SelectItem>
-                    <SelectItem value="DL">Delta Air Lines</SelectItem>
-                    <SelectItem value="UA">United Airlines</SelectItem>
-                    <SelectItem value="SW">Southwest Airlines</SelectItem>
-                    <SelectItem value="AS">Alaska Airlines</SelectItem>
-                    <SelectItem value="B6">JetBlue Airways</SelectItem>
-                    <SelectItem value="F9">Frontier Airlines</SelectItem>
-                    <SelectItem value="NK">Spirit Airlines</SelectItem>
-                    <SelectItem value="G4">Allegiant Air</SelectItem>
-                    <SelectItem value="VS">Virgin Atlantic</SelectItem>
-                    <SelectItem value="BA">British Airways</SelectItem>
-                    <SelectItem value="LH">Lufthansa</SelectItem>
-                    <SelectItem value="AF">Air France</SelectItem>
-                    <SelectItem value="KL">KLM</SelectItem>
-                    <SelectItem value="IB">Iberia</SelectItem>
-                    <SelectItem value="OS">Austrian Airlines</SelectItem>
-                    <SelectItem value="EY">Etihad Airways</SelectItem>
-                    <SelectItem value="QR">Qatar Airways</SelectItem>
-                    <SelectItem value="EK">Emirates</SelectItem>
-                    <SelectItem value="TK">Turkish Airlines</SelectItem>
-                    <SelectItem value="JL">Japan Airlines</SelectItem>
-                    <SelectItem value="NH">All Nippon Airways</SelectItem>
-                    <SelectItem value="CX">Cathay Pacific</SelectItem>
-                    <SelectItem value="SQ">Singapore Airlines</SelectItem>
-                    <SelectItem value="AC">Air Canada</SelectItem>
-                    <SelectItem value="WS">WestJet</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <Button 
-                onClick={async () => {
-                  if (!searchFormData.departure || !searchFormData.arrival || !searchFormData.departureDate) {
-                    toast({
-                      title: "Missing Information",
-                      description: "Please fill in departure, arrival, and departure date",
-                      variant: "destructive",
-                    });
-                    return;
-                  }
-                  
-                  setIsSearching(true);
-                  
-                  try {
-                    const response = await apiRequest("/api/search/flights", {
-                      method: "POST",
-                      body: {
-                        origin: searchFormData.departure,
-                        destination: searchFormData.arrival,
-                        departureDate: searchFormData.departureDate,
-                        returnDate: searchFormData.returnDate || undefined,
-                        passengers: parseInt(searchFormData.passengers),
-                        airline: searchFormData.airline && searchFormData.airline !== 'any' ? searchFormData.airline : undefined,
-                        provider: 'both', // Use both Amadeus and Duffel providers
-                        page: 1,
-                        limit: 50
-                      }
-                    });
-
-                    // Parse the JSON response from the Response object
-                    const searchResponse = await response.json();
-                    console.log("Flight search response:", searchResponse);
-                    
-                    // Handle new paginated response format
-                    if (searchResponse && searchResponse.flights && Array.isArray(searchResponse.flights) && searchResponse.flights.length > 0) {
-                      setSearchResults(searchResponse.flights);
-                      
-                      // Cache search parameters to prevent location searches in filter changes
-                      setCachedSearchParams({
-                        origin: searchFormData.departure,
-                        destination: searchFormData.arrival,
-                        departureDate: searchFormData.departureDate,
-                        returnDate: searchFormData.returnDate,
-                        passengers: parseInt(searchFormData.passengers),
-                        // Store both original location names and any resolved airport codes
-                        originCode: searchFormData.departure.length === 3 ? searchFormData.departure : undefined,
-                        destinationCode: searchFormData.arrival.length === 3 ? searchFormData.arrival : undefined
-                      });
-                      
-                      // Initialize filter results using server-side response
-                      setFilterResults({
-                        best: searchResponse.flights,
-                        cheapest: [],
-                        fastest: []
-                      });
-                      
-                      // Initialize filter counts from server response
-                      if (searchResponse.filters) {
-                        setFilterResultCounts(searchResponse.filters);
-                      } else {
-                        setFilterResultCounts({
-                          best: searchResponse.flights.length,
-                          cheapest: 0,
-                          fastest: 0
-                        });
-                      }
-                      
-                      // Ensure "best" filter is active
-                      setActiveFilter('best');
-                      
-                      const totalFromSources = (searchResponse.sources?.amadeus || 0) + (searchResponse.sources?.duffel || 0) + (searchResponse.sources?.kayak || 0);
-                      toast({
-                        title: "Flight Search Complete",
-                        description: `Found ${searchResponse.pagination?.total || searchResponse.flights.length} flights from ${totalFromSources} total sources - Amadeus: ${searchResponse.sources?.amadeus || 0}, Duffel: ${searchResponse.sources?.duffel || 0}, Kayak: ${searchResponse.sources?.kayak || 0}`,
-                      });
-                    } else {
-                      setSearchResults([]);
-                      setFilterResults({
-                        best: [],
-                        cheapest: [],
-                        fastest: []
-                      });
-                      setFilterResultCounts({
-                        best: 0,
-                        cheapest: 0,
-                        fastest: 0
-                      });
-                      toast({
-                        title: "No Flights Found",
-                        description: "Try adjusting your search criteria or dates",
-                        variant: "destructive",
-                      });
-                    }
-                  } catch (error: any) {
-                    console.error("Flight search error:", error);
-                    setSearchResults([]);
-                    toast({
-                      title: "Search Failed",
-                      description: error?.message || "Unable to search flights. Please try again.",
-                      variant: "destructive",
-                    });
-                  } finally {
-                    setIsSearching(false);
-                  }
-                }}
-                disabled={isSearching}
-                className="px-8"
-              >
-                {isSearching ? (
-                  <>
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                    Searching...
-                  </>
-                ) : (
-                  <>
-                    <Search className="h-4 w-4 mr-2" />
-                    Search Flights
-                  </>
-                )}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Group Flights
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {flightsArray.length === 0 ? (
+            <div className="py-8 text-center">
+              <Plane className="mx-auto mb-4 h-12 w-12 text-gray-400" />
+              <h3 className="mb-2 text-lg font-medium text-gray-900">No flights added yet</h3>
+              <p className="mb-4 text-gray-500">Start by adding flight information for your group members.</p>
+              <Button onClick={openManualFlightDialog}>
+                <Plus className="mr-2 h-4 w-4" />
+                Add First Flight
               </Button>
             </div>
-          </CardContent>
-        </Card>
-
-        {/* Search Results Section */}
-        {searchResults.length > 0 && (
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="flex items-center gap-2">
-                  <Search className="h-5 w-5" />
-                  Flight Search Results
-                </CardTitle>
-                {/* Kayak-style Filter Buttons */}
-                <div className="flex items-center gap-1">
-                  <Button
-                    variant={activeFilter === 'best' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => handleFilterChange('best')}
-                    disabled={filterLoading}
-                    className={`relative ${activeFilter === 'best' ? 'bg-blue-600 text-white' : 'hover:bg-blue-50'}`}
-                    data-testid="filter-best"
-                  >
-                    {filterLoading && activeFilter === 'best' && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-blue-600 rounded">
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
+          ) : (
+            <div className="space-y-4">
+              {flightsArray.map((flight: any) => (
+                <div key={flight.id} className="rounded-lg border p-4 transition-colors hover:bg-gray-50">
+                  <div className="mb-2 flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-2">
+                        <Plane className="h-4 w-4 text-blue-600" />
+                        <span className="font-semibold">{flight.airline}</span>
+                        <span className="text-gray-500">{flight.flightNumber}</span>
                       </div>
-                    )}
-                    🏆 Best
-                    {filterResultCounts.best > 0 && (
-                      <Badge variant="secondary" className="ml-1 text-xs">
-                        {filterResultCounts.best}
-                      </Badge>
-                    )}
-                  </Button>
-                  <Button
-                    variant={activeFilter === 'cheapest' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => handleFilterChange('cheapest')}
-                    disabled={filterLoading}
-                    className={`relative ${activeFilter === 'cheapest' ? 'bg-green-600 text-white' : 'hover:bg-green-50'}`}
-                    data-testid="filter-cheapest"
-                  >
-                    {filterLoading && activeFilter === 'cheapest' && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-green-600 rounded">
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
-                      </div>
-                    )}
-                    💰 Cheapest
-                    {filterResultCounts.cheapest > 0 && (
-                      <Badge variant="secondary" className="ml-1 text-xs">
-                        {filterResultCounts.cheapest}
-                      </Badge>
-                    )}
-                  </Button>
-                  <Button
-                    variant={activeFilter === 'fastest' ? 'default' : 'outline'}
-                    size="sm"
-                    onClick={() => handleFilterChange('fastest')}
-                    disabled={filterLoading}
-                    className={`relative ${activeFilter === 'fastest' ? 'bg-purple-600 text-white' : 'hover:bg-purple-50'}`}
-                    data-testid="filter-fastest"
-                  >
-                    {filterLoading && activeFilter === 'fastest' && (
-                      <div className="absolute inset-0 flex items-center justify-center bg-purple-600 rounded">
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white" />
-                      </div>
-                    )}
-                    ⚡ Fastest
-                    {filterResultCounts.fastest > 0 && (
-                      <Badge variant="secondary" className="ml-1 text-xs">
-                        {filterResultCounts.fastest}
-                      </Badge>
-                    )}
-                  </Button>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {/* Result Statistics - Kayak Style */}
-              {(() => {
-                const currentResults = filterResults[activeFilter].length > 0 ? filterResults[activeFilter] : searchResults;
-                if (currentResults.length === 0) return null;
-                
-                // Calculate statistics
-                const flightCount = currentResults.length;
-                const prices = currentResults.map((f: any) => f.price || f.totalPrice || 0).filter(p => p > 0);
-                const minPrice = prices.length > 0 ? Math.min(...prices) : 0;
-                const maxPrice = prices.length > 0 ? Math.max(...prices) : 0;
-                
-                const durations = currentResults.map((f: any) => {
-                  if (!f.duration) return 0;
-                  const hours = f.duration.match(/(\d+)h/)?.[1] || '0';
-                  const minutes = f.duration.match(/(\d+)m/)?.[1] || '0';
-                  return parseInt(hours) * 60 + parseInt(minutes);
-                }).filter(d => d > 0);
-                
-                const avgDuration = durations.length > 0 ? Math.round(durations.reduce((sum, d) => sum + d, 0) / durations.length) : 0;
-                const avgHours = Math.floor(avgDuration / 60);
-                const avgMinutes = avgDuration % 60;
-                
-                return (
-                  <div className="bg-blue-50 dark:bg-blue-950/20 rounded-lg p-4 mb-6 border border-blue-200 dark:border-blue-800">
-                    <div className="flex items-center justify-between flex-wrap gap-4">
-                      <div className="flex items-center gap-6 text-sm text-gray-700 dark:text-gray-300">
-                        <div className="flex items-center gap-2">
-                          <span className="text-blue-600 dark:text-blue-400 font-semibold">{flightCount}</span>
-                          <span>flights found</span>
+                      <Badge className={getFlightStatusColor(flight.status)}>{flight.status}</Badge>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <Button variant="ghost" size="sm" onClick={() => handleEditFlight(flight)}>
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => deleteFlightMutation.mutate(flight.id)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="grid grid-cols-1 gap-4 text-sm md:grid-cols-3">
+                    <div className="flex items-center gap-2">
+                      <PlaneTakeoff className="h-4 w-4 text-green-600" />
+                      <div>
+                        <div className="font-medium">{flight.departureAirport}</div>
+                        <div className="text-gray-500">
+                          {flight.departureTime ? format(new Date(flight.departureTime), 'MMM d, h:mm a') : 'Time TBD'}
                         </div>
-                        {prices.length > 0 && (
-                          <div className="flex items-center gap-2">
-                            <span className="text-gray-500">Price range:</span>
-                            <span className="font-medium">${minPrice}{minPrice !== maxPrice && ` - $${maxPrice}`}</span>
-                          </div>
-                        )}
-                        {avgDuration > 0 && (
-                          <div className="flex items-center gap-2">
-                            <span className="text-gray-500">Avg. flight time:</span>
-                            <span className="font-medium">{avgHours}h {avgMinutes}m</span>
-                          </div>
-                        )}
                       </div>
-                      <div className="text-xs text-gray-500 dark:text-gray-400">
-                        Filter: {activeFilter.charAt(0).toUpperCase() + activeFilter.slice(1)} 
-                        {activeFilter === 'best' && ' (balanced price & time)'}
-                        {activeFilter === 'cheapest' && ' (lowest price first)'}
-                        {activeFilter === 'fastest' && ' (shortest duration first)'}
+                    </div>
+                    <div className="flex items-center justify-center">
+                      <ArrowRight className="h-4 w-4 text-gray-400" />
+                      <div className="mx-2 text-xs text-gray-500">
+                        {flight.flightDuration ? formatDuration(flight.flightDuration) : 'Duration TBD'}
+                      </div>
+                      <ArrowRight className="h-4 w-4 text-gray-400" />
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <PlaneLanding className="h-4 w-4 text-red-600" />
+                      <div>
+                        <div className="font-medium">{flight.arrivalAirport}</div>
+                        <div className="text-gray-500">
+                          {flight.arrivalTime ? format(new Date(flight.arrivalTime), 'MMM d, h:mm a') : 'Time TBD'}
+                        </div>
                       </div>
                     </div>
                   </div>
-                );
-              })()}
-              
-              <div className="space-y-4">
-                {/* Display results for active filter */}
-                {(filterResults[activeFilter].length > 0 ? filterResults[activeFilter] : searchResults)
-                  .map((flight: any, index: number) => {
-                    const normalizedPriceSource = flight.price ?? flight.totalPrice;
-                    const priceLabel = formatPriceDisplay(normalizedPriceSource, flight.currency);
-                    const hasNumericPrice = parseNumericAmount(normalizedPriceSource) !== null;
-
-                    return (
-                      <div key={index} className="border rounded-lg p-4 hover:bg-gray-50 transition-colors">
-                        <div className="flex items-center justify-between mb-3">
-                          <div className="flex items-center gap-3">
-                            <div className="flex items-center gap-2">
-                              <Plane className="h-4 w-4 text-blue-600" />
-                              <span className="font-semibold">{getFlightAirlineName(flight)}</span>
-                              <span className="text-gray-500">{flight.flightNumber || `Flight ${index + 1}`}</span>
-                            </div>
-                            <Badge className="bg-green-100 text-green-800">
-                              Available
-                            </Badge>
-                          </div>
-                          <div className="text-right">
-                            <div className="text-2xl font-bold text-green-600">{priceLabel}</div>
-                            {hasNumericPrice && (
-                              <div className="text-sm text-gray-500">per person</div>
-                            )}
-                          </div>
-                        </div>
-                    
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm mb-4">
-                          <div className="flex items-center gap-2">
-                            <PlaneTakeoff className="h-4 w-4 text-green-600" />
-                            <div>
-                              <div className="font-medium">{flight.departure?.airport || flight.departureAirport || searchFormData.departure}</div>
-                              <div className="text-gray-500">
-                                {flight.departure?.time ? new Date(flight.departure.time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }) : 'Departure time varies'}
-                              </div>
-                            </div>
-                          </div>
-                          <div className="flex items-center justify-center">
-                            <ArrowRight className="h-4 w-4 text-gray-400" />
-                            <div className="mx-2 text-xs text-gray-500">
-                              {flight.duration ? flight.duration.replace('PT', '').replace('H', 'h ').replace('M', 'm') : 'Duration varies'}
-                            </div>
-                            <ArrowRight className="h-4 w-4 text-gray-400" />
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <PlaneLanding className="h-4 w-4 text-red-600" />
-                            <div>
-                              <div className="font-medium">{flight.arrival?.airport || flight.arrivalAirport || searchFormData.arrival}</div>
-                              <div className="text-gray-500">
-                                {flight.arrival?.time ? new Date(flight.arrival.time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' }) : 'Arrival time varies'}
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-
-                        <div className="flex items-center justify-between">
-                          <div className="flex items-center gap-4 text-sm text-gray-600">
-                            {flight.stops !== undefined && (
-                              <span>{flight.stops === 0 ? 'Non-stop' : `${flight.stops} stop${flight.stops > 1 ? 's' : ''}`}</span>
-                            )}
-                            {flight.class && (
-                              <span className="capitalize">{flight.class}</span>
-                            )}
-                          </div>
-                          <div className="flex gap-2">
-                            {/* Always show booking options for legitimate flight booking platforms */}
-                            <Button
-                              size="sm"
-                              variant="default"
-                              className="bg-blue-600 hover:bg-blue-700 text-white"
-                              asChild
-                              data-testid={`button-book-kayak-${index}`}
-                            >
-                              <a
-                                href={`https://www.kayak.com/flights/${cachedSearchParams?.originCode || 'ATL'}-${cachedSearchParams?.destinationCode || 'MIA'}/${searchFormData.departureDate}${searchFormData.returnDate ? `/${searchFormData.returnDate}` : ''}?sort=bestflight_a`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                <ExternalLink className="h-3 w-3 mr-1" />
-                                Book on Kayak
-                              </a>
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              asChild
-                              data-testid={`button-book-expedia-${index}`}
-                            >
-                              <a
-                                href={`https://www.expedia.com/Flights-Search?trip=${searchFormData.returnDate ? 'roundtrip' : 'oneway'}&leg1=from:${cachedSearchParams?.originCode || 'ATL'},to:${cachedSearchParams?.destinationCode || 'MIA'},departure:${searchFormData.departureDate}TANYT${searchFormData.returnDate ? `&leg2=from:${cachedSearchParams?.destinationCode || 'MIA'},to:${cachedSearchParams?.originCode || 'ATL'},departure:${searchFormData.returnDate}TANYT` : ''}`}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                              >
-                                Book on Expedia
-                              </a>
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => shareFlightWithGroup(flight)}
-                              data-testid={`button-propose-flight-${index}`}
-                            >
-                              <Users className="h-4 w-4 mr-2" />
-                              Propose to Group
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => {
-                                setFlightFormData({
-                                  flightNumber: flight.flightNumber || '',
-                                  airline: getFlightAirlineName(flight),
-                                  airlineCode: flight.airlineCode || '',
-                                  departureAirport: flight.departure?.airport || flight.departureAirport || searchFormData.departure,
-                                  departureCode: flight.departure?.iataCode || flight.departureCode || '',
-                                  departureTime: flight.departure?.time || flight.departureTime || '',
-                                  arrivalAirport: flight.arrival?.airport || flight.arrivalAirport || searchFormData.arrival,
-                                  arrivalCode: flight.arrival?.iataCode || flight.arrivalCode || '',
-                                  arrivalTime: flight.arrival?.time || flight.arrivalTime || '',
-                                  price: flight.price?.toString() || flight.totalPrice?.toString() || '',
-                                  seatClass: flight.class || 'economy',
-                                  flightType: 'outbound',
-                                  bookingReference: '',
-                                  aircraft: flight.aircraft || '',
-                                  status: 'confirmed'
-                                });
-                                setEditingFlight(null);
-                                setIsAddFlightOpen(true);
-                              }}
-                              data-testid={`button-add-to-trip-${index}`}
-                            >
-                              <Plus className="h-4 w-4 mr-2" />
-                              Add to Trip
-                            </Button>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-              </div>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Group Flights Section */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Users className="h-5 w-5" />
-              Group Flights
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {flightsArray.length === 0 ? (
-              <div className="text-center py-8">
-                <Plane className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">No flights added yet</h3>
-                <p className="text-gray-500 mb-4">
-                  Start by adding flight information for your group members.
-                </p>
-                <Button onClick={() => {
-                  resetFlightForm();
-                  setEditingFlight(null);
-                  setIsAddFlightOpen(true);
-                }}>
-                  <Plus className="h-4 w-4 mr-2" />
-                  Add First Flight
-                </Button>
-              </div>
-            ) : (
-              <div className="space-y-4">
-                {flightsArray.map((flight: any) => (
-                  <div key={flight.id} className="border rounded-lg p-4 hover:bg-gray-50 transition-colors">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center gap-3">
-                        <div className="flex items-center gap-2">
-                          <Plane className="h-4 w-4 text-blue-600" />
-                          <span className="font-semibold">{flight.airline}</span>
-                          <span className="text-gray-500">{flight.flightNumber}</span>
-                        </div>
-                        <Badge className={getFlightStatusColor(flight.status)}>
-                          {flight.status}
-                        </Badge>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => handleEditFlight(flight)}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => deleteFlightMutation.mutate(flight.id)}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </Button>
-                      </div>
+                  {flight.price != null && (
+                    <div className="mt-2 text-sm text-gray-600">
+                      Price: {formatPriceDisplay(flight.price, flight.currency)}
+                      {flight.seatClass && ` • ${flight.seatClass}`}
                     </div>
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-                      <div className="flex items-center gap-2">
-                        <PlaneTakeoff className="h-4 w-4 text-green-600" />
-                        <div>
-                          <div className="font-medium">{flight.departureAirport}</div>
-                          <div className="text-gray-500">
-                            {flight.departureTime ? format(new Date(flight.departureTime), 'MMM d, h:mm a') : 'Time TBD'}
-                          </div>
-                        </div>
-                      </div>
-                      <div className="flex items-center justify-center">
-                        <ArrowRight className="h-4 w-4 text-gray-400" />
-                        <div className="mx-2 text-xs text-gray-500">
-                          {flight.flightDuration ? formatDuration(flight.flightDuration) : 'Duration TBD'}
-                        </div>
-                        <ArrowRight className="h-4 w-4 text-gray-400" />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <PlaneLanding className="h-4 w-4 text-red-600" />
-                        <div>
-                          <div className="font-medium">{flight.arrivalAirport}</div>
-                          <div className="text-gray-500">
-                            {flight.arrivalTime ? format(new Date(flight.arrivalTime), 'MMM d, h:mm a') : 'Time TBD'}
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    {flight.price != null && (
-                      <div className="mt-2 text-sm text-gray-600">
-                        Price: {formatPriceDisplay(flight.price, flight.currency)}
-                        {flight.seatClass && ` • ${flight.seatClass}`}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            )}
-          </CardContent>
-        </Card>
-        </TabsContent>
-
-        {/* Group Voting Tab */}
-        <TabsContent value="voting" className="space-y-6 mt-6">
-          {/* Group Flight Proposals */}
-          {(flightProposals as FlightProposalWithDetails[]).length > 0 ? (
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Users className="h-5 w-5" />
-                  Group Flight Proposals ({(flightProposals as FlightProposalWithDetails[]).length})
-                </CardTitle>
-                <p className="text-sm text-muted-foreground">
-                  Rank these flights from 1 (most preferred) to help your group decide
-                </p>
-              </CardHeader>
-              <CardContent>
-                <div className="grid gap-4">
-                  {(flightProposals as FlightProposalWithDetails[]).map((proposal: FlightProposalWithDetails) => (
-                    <Card key={proposal.id} className="relative">
-                      <CardHeader className="pb-3">
-                        <div className="flex items-start justify-between">
-                          <div className="flex-1">
-                            <CardTitle className="text-lg font-semibold flex items-center gap-2">
-                              <PlaneTakeoff className="h-5 w-5 text-blue-600" />
-                              {proposal.airline} {proposal.flightNumber}
-                            </CardTitle>
-                            <div className="flex items-center gap-4 mt-2 text-sm text-muted-foreground">
-                              <div className="flex items-center gap-1">
-                                <MapPin className="h-3 w-3" />
-                                {proposal.departureAirport} → {proposal.arrivalAirport}
-                              </div>
-                              <div className="flex items-center gap-1">
-                                <Clock className="h-3 w-3" />
-                                {proposal.duration}
-                              </div>
-                              {proposal.stops > 0 && (
-                                <div className="text-xs bg-yellow-100 text-yellow-800 px-2 py-1 rounded">
-                                  {proposal.stops} stop{proposal.stops > 1 ? 's' : ''}
-                                </div>
-                              )}
-                            </div>
-                            <p className="text-xs text-muted-foreground mt-1">
-                              Proposed by {proposal.proposer?.firstName || 'Group Member'}
-                            </p>
-                          </div>
-                          <div className="text-right">
-                            <div className="text-lg font-bold text-blue-600">${proposal.price}</div>
-                            {proposal.averageRanking != null && (
-                              <div className="text-sm text-muted-foreground">
-                                Avg: #{proposal.averageRanking}
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </CardHeader>
-                      <CardContent className="space-y-4">
-                        <div className="bg-blue-50 p-3 rounded-lg">
-                          <div className="grid grid-cols-2 gap-4 text-sm">
-                            <div>
-                              <div className="flex items-center gap-1 text-muted-foreground">
-                                <PlaneTakeoff className="h-3 w-3" />
-                                Departure:
-                              </div>
-                              <div className="font-medium">
-                                {new Date(proposal.departureTime).toLocaleString()}
-                              </div>
-                            </div>
-                            <div>
-                              <div className="flex items-center gap-1 text-muted-foreground">
-                                <PlaneLanding className="h-3 w-3" />
-                                Arrival:
-                              </div>
-                              <div className="font-medium">
-                                {new Date(proposal.arrivalTime).toLocaleString()}
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                        
-                        <div className="flex items-center justify-between">
-                          <div className="space-y-1">
-                            <div className="text-sm font-medium text-muted-foreground">Your Ranking:</div>
-                            <div className="flex gap-1">
-                              {[1, 2, 3, 4, 5].map((rank) => (
-                                <Button
-                                  key={rank}
-                                  size="sm"
-                                  variant={proposal.currentUserRanking?.ranking === rank ? "default" : "outline"}
-                                  onClick={() => submitFlightRanking(proposal.id, rank)}
-                                  className="text-xs px-3"
-                                  data-testid={`button-rank-flight-${proposal.id}-${rank}`}
-                                >
-                                  #{rank}
-                                </Button>
-                              ))}
-                            </div>
-                          </div>
-                          
-                          <div className="flex gap-2">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => window.open(proposal.bookingUrl, '_blank')}
-                            >
-                              <ExternalLink className="h-3 w-3 mr-1" />
-                              View Details
-                            </Button>
-                          </div>
-                        </div>
-
-                        {proposal.rankings && proposal.rankings.length > 0 && (
-                          <div className="space-y-2">
-                            <div className="text-sm font-medium text-muted-foreground">Group Rankings:</div>
-                            <div className="grid grid-cols-1 gap-2">
-                              {proposal.rankings.map((ranking: any) => (
-                                <div key={ranking.id} className="flex items-center justify-between text-sm bg-gray-50 p-2 rounded">
-                                  <span>{ranking.user?.firstName || 'Member'}</span>
-                                  <Badge variant="secondary">#{ranking.ranking}</Badge>
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </CardContent>
-                    </Card>
-                  ))}
+                  )}
                 </div>
-              </CardContent>
-            </Card>
-          ) : (
-            <Card>
-              <CardContent className="flex flex-col items-center justify-center py-12">
-                <Users className="h-12 w-12 text-muted-foreground mb-4" />
-                <h3 className="text-lg font-semibold mb-2">No flight proposals yet</h3>
-                <p className="text-muted-foreground text-center mb-4">
-                  Search for flights and propose them to your group to start the voting process.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-        </TabsContent>
-
-        {/* My Flight Bookings Tab */}
-        <TabsContent value="bookings" className="space-y-6 mt-6">
-          {flightsArray.length === 0 ? (
-            <Card>
-              <CardContent className="flex flex-col items-center justify-center py-12">
-                <Plane className="h-12 w-12 text-muted-foreground mb-4" />
-                <h3 className="text-lg font-semibold mb-2">No flights added yet</h3>
-                <p className="text-muted-foreground text-center mb-4">
-                  Add your flight bookings to keep your group informed of travel plans.
-                </p>
-                <Dialog open={isAddFlightOpen} onOpenChange={setIsAddFlightOpen}>
-                  <DialogTrigger asChild>
-                    <Button>
-                      <Plus className="h-4 w-4 mr-2" />
-                      Add Flight
-                    </Button>
-                  </DialogTrigger>
-                </Dialog>
-              </CardContent>
-            </Card>
-          ) : (
-            <div className="grid gap-4">
-              {flightsArray.map((flight) => (
-                <Card key={flight.id} className="relative">
-                  <CardHeader className="pb-3">
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <CardTitle className="text-lg">
-                          {flight.airline} {flight.flightNumber}
-                        </CardTitle>
-                        <p className="text-sm text-muted-foreground flex items-center gap-1 mt-1">
-                          <MapPin className="h-3 w-3" />
-                          {flight.departureAirport} → {flight.arrivalAirport}
-                        </p>
-                      </div>
-                      <Badge className={getFlightStatusColor(flight.status || 'confirmed')}>
-                        {flight.status || 'confirmed'}
-                      </Badge>
-                    </div>
-                  </CardHeader>
-                  <CardContent className="space-y-3">
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <div className="text-sm text-muted-foreground">Departure</div>
-                        <div className="font-medium">
-                          {format(new Date(flight.departureTime), 'MMM d, h:mm a')}
-                        </div>
-                      </div>
-                      <div>
-                        <div className="text-sm text-muted-foreground">Arrival</div>
-                        <div className="font-medium">
-                          {format(new Date(flight.arrivalTime), 'MMM d, h:mm a')}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="flex items-center justify-between pt-2">
-                      <div className="flex items-center gap-2">
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => handleEditFlight(flight)}
-                        >
-                          <Edit className="h-3 w-3" />
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => deleteFlightMutation.mutate(flight.id)}
-                        >
-                          <Trash2 className="h-3 w-3" />
-                        </Button>
-                      </div>
-                      {flight.price != null && (
-                        <div className="text-lg font-semibold text-green-600">
-                          {formatPriceDisplay(flight.price, flight.currency)}
-                        </div>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
               ))}
             </div>
           )}
-        </TabsContent>
-      </Tabs>
+        </CardContent>
+      </Card>
+
     </div>
   );
 }

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1955,9 +1955,9 @@ function FlightCoordination({ tripId, user }: { tripId: number; user: any }) {
           <h2 className="text-xl font-semibold">Flight Coordination</h2>
           <p className="text-gray-600">Coordinate flights with your group</p>
         </div>
-        <Button 
+        <Button
           onClick={() => {
-            setLocation(`/trip/${tripId}/flights`);
+            setLocation(`/trip/${tripId}/flights?panel=search`);
           }}
           className="bg-primary hover:bg-red-600 text-white"
         >
@@ -2000,8 +2000,8 @@ function FlightCoordination({ tripId, user }: { tripId: number; user: any }) {
               <p className="text-gray-600 mb-4">
                 Add and coordinate flights with your travel group
               </p>
-              <Button 
-                onClick={() => setLocation(`/trip/${tripId}/flights`)}
+              <Button
+                onClick={() => setLocation(`/trip/${tripId}/flights?panel=search`)}
                 className="bg-primary hover:bg-red-600 text-white"
               >
                 <Plane className="w-4 h-4 mr-2" />


### PR DESCRIPTION
## Summary
- embed the existing flight search experience directly in the flights dashboard and gate it behind the Add Flight toggle
- wire URL query parameters, auto-search handling, and focus management so the panel opens via ?panel=search and returns focus when closed
- forward refs through SmartLocationSearch so the flights page can programmatically focus the From field when the panel appears

## Testing
- `npx tsc --noEmit`
- `npm run build --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_68d5fa51f9a4832e8a0dca5d9364f5e5