### PR TITLE
Add inline hotel search panel with filters and deep link support

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -18,6 +18,7 @@ interface LocationResult {
 }
 
 interface SmartLocationSearchProps {
+  id?: string;
   placeholder?: string;
   value?: string;
   onLocationSelect: (location: LocationResult) => void;
@@ -25,6 +26,7 @@ interface SmartLocationSearchProps {
 }
 
 const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProps>(function SmartLocationSearch({
+  id,
   placeholder = "Enter city, airport, or state...",
   value = "",
   onLocationSelect,
@@ -132,6 +134,7 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
     <div className={`relative ${className}`}>
       <div className="relative">
         <Input
+          id={id}
           ref={setInputRef}
           type="text"
           placeholder={placeholder}


### PR DESCRIPTION
## Summary
- show an inline hotel search panel when clicking Add Hotel, including filters, hide control, and query-string handling
- wire the search request to the new form fields, rename the manual logging action, and update group hotel selection messaging
- expose an id prop on SmartLocationSearch so the panel labels remain accessible

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68d6a22d2e88832e860f44c149f9943b