### PR TITLE
Restore inline hotel search panel on trip page

### DIFF
--- a/client/src/components/hotels/hotel-search-panel.tsx
+++ b/client/src/components/hotels/hotel-search-panel.tsx
@@ -665,13 +665,23 @@ export const HotelSearchPanel = forwardRef<HotelSearchPanelRef, HotelSearchPanel
         </div>
 
         <Card className="border-primary/40 shadow-sm">
-          <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-2">
-              <Filter className="h-4 w-4 text-primary" />
-              <CardTitle className="text-lg">Search Hotels for this Trip</CardTitle>
+          <CardHeader className="flex flex-col gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-center gap-2">
+                <Filter className="h-4 w-4 text-primary" />
+                <CardTitle className="text-lg">Search Hotels for this Trip</CardTitle>
+              </div>
+              {searchResults.length > 0 && (
+                <div className="text-sm text-muted-foreground">Found {searchResults.length} hotels</div>
+              )}
             </div>
-            {searchResults.length > 0 && (
-              <div className="text-sm text-muted-foreground">Found {searchResults.length} hotels</div>
+            {trip?.destination && (trip?.startDate || trip?.endDate) && (
+              <p className="text-sm text-muted-foreground">
+                Trip destination: {trip.destination}
+                {(trip.startDate || trip.endDate) && " • "}
+                {trip.startDate ? format(new Date(trip.startDate), "MMM d") : "Start TBD"}
+                {trip.endDate ? `–${format(new Date(trip.endDate), "MMM d")}` : ""}
+              </p>
             )}
           </CardHeader>
           <CardContent>

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3309,58 +3309,6 @@ function HotelBooking({ tripId, user, trip }: { tripId: number; user: any; trip?
           </Button>
         </div>
 
-        <Card className="border-dashed">
-          <CardHeader>
-            <CardTitle className="text-lg flex items-center gap-2">
-              <Plus className="h-5 w-5 text-primary" />
-              Add a Hotel Booking
-            </CardTitle>
-            <CardDescription>
-              Save a custom stay or confirmed reservation directly to this trip so everyone can view the details.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            <Collapsible open={isManualHotelFormOpen} onOpenChange={setIsManualHotelFormOpen}>
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <div>
-                  <p className="text-sm font-medium text-neutral-900">Manual entry</p>
-                  <p className="text-sm text-muted-foreground">
-                    Record a stay that isn't imported from the hotel search results.
-                  </p>
-                </div>
-                <CollapsibleTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="w-full sm:w-auto justify-between sm:justify-center"
-                  >
-                    <span>{isManualHotelFormOpen ? "Close" : "Add a Hotel"}</span>
-                    <ChevronDown
-                      className={`ml-2 h-4 w-4 transition-transform ${isManualHotelFormOpen ? "rotate-180" : ""}`}
-                    />
-                  </Button>
-                </CollapsibleTrigger>
-              </div>
-              <CollapsibleContent className="space-y-6 pt-4 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-                <Form {...form}>
-                  <form onSubmit={form.handleSubmit(onSubmit)}>
-                    <HotelFormFields
-                      form={form}
-                      isSubmitting={createHotelMutation.isPending}
-                      submitLabel={createHotelMutation.isPending ? "Saving..." : "Save Hotel"}
-                      showCancelButton
-                      onCancel={() => {
-                        form.reset(formDefaults());
-                        setIsManualHotelFormOpen(false);
-                      }}
-                    />
-                  </form>
-                </Form>
-              </CollapsibleContent>
-            </Collapsible>
-
-          </CardContent>
-        </Card>
-
         <HotelSearchPanel
           ref={searchPanelRef}
           tripId={tripId}
@@ -3371,6 +3319,46 @@ function HotelBooking({ tripId, user, trip }: { tripId: number; user: any; trip?
           hotelProposalsCount={hotelProposals.length}
           toast={toast}
         />
+
+        <Collapsible open={isManualHotelFormOpen} onOpenChange={setIsManualHotelFormOpen}>
+          <div className="rounded-lg border border-dashed bg-white shadow-sm">
+            <div className="flex flex-col gap-3 border-b border-dashed p-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-medium text-neutral-900">Manual entry</p>
+                <p className="text-sm text-muted-foreground">
+                  Record a stay that isn't imported from the hotel search results.
+                </p>
+              </div>
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="w-full sm:w-auto justify-between sm:justify-center"
+                >
+                  <span>{isManualHotelFormOpen ? "Close" : "Add a Hotel"}</span>
+                  <ChevronDown
+                    className={`ml-2 h-4 w-4 transition-transform ${isManualHotelFormOpen ? "rotate-180" : ""}`}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+            <CollapsibleContent className="space-y-6 p-4 transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
+              <Form {...form}>
+                <form onSubmit={form.handleSubmit(onSubmit)}>
+                  <HotelFormFields
+                    form={form}
+                    isSubmitting={createHotelMutation.isPending}
+                    submitLabel={createHotelMutation.isPending ? "Saving..." : "Save Hotel"}
+                    showCancelButton
+                    onCancel={() => {
+                      form.reset(formDefaults());
+                      setIsManualHotelFormOpen(false);
+                    }}
+                  />
+                </form>
+              </Form>
+            </CollapsibleContent>
+          </div>
+        </Collapsible>
 
       </div>
 


### PR DESCRIPTION
## Summary
- remove the Trip snapshot/Add a Hotel Booking card so the hotel search form sits directly beneath the Hotel Booking heading
- keep the manual hotel entry collapsible available beneath the search results trigger while preserving the Log Hotel Manually action
- add an optional trip destination/date hint within the search form header when trip details are present

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d6fcf818cc832eae27c1af3d61ef33