### PR TITLE
Remove manual log button from hotel search form

### DIFF
--- a/client/src/components/hotels/hotel-search-panel.tsx
+++ b/client/src/components/hotels/hotel-search-panel.tsx
@@ -827,15 +827,6 @@ export const HotelSearchPanel = forwardRef<HotelSearchPanelRef, HotelSearchPanel
               </div>
 
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={onLogHotelManually}
-                  className="w-full sm:w-auto"
-                >
-                  <Building className="h-4 w-4 mr-2" />
-                  Log Hotel Manually
-                </Button>
                 <Button type="submit" disabled={isSearching} className="min-w-[160px] w-full sm:w-auto">
                   <Search className="h-4 w-4 mr-2" />
                   {isSearching ? (


### PR DESCRIPTION
## Summary
- remove the redundant "Log Hotel Manually" button from the search form while retaining the dropdown option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70007be10832eaa5172a3437a089e