### PR TITLE
Adjust shared expenses summary layout

### DIFF
--- a/client/src/components/expense-tracker.tsx
+++ b/client/src/components/expense-tracker.tsx
@@ -55,7 +55,7 @@ interface ExpenseTrackerProps {
   user?: User;
 }
 
-type SummaryView = "total" | "youPaid" | "youOwe" | "youAreOwed";
+type SummaryView = "youPaid" | "youOwe" | "youAreOwed";
 
 type SortOption = "date-desc" | "date-asc" | "amount-desc" | "amount-asc";
 
@@ -323,12 +323,6 @@ export function ExpenseTracker({ tripId, user }: ExpenseTrackerProps) {
   }[] = useMemo(
     () => [
       {
-        type: "total",
-        title: "Total recorded",
-        description: "All expenses logged for this trip.",
-        amount: summary.total,
-      },
-      {
         type: "youPaid",
         title: "You paid",
         description: "Amount you covered for everyone else.",
@@ -350,7 +344,7 @@ export function ExpenseTracker({ tripId, user }: ExpenseTrackerProps) {
         amountClassName: "text-emerald-600",
       },
     ],
-    [summary.owed, summary.owes, summary.total, summary.youPaid],
+    [summary.owed, summary.owes, summary.youPaid],
   );
 
   const selectedCard = detailView
@@ -363,10 +357,6 @@ export function ExpenseTracker({ tripId, user }: ExpenseTrackerProps) {
     }
 
     const matchesView = (expense: ExpenseWithDetails) => {
-      if (detailView === "total") {
-        return true;
-      }
-
       if (!user?.id) {
         return false;
       }
@@ -509,7 +499,7 @@ export function ExpenseTracker({ tripId, user }: ExpenseTrackerProps) {
         </Button>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {cardConfigs.map((card) => (
           <Card
             key={card.type}


### PR DESCRIPTION
## Summary
- remove the "Total recorded" summary card from the shared expenses metrics grid
- update the summary card grid to use three evenly spaced columns on desktop while keeping responsive behavior for tablets and mobile

## Testing
- npm run check *(fails: existing type errors in activities.tsx, restaurants.tsx, and trip.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d70537c76c832ebb572c9ddcaa86d4