### PR TITLE
Fix auth loading hang on trips page

### DIFF
--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,14 +1,73 @@
+import { useEffect, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import type { User } from "@shared/schema";
-import { getQueryFn } from "@/lib/queryClient";
+import { buildApiUrl } from "@/lib/api";
 
 export function useAuth() {
-  const { data: user, isLoading } = useQuery<User>({
+  const isMountedRef = useRef(true);
+  const [manualLoading, setManualLoading] = useState(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const { data: user, isLoading: queryLoading } = useQuery<User | null>({
     queryKey: ["/api/auth/user"],
-    queryFn: getQueryFn<User>({ on401: "returnNull" }), // ✅ important
+    // FIXED USER REQUEST: ensure the auth lookup never leaves the UI stuck in loading
+    queryFn: async ({ signal }) => {
+      const controller = new AbortController();
+      const cleanupLinkedSignal = linkAbortSignals(signal, controller);
+
+      let cleanupTimeout: (() => void) | undefined;
+      if (typeof window !== "undefined") {
+        const timeoutId = window.setTimeout(() => {
+          controller.abort(
+            new DOMException("User request timed out", "AbortError"),
+          );
+        }, 10000);
+        cleanupTimeout = () => window.clearTimeout(timeoutId);
+      }
+
+      if (isMountedRef.current) {
+        setManualLoading(true); // FIXED USER REQUEST
+      }
+
+      try {
+        const response = await fetch(buildApiUrl("/api/auth/user"), {
+          credentials: "include",
+          signal: controller.signal,
+        });
+
+        if (response.status === 401) {
+          return null;
+        }
+
+        if (!response.ok) {
+          const message = (await response.text()) || response.statusText;
+          throw new Error(message);
+        }
+
+        return (await response.json()) as User;
+      } catch (error) {
+        if ((error as DOMException)?.name === "AbortError") {
+          console.warn("Auth user request aborted", error);
+        } else {
+          console.error("Failed to load authenticated user", error);
+        }
+        return null;
+      } finally {
+        cleanupLinkedSignal?.();
+        cleanupTimeout?.();
+        if (isMountedRef.current) {
+          setManualLoading(false); // FIXED USER REQUEST
+        }
+      }
+    },
     retry: (failureCount, error) => {
       if (error && typeof error === "object" && "message" in error) {
-        if (error.message.includes("401")) {
+        if (typeof error.message === "string" && error.message.includes("401")) {
           return false;
         }
       }
@@ -18,9 +77,33 @@ export function useAuth() {
     gcTime: 10 * 60 * 1000,   // 10 minutes
   });
 
+  useEffect(() => {
+    if (!queryLoading && isMountedRef.current) {
+      setManualLoading(false); // FIXED USER REQUEST
+    }
+  }, [queryLoading]);
+
   return {
     user,
-    isLoading,
+    isLoading: manualLoading,
     isAuthenticated: !!user,
   };
+}
+
+function linkAbortSignals(
+  source: AbortSignal | undefined,
+  targetController: AbortController,
+) {
+  if (!source) {
+    return undefined;
+  }
+
+  if (source.aborted) {
+    targetController.abort(source.reason);
+    return undefined;
+  }
+
+  const listener = () => targetController.abort(source.reason);
+  source.addEventListener("abort", listener);
+  return () => source.removeEventListener("abort", listener);
 }


### PR DESCRIPTION
## Summary
- guard the /api/auth/user lookup with an abort-aware query function so the trips page never stalls on a pending "User" request
- add timeout and explicit loading-state cleanup with // FIXED USER REQUEST markers to guarantee setLoading(false) on success, failure, or abort

## Testing
- npm run check *(fails: pre-existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d715764c048329ad159a5d4411cb0a