### PR TITLE
Add GeoNames fallback for location search and persist trip city metadata

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -15,6 +15,15 @@ interface LocationResult {
   country: string;
   state?: string;
   airports?: string[];
+  id?: string | number;
+  label?: string;
+  geonameId?: number | string;
+  cityName?: string | null;
+  countryName?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  population?: number | null;
+  source?: string;
 }
 
 interface SmartLocationSearchProps {
@@ -297,14 +306,16 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
                   }
 
                   const safeLocation = {
+                    ...location,
                     type: location.type || "city",
                     name: location.name || "Unknown Location",
                     code: location.code || "N/A",
                     displayName: location.displayName || location.name || "Unknown Location",
+                    label: location.label || location.displayName || location.name || "Unknown Location",
                     country: location.country || "Unknown Country",
                     state: location.state,
                     airports: Array.isArray(location.airports) ? location.airports : [],
-                  };
+                  } satisfies LocationResult;
 
                   const isActive = index === activeIndex;
 

--- a/client/src/components/create-trip-modal.tsx
+++ b/client/src/components/create-trip-modal.tsx
@@ -38,6 +38,12 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
       destination: "",
       startDate: "",
       endDate: "",
+      geonameId: null,
+      cityName: null,
+      countryName: null,
+      latitude: null,
+      longitude: null,
+      population: null,
     },
   });
 
@@ -98,6 +104,37 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
   const handleDestinationSelect = (location: any) => {
     setSelectedDestination(location);
     form.setValue("destination", location.displayName || location.name);
+    const geonameIdValue =
+      location?.geonameId !== undefined && location?.geonameId !== null
+        ? Number(location.geonameId)
+        : null;
+    form.setValue("geonameId", Number.isFinite(geonameIdValue ?? NaN) ? geonameIdValue : null);
+    form.setValue("cityName", location?.cityName ?? location?.name ?? null);
+    form.setValue(
+      "countryName",
+      location?.countryName ?? location?.country ?? null,
+    );
+    const latitudeValue =
+      typeof location?.latitude === "number"
+        ? location.latitude
+        : location?.latitude
+        ? Number(location.latitude)
+        : null;
+    const longitudeValue =
+      typeof location?.longitude === "number"
+        ? location.longitude
+        : location?.longitude
+        ? Number(location.longitude)
+        : null;
+    form.setValue("latitude", Number.isFinite(latitudeValue ?? NaN) ? latitudeValue : null);
+    form.setValue("longitude", Number.isFinite(longitudeValue ?? NaN) ? longitudeValue : null);
+    const populationValue =
+      typeof location?.population === "number"
+        ? location.population
+        : location?.population
+        ? Number(location.population)
+        : null;
+    form.setValue("population", Number.isFinite(populationValue ?? NaN) ? populationValue : null);
   };
 
   return (

--- a/server/locationDatabase.ts
+++ b/server/locationDatabase.ts
@@ -360,6 +360,10 @@ export const airportInfo = {
   'TLV': { name: 'Ben Gurion Airport', city: 'Tel Aviv', country: 'Israel' },
 };
 
+/**
+ * @deprecated This hardcoded search is retained only for legacy airport helpers.
+ *             GeoNames is now used as the fallback for /api/locations/search.
+ */
 // Smart location search function - completely flexible
 export function searchLocations(query: string): LocationResult[] {
   const results: LocationResult[] = [];

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -119,6 +119,12 @@ export interface TripCalendar {
   shareCode: string;
   createdBy: string;
   createdAt: IsoDate | null;
+  geonameId?: number | null;
+  cityName?: string | null;
+  countryName?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  population?: number | null;
 }
 
 export const insertTripCalendarSchema = z.object({
@@ -126,6 +132,12 @@ export const insertTripCalendarSchema = z.object({
   destination: z.string().min(1, "Destination is required"),
   startDate: z.union([z.date(), z.string()]),
   endDate: z.union([z.date(), z.string()]),
+  geonameId: nullableNumberInput("Geoname ID must be a number"),
+  cityName: z.string().nullable().optional(),
+  countryName: z.string().nullable().optional(),
+  latitude: nullableNumberInput("Latitude must be a number"),
+  longitude: nullableNumberInput("Longitude must be a number"),
+  population: nullableNumberInput("Population must be a number"),
 });
 
 export type InsertTripCalendar = z.infer<typeof insertTripCalendarSchema>;


### PR DESCRIPTION
## Summary
- replace the internal location database fallback with a GeoNames API fallback for `/api/locations/search`, using the `GEONAMES_USERNAME` credential and normalising the response shape
- carry GeoNames city details through trip creation by extending the shared schema, client form handling, and storage layer so trips store geoname, location, and population metadata
- preserve additional metadata in `SmartLocationSearch` results and mark the legacy location database search as deprecated for future cleanup

## Testing
- `npm run check` *(fails: existing TypeScript errors in unrelated files such as activities.tsx and trip.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68daa92ec4588329bbb4073984d350e2