### PR TITLE
Fix proposals tab rendering in trip dashboard

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1766,7 +1766,7 @@ export default function Trip() {
 
                 {activeTab === "proposals" && (
                   <div className="space-y-6" data-testid="proposals-section">
-                    <Proposals tripId={parseInt(id || "0")} />
+                    <Proposals tripId={parseInt(id || "0")} layout="embedded" />
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- add an embedded layout option to the proposals page so the trip dashboard can reuse the same filters, tabs, and status messaging without a full-page takeover
- share loading and error states across page and embedded variants so the trip view shows inline cards instead of blank screens
- update the trip dashboard to request the embedded proposals view when the Proposals tab is selected

## Testing
- npm run lint --silent

------
https://chatgpt.com/codex/tasks/task_e_68daca269840832e9e6f95e51fa38eff