### PR TITLE
Revamp shared expenses layout

### DIFF
--- a/client/src/components/add-expense-modal.tsx
+++ b/client/src/components/add-expense-modal.tsx
@@ -1236,6 +1236,10 @@ export function AddExpenseModal({
               />
             </div>
 
+            <p className="px-6 text-xs text-muted-foreground">
+              Splits include the payer; the payer never receives a request.
+            </p>
+
             <div className="flex flex-col gap-3 border-t bg-muted/30 px-6 py-4 sm:flex-row sm:items-center sm:justify-end">
               {submitError ? (
                 <p className="text-sm font-medium text-destructive sm:mr-auto">


### PR DESCRIPTION
## Summary
- replace shared expenses summary cards with a net balance pill and supporting metrics line
- convert the expense list into lightweight collapsible sections with streamlined rows and badges
- add payer-inclusive helper messaging to the add expense form and expense detail view

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dacc015888832eb6bc021692821ec7