### PR TITLE
Fix API proxy for nearest airport lookup

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,7 @@ export default defineConfig(async ({ mode }) => {
       proxy: {
         "/health": apiProxyTarget,
         "/search": apiProxyTarget,
+        "/api": apiProxyTarget,
       },
     },
   };


### PR DESCRIPTION
## Summary
- add a Vite dev-server proxy entry for /api so nearest airport lookup requests reach the backend in development

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae27a5bc883298d623e653bbc6cf4