### PR TITLE
Fix proposals tab layout and flight query invalidation

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1766,7 +1766,7 @@ export default function Trip() {
 
                 {activeTab === "proposals" && (
                   <div className="space-y-6" data-testid="proposals-section">
-                    <Proposals tripId={parseInt(id || "0")} />
+                    <Proposals tripId={parseInt(id || "0")} embedded />
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- add an embedded mode to the proposals page so it can be rendered inside the trip dashboard without the standalone shell
- update the trip proposals tab to use the embedded layout and reuse shared content
- fix the flight proposal ranking mutation to invalidate the correct query key so votes refresh immediately

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dad84b36bc832e86695dfe65cf17ae