### PR TITLE
Align My Schedule with RSVP rules

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1975,9 +1975,13 @@ export function setupRoutes(app: Express) {
       const filteredAttendeeIds = Array.from(
         new Set(attendeeIds.filter((id) => typeof id === 'string' && validMemberIds.has(id))),
       );
-      const inviteeIds = Array.from(new Set([...filteredAttendeeIds, userId]));
+      const attendeeIdSet = new Set(filteredAttendeeIds);
+      attendeeIdSet.delete(userId);
+      const inviteeIds = Array.from(attendeeIdSet);
 
       const activity = await storage.createActivity(activityData, userId, inviteeIds);
+
+      await storage.setActivityInviteStatus(activity.id, userId, "accepted");
 
       const attendeesToNotify = inviteeIds.filter((attendeeId) => attendeeId !== userId);
 


### PR DESCRIPTION
## Summary
- auto-accept creators as attending when creating scheduled activities so they immediately appear on personal calendars
- filter and present "My Schedule" entries based on creator/accepted RSVPs while surfacing a Proposed badge for personal drafts
- highlight personal proposals in the calendar grid and refresh the My Schedule copy to match the new inclusion rules

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68daefe289f0832ebf20183cdbeb6a5c