### PR TITLE
Guard proposals tab rendering on loaded trip

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1765,9 +1765,9 @@ export default function Trip() {
                   />
                 )}
 
-                {activeTab === "proposals" && (
+                {activeTab === "proposals" && trip && (
                   <div className="space-y-6" data-testid="proposals-section">
-                    <Proposals tripId={parseInt(id || "0")} embedded />
+                    <Proposals tripId={trip.id} embedded />
                   </div>
                 )}
 


### PR DESCRIPTION
## Summary
- guard the trip proposals tab so it only renders after the trip data has loaded
- pass the numeric trip id from the loaded trip into the embedded proposals view

## Testing
- npm run check *(fails: pre-existing TypeScript errors in unrelated files)*
- npm run dev *(fails: server requires DATABASE_URL environment variable to connect to Postgres)*

------
https://chatgpt.com/codex/tasks/task_e_68daf03a3518832e818ae824284d4b8f