### PR TITLE
Add post-redirect booking prompts for flights and hotels

### DIFF
--- a/client/src/components/hotels/hotel-search-panel.tsx
+++ b/client/src/components/hotels/hotel-search-panel.tsx
@@ -18,6 +18,7 @@ import SmartLocationSearch from "@/components/SmartLocationSearch";
 import { TravelLoading } from "@/components/LoadingSpinners";
 import { apiFetch } from "@/lib/api";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { HOTEL_REDIRECT_STORAGE_KEY, markExternalRedirect } from "@/lib/externalRedirects";
 import type { TripWithDates, HotelSearchResult } from "@shared/schema";
 import { format } from "date-fns";
 import {
@@ -235,6 +236,7 @@ export const HotelSearchPanel = forwardRef<HotelSearchPanelRef, HotelSearchPanel
         }
 
         if (url) {
+          markExternalRedirect(HOTEL_REDIRECT_STORAGE_KEY);
           window.open(url, "_blank", "noopener,noreferrer");
         }
       },

--- a/client/src/lib/externalRedirects.ts
+++ b/client/src/lib/externalRedirects.ts
@@ -1,0 +1,23 @@
+export const FLIGHT_REDIRECT_STORAGE_KEY = "vacationsync:flight_redirect";
+export const HOTEL_REDIRECT_STORAGE_KEY = "vacationsync:hotel_redirect";
+
+export const markExternalRedirect = (storageKey: string) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.setItem(storageKey, "true");
+};
+
+export const clearExternalRedirect = (storageKey: string) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.localStorage.removeItem(storageKey);
+};
+
+export const hasExternalRedirect = (storageKey: string): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.localStorage.getItem(storageKey) === "true";
+};


### PR DESCRIPTION
## Summary
- add shared helpers for tracking external redirect flags in local storage
- mark flight and hotel redirects when opening third-party search links
- show sequential return dialogs that optionally open the manual add flight or hotel forms

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated pages)*

------
https://chatgpt.com/codex/tasks/task_e_68db15a64b8c83299b9e159547e6d3e4