### PR TITLE
Fix rule-of-hooks violations in flights and proposals tabs

### DIFF
--- a/client/src/pages/proposals.tsx
+++ b/client/src/pages/proposals.tsx
@@ -1210,84 +1210,6 @@ function ProposalsPage({ tripId, embedded = false }: ProposalsPageProps = {}) {
     );
   };
 
-  const boundaryWrapperClass = embedded
-    ? "py-12 flex items-center justify-center"
-    : "min-h-screen bg-neutral-50 flex items-center justify-center";
-
-  if (!tripId) {
-    return (
-      <div className={boundaryWrapperClass}>
-        <Card className="w-full max-w-md mx-4">
-          <CardContent className="pt-6 text-center">
-            <AlertCircle className="w-12 h-12 text-amber-500 mx-auto mb-4" />
-            <h2 className="text-lg font-semibold mb-2">Trip not specified</h2>
-            <p className="text-neutral-600 mb-4">
-              We couldn't determine which trip to load proposals for. Please go back and pick a trip first.
-            </p>
-            <Link href="/">
-              <Button data-testid="button-trip-missing-back-home">Back to Home</Button>
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  if (authLoading || tripLoading) {
-    return (
-      <div className={boundaryWrapperClass}>
-        <TravelLoading variant="journey" size="lg" text="Loading your proposals..." />
-      </div>
-    );
-  }
-
-  if (tripError) {
-    const parsedError = parseApiError(tripError);
-
-    return (
-      <div className={boundaryWrapperClass}>
-        <Card className="w-full max-w-md mx-4">
-          <CardContent className="pt-6 text-center">
-            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-            <h2 className="text-lg font-semibold mb-2">Unable to load trip</h2>
-            <p className="text-neutral-600 mb-4">
-              {parsedError.message || "Something went wrong while loading this trip. Please try again."}
-            </p>
-            <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
-              <Button onClick={() => queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}`] })}>
-                Try again
-              </Button>
-              <Link href="/">
-                <Button variant="outline" data-testid="button-trip-error-back-home">
-                  Back to Home
-                </Button>
-              </Link>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  if (!trip) {
-    return (
-      <div className={boundaryWrapperClass}>
-        <Card className="w-full max-w-md mx-4">
-          <CardContent className="pt-6 text-center">
-            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-            <h2 className="text-lg font-semibold mb-2">Trip Not Found</h2>
-            <p className="text-neutral-600 mb-4">
-              The trip you're looking for doesn't exist or you don't have access to it.
-            </p>
-            <Link href="/">
-              <Button data-testid="button-back-home">Back to Home</Button>
-            </Link>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   // Hotel proposal card component
   const HotelProposalCard = ({ proposal }: { proposal: HotelProposalWithDetails }) => {
     const userRanking = getUserRanking(proposal.rankings || [], user?.id || '');
@@ -1786,6 +1708,84 @@ function ProposalsPage({ tripId, embedded = false }: ProposalsPageProps = {}) {
     restaurantProposalsHasError;
 
   const noProposalsAtAll = !hasProposalDataIssues && totalAvailableProposals === 0;
+
+  const boundaryWrapperClass = embedded
+    ? "py-12 flex items-center justify-center"
+    : "min-h-screen bg-neutral-50 flex items-center justify-center";
+
+  if (!tripId) {
+    return (
+      <div className={boundaryWrapperClass}>
+        <Card className="w-full max-w-md mx-4">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="w-12 h-12 text-amber-500 mx-auto mb-4" />
+            <h2 className="text-lg font-semibold mb-2">Trip not specified</h2>
+            <p className="text-neutral-600 mb-4">
+              We couldn't determine which trip to load proposals for. Please go back and pick a trip first.
+            </p>
+            <Link href="/">
+              <Button data-testid="button-trip-missing-back-home">Back to Home</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (authLoading || tripLoading) {
+    return (
+      <div className={boundaryWrapperClass}>
+        <TravelLoading variant="journey" size="lg" text="Loading your proposals..." />
+      </div>
+    );
+  }
+
+  if (tripError) {
+    const parsedError = parseApiError(tripError);
+
+    return (
+      <div className={boundaryWrapperClass}>
+        <Card className="w-full max-w-md mx-4">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+            <h2 className="text-lg font-semibold mb-2">Unable to load trip</h2>
+            <p className="text-neutral-600 mb-4">
+              {parsedError.message || "Something went wrong while loading this trip. Please try again."}
+            </p>
+            <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
+              <Button onClick={() => queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}`] })}>
+                Try again
+              </Button>
+              <Link href="/">
+                <Button variant="outline" data-testid="button-trip-error-back-home">
+                  Back to Home
+                </Button>
+              </Link>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!trip) {
+    return (
+      <div className={boundaryWrapperClass}>
+        <Card className="w-full max-w-md mx-4">
+          <CardContent className="pt-6 text-center">
+            <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+            <h2 className="text-lg font-semibold mb-2">Trip Not Found</h2>
+            <p className="text-neutral-600 mb-4">
+              The trip you're looking for doesn't exist or you don't have access to it.
+            </p>
+            <Link href="/">
+              <Button data-testid="button-back-home">Back to Home</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   const mainContent = (
     <div className="space-y-6">

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3033,6 +3033,24 @@ function FlightCoordination({
     });
   }, []);
 
+  const handleManualDialogOpen = useCallback(() => {
+    resetManualFlightForm();
+    setIsManualDialogOpen(true);
+  }, [resetManualFlightForm]);
+
+  useEffect(() => {
+    if (manualDialogOpenSignal > 0) {
+      handleManualDialogOpen();
+    }
+  }, [handleManualDialogOpen, manualDialogOpenSignal]);
+
+  const handleManualDialogChange = (open: boolean) => {
+    if (!open) {
+      resetManualFlightForm();
+    }
+    setIsManualDialogOpen(open);
+  };
+
   const createFlightMutation = useMutation({
     mutationFn: async (flightData: InsertFlight) => {
       return apiRequest(`/api/trips/${tripId}/flights`, {
@@ -3153,43 +3171,6 @@ function FlightCoordination({
       </div>
     );
   }
-
-
-  const handleManualDialogOpen = useCallback(() => {
-    resetManualFlightForm();
-    setIsManualDialogOpen(true);
-  }, [resetManualFlightForm]);
-
-
-  useEffect(() => {
-    if (manualDialogOpenSignal > 0) {
-      handleManualDialogOpen();
-    }
-  }, [handleManualDialogOpen, manualDialogOpenSignal]);
-
-
-  const handleManualDialogChange = (open: boolean) => {
-    if (!open) {
-      resetManualFlightForm();
-    }
-    setIsManualDialogOpen(open);
-  };
-
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center p-8">
-        <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-blue-600" />
-      </div>
-    );
-  }
-
-  useEffect(() => {
-    if (manualDialogOpenSignal > 0) {
-      handleManualDialogOpen();
-    }
-  }, [handleManualDialogOpen, manualDialogOpenSignal]);
-
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- reorder the FlightCoordination dialog hooks so they are declared before conditional returns and remove duplicate effect calls
- move the ProposalsPage guard clauses after the memoized computations to keep hook usage consistent regardless of props

## Testing
- npm run check *(fails: existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db1f394adc83298e66f129c31b7c42