### PR TITLE
Ensure Pointhound round trips open both legs

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3029,8 +3029,7 @@ function FlightCoordination({
       return;
     }
 
-    markExternalRedirect(FLIGHT_REDIRECT_STORAGE_KEY);
-    window.open(outboundUrl, "_blank", "noopener,noreferrer");
+    const pointhoundUrls = [outboundUrl];
 
     if (isRoundTrip && returnDate) {
       const inboundUrl = buildPointhoundLink(
@@ -3040,9 +3039,14 @@ function FlightCoordination({
       );
 
       if (inboundUrl) {
-        window.open(inboundUrl, "_blank", "noopener,noreferrer");
+        pointhoundUrls.push(inboundUrl);
       }
     }
+
+    markExternalRedirect(FLIGHT_REDIRECT_STORAGE_KEY);
+    pointhoundUrls.forEach((url) => {
+      window.open(url, "_blank", "noopener,noreferrer");
+    });
   }, [
     buildPointhoundLink,
     isRoundTrip,


### PR DESCRIPTION
## Summary
- gather outbound and inbound Pointhound URLs before redirect handling
- open all constructed Pointhound tabs so round-trip searches show both legs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db26f2f58c8329870fed6a6c76b7a0