### PR TITLE
Adjust redirect dialog buttons for clarity

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -2361,17 +2361,17 @@ export default function Trip() {
             </DialogHeader>
             <DialogFooter className="gap-2 sm:flex-row">
               <Button
-                variant="outline"
-                className="sm:flex-1"
-                onClick={handleFlightReturnNo}
-              >
-                No
-              </Button>
-              <Button
                 className="sm:flex-1 bg-gradient-to-r from-primary via-rose-500 to-orange-500 text-white shadow-md hover:opacity-90"
                 onClick={handleFlightReturnYes}
               >
                 Yes
+              </Button>
+              <Button
+                variant="outline"
+                className="sm:flex-1 border border-neutral-200 bg-white text-neutral-700 hover:border-primary hover:text-primary"
+                onClick={handleFlightReturnNo}
+              >
+                No
               </Button>
             </DialogFooter>
           </DialogContent>
@@ -2394,17 +2394,17 @@ export default function Trip() {
             </DialogHeader>
             <DialogFooter className="gap-2 sm:flex-row">
               <Button
-                variant="outline"
-                className="sm:flex-1"
-                onClick={handleHotelReturnNo}
-              >
-                No
-              </Button>
-              <Button
                 className="sm:flex-1 bg-gradient-to-r from-primary via-rose-500 to-orange-500 text-white shadow-md hover:opacity-90"
                 onClick={handleHotelReturnYes}
               >
                 Yes
+              </Button>
+              <Button
+                variant="outline"
+                className="sm:flex-1 border border-neutral-200 bg-white text-neutral-700 hover:border-primary hover:text-primary"
+                onClick={handleHotelReturnNo}
+              >
+                No
               </Button>
             </DialogFooter>
           </DialogContent>


### PR DESCRIPTION
## Summary
- swap the button order in the flight and hotel redirect prompts so “Yes” appears on the left
- restyle the outline button to give the “No” option a solid white background and dark text for visibility

## Testing
- npm run test *(fails: Jest requires ts-node for TypeScript config files in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db2a693618832994f71fe4278574bf