### PR TITLE
Normalize hotel payload keys for Postgres insert

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3127,7 +3127,22 @@ export function setupRoutes(app: Express) {
         tripId,
       });
 
-      const hotel = await storage.addHotel(validatedData, userId);
+      const normalizedValidatedHotelData = normalizeHotelRequestBody(
+        validatedData,
+        tripId,
+      );
+
+      const hotelInsertData: Record<string, unknown> = {
+        ...normalizedValidatedHotelData,
+      };
+
+      for (const key of Object.keys(hotelInsertData)) {
+        if (hotelInsertData[key] === undefined) {
+          hotelInsertData[key] = null;
+        }
+      }
+
+      const hotel = await storage.addHotel(hotelInsertData, userId);
       res.json(hotel);
     } catch (error: unknown) {
       console.error("Error adding hotel:", error);


### PR DESCRIPTION
## Summary
- map saved hotel payloads to snake_case before inserting so Postgres columns match incoming camelCase data
- allow hotel creation to accept normalized payloads while enforcing required fields and converting optional values to NULL

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db3382c6c88329926127f7f8ba312e