### PR TITLE
Fix flight autocomplete input handling

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -82,9 +82,15 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
     }
   };
 
-  // ROOT CAUSE 1 FIX: Sync value prop changes to internal query state
+  // Sync value prop changes to internal query state without interrupting user edits
+  const previousValueRef = useRef(value);
   useEffect(() => {
-    if (value !== undefined && value !== query) {
+    if (value === undefined) {
+      previousValueRef.current = value;
+      return;
+    }
+
+    if (value !== previousValueRef.current) {
       const nextValue = value || "";
       setQuery(nextValue);
 
@@ -92,8 +98,9 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
       lastSelectedQueryRef.current = trimmedValue.length > 0 ? trimmedValue : null;
       isUserEditingRef.current = false;
       lastFetchedQueryKeyRef.current = "";
+      previousValueRef.current = value;
     }
-  }, [value, query]);
+  }, [value]);
 
   const normalisedAllowedTypes = allowedTypes && allowedTypes.length > 0
     ? Array.from(


### PR DESCRIPTION
## Summary
- prevent SmartLocationSearch from overwriting active edits when the external value prop has not changed
- track selection state in flight search inputs so clearing or typing immediately re-enables autocomplete lookups
- update manual flight forms to clear stored codes when editing typed values and to resync when a suggestion is chosen

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd330dc208329ad9868585c65c84c