### PR TITLE
Highlight proposals in calendar and activity dialog

### DIFF
--- a/client/src/components/activity-details-dialog.tsx
+++ b/client/src/components/activity-details-dialog.tsx
@@ -274,40 +274,70 @@ export function ActivityDetailsDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-2xl">
         <DialogHeader>
-          <DialogTitle className="text-xl font-semibold text-neutral-900">
-            {activity?.name ?? "Activity"}
-          </DialogTitle>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <DialogTitle className="text-xl font-semibold text-neutral-900">
+              {activity?.name ?? "Activity"}
+            </DialogTitle>
+            {isProposal && (
+              <Badge className="bg-blue-100 text-blue-800 border border-blue-200">
+                Proposed plan
+              </Badge>
+            )}
+          </div>
           <DialogDescription className="text-sm text-neutral-600">
-            Review the details and let everyone know if you’re joining.
+            {isProposal
+              ? "Gauge interest from the group before scheduling this activity."
+              : "Review the details and let everyone know if you’re joining."}
           </DialogDescription>
         </DialogHeader>
 
         {activity && (
           <div className="space-y-6">
             <div className="grid gap-4 sm:grid-cols-2">
-              <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <div
+                className={cn(
+                  "flex items-start space-x-3 rounded-lg border bg-neutral-50 p-4",
+                  isProposal && "border-blue-200 bg-blue-50",
+                )}
+              >
                 <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
                   <Calendar className="h-4 w-4" />
                 </div>
                 <div>
                   <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">When</p>
-                  <p className="text-sm font-medium text-neutral-900">{formatDateTime(activity.startTime)}</p>
+                  <p className="text-sm font-medium text-neutral-900">
+                    {formatDateTime(activity.startTime)}
+                  </p>
                   {endTimeLabel && (
                     <p className="text-xs text-neutral-500">Ends at {endTimeLabel}</p>
+                  )}
+                  {isProposal && (
+                    <p className="text-xs text-blue-700">
+                      Timing can change once the group confirms.
+                    </p>
                   )}
                 </div>
               </div>
 
-              <div className="flex items-start space-x-3 rounded-lg border border-neutral-200 bg-neutral-50 p-4">
+              <div
+                className={cn(
+                  "flex items-start space-x-3 rounded-lg border bg-neutral-50 p-4",
+                  isProposal && "border-blue-200 bg-blue-50",
+                )}
+              >
                 <div className="mt-1 rounded-md bg-primary/10 p-2 text-primary">
                   <Users className="h-4 w-4" />
                 </div>
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">RSVP summary</p>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-neutral-500">
+                    {isProposal ? "Interest" : "RSVP summary"}
+                  </p>
                   <p className="text-sm font-medium text-neutral-900">
-                    {activity.acceptedCount} going
-                    {activity.pendingCount > 0 && ` • ${activity.pendingCount} pending`}
-                    {activity.declinedCount > 0 && ` • ${activity.declinedCount} declined`}
+                    {activity.acceptedCount} {isProposal ? "interested" : "going"}
+                    {activity.pendingCount > 0
+                      && ` • ${activity.pendingCount} ${isProposal ? "considering" : "pending"}`}
+                    {activity.declinedCount > 0
+                      && ` • ${activity.declinedCount} ${isProposal ? "not interested" : "declined"}`}
                     {waitlistedCount > 0 && ` • ${waitlistedCount} waitlist`}
                   </p>
                 </div>

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -215,7 +215,16 @@ export function CalendarGrid({
                         currentUserId
                           && (activity.postedBy === currentUserId || activity.poster?.id === currentUserId),
                       );
-                      const showProposedChip = Boolean(highlightPersonalProposals && isProposal && isCreator);
+                      const showPersonalProposalChip = Boolean(
+                        highlightPersonalProposals && isProposal && isCreator,
+                      );
+                      const showGlobalProposalChip = Boolean(isProposal && !showPersonalProposalChip);
+                      const rawCategoryColor =
+                        categoryColors[activity.category as keyof typeof categoryColors]
+                        || categoryColors.other;
+                      const [bgClass = "", textClass = "", borderClass = ""] = rawCategoryColor.split(" ");
+                      const resolvedBorderClass = isProposal ? "border border-dashed border-blue-400" : borderClass;
+                      const proposalEnhancements = isProposal ? "bg-blue-50/40 text-blue-900" : "";
 
                       return (
                       <Tooltip key={activity.id}>
@@ -227,7 +236,9 @@ export function CalendarGrid({
                               onActivityClick?.(activity);
                             }}
                             className={`group flex w-full items-center gap-2 rounded-md border px-2 py-1 text-[12px] leading-5 font-medium shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-1 ${
-                              categoryColors[activity.category as keyof typeof categoryColors] || categoryColors.other
+                              [bgClass, textClass, resolvedBorderClass, proposalEnhancements]
+                                .filter(Boolean)
+                                .join(" ")
                             }`}
                             aria-label={formatActivityAriaLabel(activity, day)}
                           >
@@ -237,8 +248,14 @@ export function CalendarGrid({
                             <span className="flex-1 truncate text-left">
                               {activity.name}
                             </span>
-                            {showProposedChip && (
-                              <span className="shrink-0 rounded-sm bg-white/80 px-1 text-[10px] font-semibold uppercase tracking-wide text-blue-700">
+                            {(showPersonalProposalChip || showGlobalProposalChip) && (
+                              <span
+                                className={`shrink-0 rounded-sm px-1 text-[10px] font-semibold uppercase tracking-wide ${
+                                  showPersonalProposalChip
+                                    ? "bg-white/80 text-blue-700"
+                                    : "bg-blue-100 text-blue-800"
+                                }`}
+                              >
                                 Proposed
                               </span>
                             )}


### PR DESCRIPTION
## Summary
- add a proposed-plan badge and tailored copy to the activity details dialog when viewing proposal items
- visually distinguish proposed activities on the group calendar with dashed borders and chips for all viewers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbd81d545c832e8632d34233b3bf87