### PR TITLE
Enable airport-aware flight location search

### DIFF
--- a/client/src/pages/flights.tsx
+++ b/client/src/pages/flights.tsx
@@ -692,9 +692,9 @@ function FlightSearchPanel({
                     <SmartLocationSearch
                       ref={fromInputRef}
                       id="departure"
-                      placeholder="Search departure city"
+                      placeholder="Search departure city or airport"
                       value={departureQuery}
-                      allowedTypes={['city']}
+                      allowedTypes={['city', 'airport']}
                       onQueryChange={handleDepartureQueryChange}
                       onLocationSelect={handleDepartureLocationSelect}
                     />
@@ -740,9 +740,9 @@ function FlightSearchPanel({
                     <Label htmlFor="arrival">To</Label>
                     <SmartLocationSearch
                       id="arrival"
-                      placeholder="Search arrival city"
+                      placeholder="Search arrival city or airport"
                       value={arrivalQuery}
-                      allowedTypes={['city']}
+                      allowedTypes={['city', 'airport']}
                       onQueryChange={handleArrivalQueryChange}
                       onLocationSelect={handleArrivalLocationSelect}
                     />
@@ -2585,6 +2585,7 @@ export default function FlightsPage() {
                       <SmartLocationSearch
                         placeholder="Departure airport (e.g., JFK, New York)"
                         value={flightFormData.departureAirport}
+                        allowedTypes={['airport', 'city']}
                         onQueryChange={(value) => {
                           setFlightFormData((prev) => ({
                             ...prev,
@@ -2610,6 +2611,7 @@ export default function FlightsPage() {
                       <SmartLocationSearch
                         placeholder="Arrival airport (e.g., LAX, Los Angeles)"
                         value={flightFormData.arrivalAirport}
+                        allowedTypes={['airport', 'city']}
                         onQueryChange={(value) => {
                           setFlightFormData((prev) => ({
                             ...prev,

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3286,9 +3286,9 @@ function FlightCoordination({
               <div className="space-y-2">
                 <Label>From</Label>
                 <SmartLocationSearch
-                  placeholder="Search departure city"
+                  placeholder="Search departure city or airport"
                   value={departureQuery}
-                  allowedTypes={['city']}
+                  allowedTypes={['city', 'airport']}
                   onQueryChange={handleDepartureQueryChange}
                   onLocationSelect={handleDepartureLocationSelect}
                 />
@@ -3323,9 +3323,9 @@ function FlightCoordination({
               <div className="space-y-2">
                 <Label>To</Label>
                 <SmartLocationSearch
-                  placeholder="Search arrival city"
+                  placeholder="Search arrival city or airport"
                   value={arrivalQuery}
-                  allowedTypes={['city']}
+                  allowedTypes={['city', 'airport']}
                   onQueryChange={handleArrivalQueryChange}
                   onLocationSelect={handleArrivalLocationSelect}
                 />


### PR DESCRIPTION
## Summary
- allow the Flights tab search inputs to query both cities and airports so autocomplete works again
- extend manual flight entry and trip flight coordination to use airport-aware SmartLocationSearch fields
- update field copy to reflect the broader search scope

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dbdc6e8d348329b68a4563f40241e2