### PR TITLE
Rebuild dashboard overview experience

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,7 @@ import Landing from "@/pages/landing";
 import Login from "@/pages/login";
 import Register from "@/pages/register";
 import Home from "@/pages/home";
+import PlanTrip from "@/pages/plan-trip";
 import Trip from "@/pages/trip";
 import MemberSchedule from "@/pages/member-schedule";
 import Join from "@/pages/join";
@@ -71,6 +72,7 @@ function Router() {
         <Route path="/login" component={Login} />
         <Route path="/register" component={Register} />
         <Route path="/trip/:id" component={Trip} />
+        <Route path="/trips/new" component={PlanTrip} />
         <Route path="/trip/:tripId/members" component={MemberSchedule} />
         <Route path="/trip/:tripId/flights" component={Flights} />
         <Route path="/trips/:tripId/flights" component={Flights} />

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,12 +1,9 @@
-import { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useLocation } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import {
   differenceInCalendarDays,
-  isAfter,
   isBefore,
-  isSameDay,
-  isWithinInterval,
   parseISO,
   startOfDay,
 } from "date-fns";
@@ -16,86 +13,27 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import {
   Avatar,
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar";
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
-import { NotificationIcon } from "@/components/notification-icon";
-import { CreateTripModal } from "@/components/create-trip-modal";
 import { useAuth } from "@/hooks/useAuth";
-import { apiRequest } from "@/lib/queryClient";
 import type { LastConversion } from "@/components/dashboard/converter-types";
-import type {
-  ActivityWithDetails,
-  FlightWithDetails,
-  HotelWithDetails,
-  PackingItem,
-  PackingItemGroupStatus,
-  TripWithDetails,
-  User,
-} from "@shared/schema";
-import { Calendar, ChevronRight, Ellipsis, MapPin, Users } from "lucide-react";
+import type { TripWithDetails } from "@shared/schema";
+import {
+  CalendarDays,
+  Globe2,
+  Plane,
+  UserRound,
+  MapPin,
+} from "lucide-react";
 import { Link } from "wouter";
 
 const CurrencyConverterTool = lazy(() =>
   import("@/components/dashboard/currency-converter-tool"),
 );
 
-type TripSummary = {
-  id: number;
-  name: string;
-  destination: string;
-  startDate: string;
-  endDate: string;
-  travelersCount: number;
-  travelers: { avatar?: string | null; initial: string }[];
-  progressPercent: number;
-  nextUp: NextUpAction | null;
-};
-
-type NextUpAction = {
-  label: string;
-  href: string;
-  ariaLabel: string;
-};
-
-type Insight = {
-  id: string;
-  icon: string;
-  title: string;
-  description: string;
-  action: { label: string; href: string };
-};
-
-type ExpenseBalanceSummary = {
-  owes: number;
-  owed: number;
-  balance: number;
-};
-
-type PackingItemWithMeta = PackingItem & {
-  user: User;
-  groupStatus?: PackingItemGroupStatus;
-};
-
-type HeroTripDetails = {
-  flights: FlightWithDetails[];
-  hotels: HotelWithDetails[];
-  activities: ActivityWithDetails[];
-  expenseBalance: ExpenseBalanceSummary;
-  packingItems: PackingItemWithMeta[];
-};
-
 const LAST_CONVERSION_KEY = "dashboard.converter.last";
-const DISMISSED_INSIGHTS_KEY = "dashboard.dismissed";
-const DISMISS_COOLDOWN_MS = 7 * 24 * 60 * 60 * 1000;
 
 function useMediaQuery(query: string) {
   const [matches, setMatches] = useState(() =>
@@ -116,13 +54,16 @@ function useMediaQuery(query: string) {
   return matches;
 }
 
+function toDateString(value: TripWithDetails["startDate"]): string {
+  return typeof value === "string" ? value : value.toISOString();
+}
+
 function formatDateRange(startDate: string, endDate: string): string {
   const start = parseISO(startDate);
   const end = parseISO(endDate);
 
   const sameYear = start.getFullYear() === end.getFullYear();
-  const sameMonth =
-    sameYear && start.getMonth() === end.getMonth();
+  const sameMonth = sameYear && start.getMonth() === end.getMonth();
 
   const startFormatter = new Intl.DateTimeFormat(undefined, {
     month: "short",
@@ -154,11 +95,11 @@ function getCountdownLabel(startDate: string, endDate: string): string {
   const end = startOfDay(parseISO(endDate));
   const today = startOfDay(new Date());
 
-  if (isSameDay(start, today)) {
+  if (start.getTime() === today.getTime()) {
     return "Starts today";
   }
 
-  if (isAfter(start, today)) {
+  if (start > today) {
     const diff = differenceInCalendarDays(start, today);
     if (diff === 1) {
       return "1 day to go";
@@ -166,7 +107,7 @@ function getCountdownLabel(startDate: string, endDate: string): string {
     return `${diff} days to go`;
   }
 
-  if (isWithinInterval(today, { start, end })) {
+  if (today >= start && today <= end) {
     return "In progress";
   }
 
@@ -178,14 +119,33 @@ function getCountdownLabel(startDate: string, endDate: string): string {
 }
 
 function getTravelersLabel(count: number): string {
-  if (count === 1) {
-    return "1 traveler";
-  }
-  return `${count} travelers`;
+  return count === 1 ? "1 traveler" : `${count} travelers`;
 }
 
-function toDateString(value: TripWithDetails["startDate"]): string {
-  return typeof value === "string" ? value : value.toISOString();
+function calculatePlanningProgress(trip: TripWithDetails): number {
+  const invitesComplete = trip.members.every((member) => member.joinedAt);
+  const start = parseISO(toDateString(trip.startDate));
+  const today = startOfDay(new Date());
+  const daysUntil = differenceInCalendarDays(start, today);
+
+  let progress = 25;
+  if (trip.memberCount > 1) {
+    progress += 15;
+  }
+  if (invitesComplete) {
+    progress += 20;
+  }
+  if (daysUntil <= 30) {
+    progress += 15;
+  }
+  if (daysUntil <= 7) {
+    progress += 10;
+  }
+  if (daysUntil <= 0) {
+    progress += 10;
+  }
+
+  return Math.min(95, Math.max(progress, 20));
 }
 
 function buildTravelerData(
@@ -208,270 +168,9 @@ function buildTravelerData(
   });
 }
 
-function calculatePlanningProgress(
-  trip: TripWithDetails,
-  details?: Partial<HeroTripDetails>,
-): number {
-  const tasks = [
-    { id: "crew", complete: trip.memberCount > 1 },
-    {
-      id: "invitations",
-      complete: trip.members.every((member) => member.joinedAt != null),
-    },
-    {
-      id: "lodging",
-      complete: details ? (details.hotels?.length ?? 0) > 0 : false,
-    },
-    {
-      id: "flights",
-      complete: details ? (details.flights?.length ?? 0) > 0 : false,
-    },
-    {
-      id: "schedule",
-      complete: details
-        ? hasDayOneActivity(details.activities, toDateString(trip.startDate))
-        : false,
-    },
-    {
-      id: "expenses",
-      complete: details ? !hasUnsettledExpenses(details.expenseBalance) : false,
-    },
-    {
-      id: "packing",
-      complete: details ? (details.packingItems?.length ?? 0) > 0 : false,
-    },
-  ];
-
-  const completed = tasks.filter((task) => task.complete).length;
-  const progress = Math.round((completed / tasks.length) * 100);
-  return Math.min(95, Math.max(progress, completed > 0 ? 20 : 8));
-}
-
-function hasDayOneActivity(
-  activities: ActivityWithDetails[] | undefined,
-  startDate: string,
-) {
-  if (!activities || activities.length === 0) {
-    return false;
-  }
-  const start = startOfDay(parseISO(startDate));
-  return activities.some((activity) =>
-    isSameDay(
-      startOfDay(parseISO(toActivityDateString(activity.startTime))),
-      start,
-    ),
-  );
-}
-
-function toActivityDateString(value: ActivityWithDetails["startTime"]): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  return String(value);
-}
-
-function hasUnsettledExpenses(balance?: ExpenseBalanceSummary) {
-  if (!balance) {
-    return false;
-  }
-  return balance.owes > 0 || balance.owed > 0;
-}
-
-function determineNextUp(
-  trip: TripWithDetails,
-  details: HeroTripDetails | null,
-): NextUpAction | null {
-  if (!details) {
-    return null;
-  }
-
-  const tripBasePath = `/trip/${trip.id}`;
-
-  const hasFlights = details.flights.length > 0;
-  const hasHotels = details.hotels.length > 0;
-  if (!hasFlights || !hasHotels) {
-    return {
-      label: "Next up: Confirm reservations",
-      href: `${tripBasePath}?view=${hasFlights ? "hotels" : "flights"}`,
-      ariaLabel: "Open reservations to confirm travel details",
-    };
-  }
-
-  if (!hasDayOneActivity(details.activities, toDateString(trip.startDate))) {
-    return {
-      label: "Next up: Add your day-one plans",
-      href: `${tripBasePath}?view=activities`,
-      ariaLabel: "Open activities to plan the first day",
-    };
-  }
-
-  if (hasUnsettledExpenses(details.expenseBalance)) {
-    return {
-      label: "Next up: Settle outstanding expenses",
-      href: `${tripBasePath}?view=expenses`,
-      ariaLabel: "Open expenses to settle outstanding balances",
-    };
-  }
-
-  const pendingMembers = trip.members.filter((member) => !member.joinedAt);
-  if (pendingMembers.length > 0) {
-    return {
-      label: "Next up: Follow up on invites",
-      href: `${tripBasePath}?view=members`,
-      ariaLabel: "Open members list to manage invitations",
-    };
-  }
-
-  const daysUntil = differenceInCalendarDays(
-    startOfDay(parseISO(toDateString(trip.startDate))),
-    startOfDay(new Date()),
-  );
-  if (daysUntil < 7 && details.packingItems.length === 0) {
-    return {
-      label: "Next up: Start your packing list",
-      href: `${tripBasePath}?view=packing`,
-      ariaLabel: "Open packing list to add items",
-    };
-  }
-
-  return null;
-}
-
-function buildInsights(
-  trip: TripWithDetails | null,
-  details: HeroTripDetails | null,
-  nextUp: NextUpAction | null,
-  dismissed: Record<string, number>,
-): Insight[] {
-  if (!trip || !details) {
-    return [];
-  }
-
-  const now = Date.now();
-  const shouldShow = (id: string) => {
-    const dismissedAt = dismissed[id];
-    if (!dismissedAt) {
-      return true;
-    }
-    return now - dismissedAt > DISMISS_COOLDOWN_MS;
-  };
-
-  const insights: Insight[] = [];
-
-  if (!details.hotels.length && shouldShow("add-hotel")) {
-    insights.push({
-      id: "add-hotel",
-      icon: "bed",
-      title: "Confirm your hotel",
-      description: "Lock in a stay so everyone knows where to meet on arrival.",
-      action: { label: "Add hotel", href: `/trip/${trip.id}?view=hotels` },
-    });
-  }
-
-  if (hasUnsettledExpenses(details.expenseBalance) && shouldShow("expenses")) {
-    insights.push({
-      id: "expenses",
-      icon: "wallet",
-      title: "Split an expense early",
-      description: "Log shared costs before takeoff so everyone stays aligned.",
-      action: { label: "Log expense", href: `/trip/${trip.id}?view=expenses` },
-    });
-  }
-
-  if (
-    !hasDayOneActivity(details.activities, toDateString(trip.startDate)) &&
-    shouldShow("day-one")
-  ) {
-    insights.push({
-      id: "day-one",
-      icon: "calendar",
-      title: "Fill day one",
-      description: "Add a standout activity to kick the trip off together.",
-      action: { label: "Add activity", href: `/trip/${trip.id}?view=activities` },
-    });
-  }
-
-  if (!details.packingItems.length && shouldShow("packing")) {
-    insights.push({
-      id: "packing",
-      icon: "checklist",
-      title: "Prep your packing",
-      description: "Start the shared packing list so teammates can contribute.",
-      action: { label: "View packing", href: `/trip/${trip.id}?view=packing` },
-    });
-  }
-
-  if (!insights.length && nextUp && shouldShow("next-up")) {
-    insights.push({
-      id: "next-up",
-      icon: "sparkle",
-      title: "Keep momentum",
-      description: "Stay on track by completing the highlighted next step.",
-      action: { label: "Go now", href: nextUp.href },
-    });
-  }
-
-  return insights.slice(0, 3);
-}
-
-async function fetchHeroTripDetails(tripId: number): Promise<HeroTripDetails> {
-  const [flightsRes, hotelsRes, activitiesRes, packingRes, balancesRes] = await Promise.all([
-    apiRequest(`/api/trips/${tripId}/flights`),
-    apiRequest(`/api/trips/${tripId}/hotels`),
-    apiRequest(`/api/trips/${tripId}/activities`),
-    apiRequest(`/api/trips/${tripId}/packing`),
-    apiRequest(`/api/trips/${tripId}/expenses/balances`),
-  ]);
-
-  const [flights, hotels, activities, packingItems, expenseBalance] = await Promise.all([
-    flightsRes.json() as Promise<FlightWithDetails[]>,
-    hotelsRes.json() as Promise<HotelWithDetails[]>,
-    activitiesRes.json() as Promise<ActivityWithDetails[]>,
-    packingRes.json() as Promise<PackingItemWithMeta[]>,
-    balancesRes.json() as Promise<ExpenseBalanceSummary>,
-  ]);
-
-  return {
-    flights,
-    hotels,
-    activities,
-    packingItems,
-    expenseBalance,
-  };
-}
-
-function loadDismissedInsights(): Record<string, number> {
-  if (typeof window === "undefined") {
-    return {};
-  }
-  try {
-    const stored = window.localStorage.getItem(DISMISSED_INSIGHTS_KEY);
-    if (!stored) {
-      return {};
-    }
-    const parsed = JSON.parse(stored);
-    if (typeof parsed !== "object" || parsed === null) {
-      return {};
-    }
-    return parsed;
-  } catch (error) {
-    console.warn("Failed to parse dismissed insights", error);
-    return {};
-  }
-}
-
-function storeDismissedInsights(value: Record<string, number>) {
-  if (typeof window === "undefined") {
-    return;
-  }
-  try {
-    window.localStorage.setItem(DISMISSED_INSIGHTS_KEY, JSON.stringify(value));
-  } catch (error) {
-    console.warn("Failed to store dismissed insights", error);
-  }
+function buildDestinationImageUrl(destination: string): string {
+  const query = encodeURIComponent(`${destination} travel landscape`);
+  return `https://source.unsplash.com/1600x900/?${query}`;
 }
 
 function loadLastConversion(): LastConversion | null {
@@ -505,129 +204,33 @@ function storeLastConversion(conversion: LastConversion) {
   }
 }
 
-function TripHeroSkeleton() {
-  return (
-    <Card className="relative overflow-hidden rounded-2xl border-0 bg-white/90 p-6 shadow-sm">
-      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="space-y-4">
-          <Skeleton className="h-8 w-64" />
-          <Skeleton className="h-4 w-48" />
-          <Skeleton className="h-4 w-40" />
-          <Skeleton className="h-2 w-72 rounded-full" />
-        </div>
-        <Skeleton className="h-10 w-32 rounded-full" />
-      </div>
-    </Card>
-  );
-}
+type TripSummary = {
+  id: number;
+  name: string;
+  destination: string;
+  startDate: string;
+  endDate: string;
+  travelersCount: number;
+  travelers: { avatar?: string | null; initial: string }[];
+  progressPercent: number;
+};
 
-function TripGridSkeleton() {
-  return (
-    <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
-      {Array.from({ length: 3 }).map((_, index) => (
-        <Card key={index} className="rounded-2xl border border-slate-200/70 p-5 shadow-none">
-          <Skeleton className="mb-4 h-6 w-44" />
-          <Skeleton className="mb-3 h-4 w-32" />
-          <Skeleton className="h-2 w-full rounded-full" />
-        </Card>
-      ))}
-    </div>
-  );
-}
-
-function InsightSkeleton() {
-  return (
-    <Card className="rounded-2xl border border-slate-200/70 p-5 shadow-none">
-      <Skeleton className="mb-3 h-5 w-32" />
-      <Skeleton className="mb-2 h-4 w-64" />
-      <Skeleton className="h-8 w-24 rounded-full" />
-    </Card>
-  );
-}
-
-function UpcomingTripCard({ trip }: { trip: TripSummary }) {
-  const [, setLocation] = useLocation();
-  const dateLabel = formatDateRange(trip.startDate, trip.endDate);
-  const countdown = getCountdownLabel(trip.startDate, trip.endDate);
-
-  const handleOpen = useCallback(() => {
-    setLocation(`/trip/${trip.id}`);
-  }, [setLocation, trip.id]);
-
-  return (
-    <Card
-      role="link"
-      tabIndex={0}
-      onClick={handleOpen}
-      onKeyDown={(event) => {
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          handleOpen();
-        }
-      }}
-      className="group relative flex cursor-pointer flex-col gap-4 rounded-2xl border border-slate-200/80 bg-white/90 p-5 transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-    >
-      <div className="flex items-start justify-between gap-2">
-        <div className="space-y-1">
-          <h3 className="line-clamp-1 text-lg font-semibold text-slate-900">{trip.name}</h3>
-          <p className="text-sm text-slate-500">{dateLabel}</p>
-        </div>
-        <ChevronRight className="mt-1 h-4 w-4 text-slate-400 transition-transform group-hover:translate-x-1" />
-      </div>
-      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-500">
-        <span className="inline-flex items-center gap-1">
-          <Users className="h-4 w-4" aria-hidden="true" />
-          {getTravelersLabel(trip.travelersCount)}
-        </span>
-        <span className="inline-flex items-center gap-1">
-          <Calendar className="h-4 w-4" aria-hidden="true" />
-          {countdown}
-        </span>
-      </div>
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex -space-x-2">
-          {trip.travelers.slice(0, 3).map((traveler, index) => (
-            <Avatar
-              key={`${trip.id}-avatar-${index}`}
-              className="h-8 w-8 border-2 border-white bg-slate-100"
-            >
-              <AvatarImage
-                src={traveler.avatar ?? undefined}
-                loading="lazy"
-                alt="Traveler avatar"
-              />
-              <AvatarFallback>{traveler.initial}</AvatarFallback>
-            </Avatar>
-          ))}
-        </div>
-        <div className="flex flex-1 flex-col gap-1">
-          <div className="flex items-center justify-between text-xs text-slate-500">
-            <span>Planning {trip.progressPercent}%</span>
-          </div>
-          <Progress
-            value={trip.progressPercent}
-            aria-label={`Planning progress ${trip.progressPercent} percent`}
-            className="h-2 overflow-hidden rounded-full bg-slate-100"
-          />
-        </div>
-      </div>
-    </Card>
-  );
-}
+type Insight = {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  icon: string;
+};
 
 export default function Home() {
   const { user } = useAuth();
   const [, setLocation] = useLocation();
-  const [showCreateModal, setShowCreateModal] = useState(false);
-  const [isConverterOpen, setIsConverterOpen] = useState(false);
   const [lastConversion, setLastConversion] = useState<LastConversion | null>(null);
-  const [dismissedInsights, setDismissedInsights] = useState<Record<string, number>>({});
-
   const isDesktop = useMediaQuery("(min-width: 1024px)");
 
   useEffect(() => {
     setLastConversion(loadLastConversion());
-    setDismissedInsights(loadDismissedInsights());
   }, []);
 
   const {
@@ -640,70 +243,49 @@ export default function Home() {
     retry: false,
   });
 
-  const now = startOfDay(new Date());
+  const today = startOfDay(new Date());
 
-  const { upcomingTrips, primaryTrip, pastTrips } = useMemo(() => {
+  const {
+    primaryTrip,
+    upcomingTrips,
+    highlightStats,
+  } = useMemo(() => {
     const allTrips = trips ?? [];
-    const futureTrips = allTrips
-      .filter((trip) => !isBefore(parseISO(toDateString(trip.endDate)), now))
-      .sort(
-        (a, b) =>
-          parseISO(toDateString(a.startDate)).getTime() -
-          parseISO(toDateString(b.startDate)).getTime(),
-      );
-    const selectedPrimary = futureTrips.length > 0 ? futureTrips[0] : null;
-    const remainingUpcoming = selectedPrimary
-      ? futureTrips.slice(1)
-      : futureTrips;
-    const previousTrips = allTrips
-      .filter((trip) => isBefore(parseISO(toDateString(trip.endDate)), now))
-      .sort(
-        (a, b) =>
-          parseISO(toDateString(b.startDate)).getTime() -
-          parseISO(toDateString(a.startDate)).getTime(),
-      );
+    const sorted = [...allTrips].sort(
+      (a, b) =>
+        parseISO(toDateString(a.startDate)).getTime() -
+        parseISO(toDateString(b.startDate)).getTime(),
+    );
+
+    const futureTrips = sorted.filter(
+      (trip) => !isBefore(parseISO(toDateString(trip.endDate)), today),
+    );
+    const primary = futureTrips[0] ?? null;
+
+    const highlightUpcomingCount = futureTrips.length;
+    const destinationSet = new Set(sorted.map((trip) => trip.destination).filter(Boolean));
+    const destinationsCount = destinationSet.size;
+
+    const nextTripDays = primary
+      ? Math.max(0, differenceInCalendarDays(parseISO(toDateString(primary.startDate)), today))
+      : null;
+
+    const currentYear = today.getFullYear();
+    const travelersThisYear = sorted
+      .filter((trip) => parseISO(toDateString(trip.startDate)).getFullYear() === currentYear)
+      .reduce((total, trip) => total + (trip.memberCount ?? 0), 0);
 
     return {
-      upcomingTrips: remainingUpcoming,
-      primaryTrip: selectedPrimary,
-      pastTrips: previousTrips,
+      primaryTrip: primary,
+      upcomingTrips: futureTrips,
+      highlightStats: {
+        upcoming: highlightUpcomingCount,
+        destinations: destinationsCount,
+        daysToNext: nextTripDays,
+        travelersThisYear,
+      },
     };
-  }, [now, trips]);
-
-  const heroDetailsQuery = useQuery<HeroTripDetails>({
-    queryKey: ["dashboard", "hero", primaryTrip?.id],
-    queryFn: () => fetchHeroTripDetails(primaryTrip!.id),
-    enabled: Boolean(primaryTrip),
-    retry: false,
-  });
-
-  const heroDetails = heroDetailsQuery.data ?? null;
-  const heroNextUp = primaryTrip
-    ? determineNextUp(primaryTrip, heroDetails)
-    : null;
-
-  const insights = useMemo(
-    () => buildInsights(primaryTrip ?? null, heroDetails, heroNextUp, dismissedInsights),
-    [dismissedInsights, heroDetails, heroNextUp, primaryTrip],
-  );
-
-  const heroSummary: TripSummary | null = useMemo(() => {
-    if (!primaryTrip) {
-      return null;
-    }
-    const progress = calculatePlanningProgress(primaryTrip, heroDetails ?? undefined);
-    return {
-      id: primaryTrip.id,
-      name: primaryTrip.name || primaryTrip.destination,
-      destination: primaryTrip.destination,
-      startDate: toDateString(primaryTrip.startDate),
-      endDate: toDateString(primaryTrip.endDate),
-      travelersCount: primaryTrip.memberCount,
-      travelers: buildTravelerData(primaryTrip.members),
-      progressPercent: progress,
-      nextUp: heroNextUp,
-    };
-  }, [heroDetails, heroNextUp, primaryTrip]);
+  }, [today, trips]);
 
   const upcomingSummaries: TripSummary[] = useMemo(() => {
     return upcomingTrips.map((trip) => ({
@@ -715,448 +297,361 @@ export default function Home() {
       travelersCount: trip.memberCount,
       travelers: buildTravelerData(trip.members),
       progressPercent: calculatePlanningProgress(trip),
-      nextUp: null,
     }));
   }, [upcomingTrips]);
 
-  const handleOpenTrip = useCallback(
-    (tripId: number) => {
-      setLocation(`/trip/${tripId}`);
-    },
-    [setLocation],
-  );
+  const insights: Insight[] = useMemo(() => {
+    if (!primaryTrip) {
+      return [];
+    }
+    const base = `/trip/${primaryTrip.id}`;
+    return [
+      {
+        id: "invite",
+        title: "Invite your crew",
+        description: "Make sure everyone is looped in before takeoff.",
+        href: `${base}?view=members`,
+        icon: "👥",
+      },
+      {
+        id: "schedule",
+        title: "Review day one",
+        description: "Double-check the first day’s plans to start strong.",
+        href: `${base}?view=activities`,
+        icon: "🗓️",
+      },
+      {
+        id: "expenses",
+        title: "Track shared costs",
+        description: "Peek at expenses so there are no surprises later.",
+        href: `${base}?view=expenses`,
+        icon: "💳",
+      },
+    ];
+  }, [primaryTrip]);
 
-  const handleDismissInsight = useCallback(
-    (id: string) => {
-      setDismissedInsights((prev) => {
-        const next = { ...prev, [id]: Date.now() };
-        storeDismissedInsights(next);
-        return next;
-      });
-    },
-    [],
-  );
+  const heroBackground = primaryTrip
+    ? buildDestinationImageUrl(primaryTrip.destination)
+    : null;
 
-  const handleConversionUpdate = useCallback((conversion: LastConversion) => {
+  const nextTripChip = primaryTrip
+    ? `Next up: ${primaryTrip.name || primaryTrip.destination} · ${formatDateRange(
+        toDateString(primaryTrip.startDate),
+        toDateString(primaryTrip.endDate),
+      )}`
+    : null;
+
+  const handlePlanTrip = () => {
+    setLocation("/trips/new");
+  };
+
+  const handleOpenTrip = (tripId: number) => {
+    setLocation(`/trip/${tripId}`);
+  };
+
+  const handleConversionUpdate = (conversion: LastConversion) => {
     setLastConversion(conversion);
     storeLastConversion(conversion);
-  }, []);
+  };
 
   return (
-    <div className="relative min-h-screen">
-      <header className="sticky top-0 z-20 border-b border-slate-200/60 bg-white/85 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
-          <Link href="/" className="flex items-center gap-2 text-lg font-semibold text-slate-900">
-            <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-sky-500 text-white shadow-sm">
-              VS
-            </span>
-            <span className="hidden sm:inline">VacationSync</span>
-          </Link>
-          <h1 className="text-xl font-semibold text-slate-900 sm:text-2xl">Dashboard</h1>
-          <div className="flex items-center gap-3">
-            <NotificationIcon />
-            <Link
-              href="/profile"
-              className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-              aria-label="Open profile"
-            >
-              <Avatar className="h-10 w-10 border-2 border-white shadow-sm">
-                <AvatarImage src={user?.profileImageUrl ?? undefined} alt="Profile" />
-                <AvatarFallback>
-                  {user?.firstName?.[0]?.toUpperCase() ?? user?.email?.[0]?.toUpperCase() ?? "U"}
-                </AvatarFallback>
-              </Avatar>
-            </Link>
+    <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100 pb-20">
+      <section className="relative isolate h-[320px] w-full overflow-hidden sm:h-[380px] lg:h-[420px]">
+        <div className="absolute inset-0">
+          {heroBackground ? (
+            <img
+              src={heroBackground}
+              alt=""
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="h-full w-full bg-gradient-to-br from-[#ff7e5f] via-[#feb47b] to-[#654ea3]" />
+          )}
+          <div className="absolute inset-0 bg-slate-900/45" aria-hidden="true" />
+        </div>
+        <div className="relative mx-auto flex h-full max-w-6xl items-end px-6 pb-10">
+          <div className="max-w-xl rounded-3xl border border-white/20 bg-white/10 p-8 text-white shadow-xl backdrop-blur">
+            <div className="flex flex-col gap-3">
+              <div className="text-sm uppercase tracking-[0.2em] text-white/80">Your travel hub</div>
+              <h1 className="text-4xl font-semibold sm:text-5xl">Dashboard</h1>
+              <p className="text-base text-white/80">
+                Plan new trips and see what’s next—all in one place.
+              </p>
+              <div className="flex flex-wrap items-center gap-3">
+                <Button
+                  onClick={handlePlanTrip}
+                  className="rounded-full bg-gradient-to-r from-[#ff7e5f] via-[#feb47b] to-[#654ea3] px-6 text-base font-semibold text-white shadow-lg hover:opacity-90"
+                >
+                  Plan a New Trip
+                </Button>
+                {nextTripChip ? (
+                  <span className="rounded-full bg-white/20 px-3 py-1 text-xs font-medium text-white/90">
+                    {nextTripChip}
+                  </span>
+                ) : null}
+              </div>
+            </div>
           </div>
         </div>
-      </header>
+      </section>
 
-      <main className="mx-auto flex w-full max-w-6xl flex-col gap-10 px-6 py-8 lg:flex-row">
-        <div className="flex-1 space-y-10">
+      <div className="mx-auto -mt-16 flex max-w-6xl flex-col gap-12 px-6 sm:-mt-20">
+        <section aria-labelledby="dashboard-highlights" className="rounded-3xl border border-white/40 bg-white/90 p-6 shadow-lg backdrop-blur">
+          <h2 id="dashboard-highlights" className="sr-only">
+            Highlights
+          </h2>
           {isLoading ? (
-            <TripHeroSkeleton />
-          ) : error ? (
-            <Card className="rounded-2xl border border-amber-200 bg-amber-50/80 p-6 text-sm text-amber-800">
-              We’re having trouble loading your trips right now. Try refreshing the page.
-            </Card>
-          ) : heroSummary ? (
-            <section aria-labelledby="primary-trip-heading">
-              <Card
-                role="group"
-                className="relative overflow-hidden rounded-2xl border-0 bg-gradient-to-br from-white via-white to-sky-50 p-6 shadow-sm transition-shadow hover:shadow-md"
-              >
-                <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.18),_transparent_60%)]" />
-                <div className="flex flex-col gap-6">
-                  <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="flex-1 space-y-3">
-                      <h2
-                        id="primary-trip-heading"
-                        className="text-3xl font-semibold text-slate-900"
-                        title={heroSummary.name}
-                      >
-                        {heroSummary.name}
-                      </h2>
-                      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
-                        <span className="inline-flex items-center gap-1">
-                          <Calendar className="h-4 w-4" aria-hidden="true" />
-                          {formatDateRange(heroSummary.startDate, heroSummary.endDate)}
-                        </span>
-                        <span className="inline-flex items-center gap-1">
-                          <Users className="h-4 w-4" aria-hidden="true" />
-                          {getTravelersLabel(heroSummary.travelersCount)}
-                        </span>
-                        <span className="inline-flex items-center gap-1">
-                          <MapPin className="h-4 w-4" aria-hidden="true" />
-                          {getCountdownLabel(heroSummary.startDate, heroSummary.endDate)}
-                        </span>
-                      </div>
-                    </div>
-                    <div className="flex items-start gap-3">
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-10 w-10 rounded-full bg-white/60 text-slate-500 hover:bg-white"
-                            aria-label="Open trip quick actions"
-                          >
-                            <Ellipsis className="h-5 w-5" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" className="w-48">
-                          <DropdownMenuItem onClick={() => setLocation(`/trip/${heroSummary.id}?view=packing`)}>
-                            View packing list
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setLocation(`/trip/${heroSummary.id}?view=activities`)}>
-                            Finalize activities
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setLocation(`/trip/${heroSummary.id}?view=expenses`)}>
-                            Log expense
-                          </DropdownMenuItem>
-                          <DropdownMenuItem onClick={() => setLocation(`/trip/${heroSummary.id}?view=members`)}>
-                            Invite travelers
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
-                      <Button
-                        onClick={() => handleOpenTrip(heroSummary.id)}
-                        className="rounded-full px-5"
-                      >
-                        Open trip
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div className="flex flex-col gap-4">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div className="flex items-center gap-3">
-                        <div className="flex -space-x-2">
-                          {heroSummary.travelers.slice(0, 3).map((traveler, index) => (
-                            <Avatar
-                              key={`hero-avatar-${index}`}
-                              className="h-10 w-10 border-2 border-white bg-slate-100"
-                            >
-                              <AvatarImage
-                                src={traveler.avatar ?? undefined}
-                                loading="lazy"
-                                alt="Traveler avatar"
-                              />
-                              <AvatarFallback>{traveler.initial}</AvatarFallback>
-                            </Avatar>
-                          ))}
-                        </div>
-                        <Badge variant="secondary" className="rounded-full bg-white/70 text-slate-600">
-                          Planning {heroSummary.progressPercent}%
-                        </Badge>
-                      </div>
-                      {heroSummary.nextUp ? (
-                        <Link
-                          href={heroSummary.nextUp.href}
-                          aria-label={heroSummary.nextUp.ariaLabel}
-                          className="inline-flex items-center gap-1 text-sm font-medium text-sky-600 hover:text-sky-700"
-                        >
-                          {heroSummary.nextUp.label}
-                          <ChevronRight className="h-4 w-4" />
-                        </Link>
-                      ) : null}
-                    </div>
-                    <Progress
-                      value={heroSummary.progressPercent}
-                      aria-label={`Planning progress ${heroSummary.progressPercent} percent`}
-                      className="h-2 overflow-hidden rounded-full bg-white/60"
-                    />
-                    {isSameDay(startOfDay(parseISO(heroSummary.startDate)), startOfDay(new Date())) ? (
-                      <Link
-                        href={`/trip/${heroSummary.id}?view=schedule`}
-                        className="text-sm text-sky-600 hover:text-sky-700"
-                      >
-                        View today’s schedule
-                      </Link>
-                    ) : null}
-                  </div>
-                </div>
-              </Card>
-            </section>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <Card
+                  key={`highlight-skeleton-${index}`}
+                  className="rounded-2xl border border-slate-100/60 bg-white/70 p-6 shadow-sm"
+                >
+                  <Skeleton className="h-5 w-10" />
+                  <Skeleton className="mt-4 h-6 w-20" />
+                  <Skeleton className="mt-2 h-4 w-24" />
+                </Card>
+              ))}
+            </div>
           ) : (
-            <section>
-              <Card className="flex flex-col items-center justify-center gap-4 rounded-2xl border-0 bg-white/90 p-10 text-center shadow-sm">
-                <div className="text-3xl">🧭</div>
-                <h2 className="text-2xl font-semibold text-slate-900">Plan your first trip</h2>
-                <p className="max-w-md text-sm text-slate-600">
-                  Create a trip to see it highlighted here with one clear next step to keep you moving.
-                </p>
-                <Button onClick={() => setShowCreateModal(true)} className="rounded-full px-6">
-                  Plan a trip
-                </Button>
-              </Card>
-            </section>
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <HighlightCard
+                icon={<Plane className="h-5 w-5 text-[#ff7e5f]" aria-hidden="true" />}
+                value={highlightStats.upcoming}
+                label="Upcoming trips"
+                href={primaryTrip ? `/trip/${primaryTrip.id}` : "/"}
+              />
+              <HighlightCard
+                icon={<Globe2 className="h-5 w-5 text-[#ff7e5f]" aria-hidden="true" />}
+                value={highlightStats.destinations}
+                label="Destinations"
+                href={primaryTrip ? `/trip/${primaryTrip.id}` : "/"}
+              />
+              <HighlightCard
+                icon={<CalendarDays className="h-5 w-5 text-[#ff7e5f]" aria-hidden="true" />}
+                value={highlightStats.daysToNext ?? "—"}
+                label="Days to next trip"
+                href={primaryTrip ? `/trip/${primaryTrip.id}` : "/"}
+              />
+              <HighlightCard
+                icon={<UserRound className="h-5 w-5 text-[#ff7e5f]" aria-hidden="true" />}
+                value={highlightStats.travelersThisYear}
+                label="Travelers this year"
+                href={primaryTrip ? `/trip/${primaryTrip.id}?view=members` : "/"}
+              />
+            </div>
           )}
+        </section>
 
-          <section className="space-y-4" aria-labelledby="upcoming-trips-heading">
-            <div className="flex items-center justify-between">
-              <h2 id="upcoming-trips-heading" className="text-xl font-semibold text-slate-900">
+        <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="space-y-10">
+            <section aria-labelledby="upcoming-trips-heading" className="space-y-4">
+              <h2 id="upcoming-trips-heading" className="text-2xl font-semibold text-slate-900">
                 Upcoming trips
               </h2>
-              {upcomingSummaries.length === 0 && primaryTrip && (
-                <p className="text-sm text-slate-500">You’re all set for now.</p>
-              )}
-            </div>
-            {isLoading ? (
-              <TripGridSkeleton />
-            ) : upcomingSummaries.length > 0 ? (
-              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-                {upcomingSummaries.map((trip) => (
-                  <UpcomingTripCard key={trip.id} trip={trip} />
-                ))}
-              </div>
-            ) : !primaryTrip ? (
-              <Card className="rounded-2xl border border-dashed border-slate-300 p-8 text-center">
-                <p className="text-sm text-slate-500">
-                  Future plans will appear here once you’ve created a trip.
-                </p>
-              </Card>
-            ) : null}
-            {upcomingSummaries.length === 0 && primaryTrip ? (
-              <div className="flex justify-center pt-2">
-                <Button variant="ghost" onClick={() => setShowCreateModal(true)} className="rounded-full">
-                  Plan a trip
-                </Button>
-              </div>
-            ) : null}
-          </section>
 
-          {pastTrips.length > 0 ? (
-            <section className="space-y-4" aria-labelledby="past-trips-heading">
-              <div className="flex items-center justify-between">
-                <h2 id="past-trips-heading" className="text-xl font-semibold text-slate-900">
-                  Recent trips
-                </h2>
-              </div>
-              <div className="grid gap-3 md:grid-cols-2">
-                {pastTrips.slice(0, 4).map((trip) => (
-                  <Card
-                    key={trip.id}
-                    onClick={() => handleOpenTrip(trip.id)}
-                    className="flex cursor-pointer flex-col gap-2 rounded-2xl border border-slate-200/80 bg-white/80 p-5 transition-shadow hover:shadow-md"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div>
-                        <h3 className="text-base font-semibold text-slate-900">{trip.name || trip.destination}</h3>
-                        <p className="text-sm text-slate-500">{formatDateRange(toDateString(trip.startDate), toDateString(trip.endDate))}</p>
-                      </div>
-                      <ChevronRight className="h-4 w-4 text-slate-400" />
-                    </div>
-                    <p className="text-xs text-slate-500">
-                      {differenceInCalendarDays(now, parseISO(toDateString(trip.endDate)))} days ago
-                    </p>
-                  </Card>
-                ))}
-              </div>
-            </section>
-          ) : null}
-
-          <section className="space-y-4" aria-labelledby="insights-heading">
-            <div className="flex items-center justify-between">
-              <h2 id="insights-heading" className="text-xl font-semibold text-slate-900">
-                Helpful insights
-              </h2>
-              {heroDetailsQuery.isError ? (
-                <span className="text-xs text-amber-600">
-                  Some suggestions aren’t available right now. Try again later.
-                </span>
+              {error ? (
+                <Card className="rounded-3xl border border-amber-200 bg-amber-50/80 p-6 text-amber-900">
+                  We’re having trouble loading your trips right now. Try refreshing the page.
+                </Card>
               ) : null}
-            </div>
-            {heroDetailsQuery.isLoading ? (
-              <div className="grid gap-3 md:grid-cols-2">
-                {Array.from({ length: 2 }).map((_, index) => (
-                  <InsightSkeleton key={index} />
-                ))}
-              </div>
-            ) : insights.length > 0 ? (
-              <div className="grid gap-3 md:grid-cols-2">
-                {insights.map((insight) => (
-                  <Card key={insight.id} className="flex flex-col gap-3 rounded-2xl border border-slate-200/80 bg-white/90 p-5">
-                    <div className="flex items-start justify-between gap-4">
-                      <div>
-                        <h3 className="text-base font-semibold text-slate-900">{insight.title}</h3>
-                        <p className="text-sm text-slate-600">{insight.description}</p>
+
+              {isLoading ? (
+                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <Card key={`trip-skeleton-${index}`} className="overflow-hidden rounded-3xl border border-slate-100 bg-white p-4 shadow-sm">
+                      <Skeleton className="aspect-video w-full rounded-2xl" />
+                      <div className="mt-4 space-y-2">
+                        <Skeleton className="h-5 w-2/3" />
+                        <Skeleton className="h-4 w-1/2" />
+                        <Skeleton className="h-2 w-full rounded-full" />
                       </div>
-                      <button
-                        className="text-xs text-slate-400 hover:text-slate-500"
-                        onClick={() => handleDismissInsight(insight.id)}
-                        aria-label="Dismiss insight"
-                      >
-                        ×
-                      </button>
-                    </div>
-                    <Button
-                      variant="secondary"
-                      className="w-fit rounded-full bg-slate-900 text-white hover:bg-slate-800"
-                      onClick={() => setLocation(insight.action.href)}
-                    >
-                      {insight.action.label}
-                    </Button>
-                  </Card>
-                ))}
-              </div>
-            ) : (
-              <Card className="rounded-2xl border border-slate-200/80 bg-white/80 p-6 text-sm text-slate-600">
-                We’ll surface new tips here as soon as we detect something that needs your attention.
-              </Card>
-            )}
-          </section>
-        </div>
-
-        <aside className="lg:w-[320px] lg:flex lg:flex-col lg:gap-6">
-          <section className="hidden lg:block">
-            <div className="rounded-2xl border border-slate-200/80 bg-white/80 p-5 shadow-sm">
-              <button
-                onClick={() => setIsConverterOpen(true)}
-                className="flex w-full items-center justify-between gap-4 rounded-xl border border-slate-200/60 bg-slate-50/70 px-4 py-3 text-left text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500"
-                aria-expanded={isConverterOpen}
-              >
-                <span>Convert currency 💱</span>
-                <div className="flex items-center gap-3 text-xs text-slate-500">
-                  {lastConversion ? (
-                    <span className="hidden sm:inline">
-                      {formatMiniConversion(lastConversion)}
-                    </span>
-                  ) : null}
-                  <ChevronRight className="h-4 w-4" />
+                    </Card>
+                  ))}
                 </div>
-              </button>
-              <div className="mt-4">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="outline" className="w-full justify-between rounded-xl border-slate-200 text-slate-600">
-                      <span>+ Add</span>
-                      <ChevronRight className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
-                    <DropdownMenuItem onClick={() => primaryTrip && setLocation(`/trip/${primaryTrip.id}?view=activities`)}>
-                      Activity
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => primaryTrip && setLocation(`/trip/${primaryTrip.id}?view=expenses`)}>
-                      Expense
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => primaryTrip && setLocation(`/trip/${primaryTrip.id}?view=hotels`)}>
-                      Hotel
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={() => primaryTrip && setLocation(`/trip/${primaryTrip.id}?view=flights`)}>
-                      Flight
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            </div>
-          </section>
-        </aside>
-      </main>
+              ) : upcomingSummaries.length > 0 ? (
+                <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+                  {upcomingSummaries.map((trip) => (
+                    <TripCard key={trip.id} trip={trip} onOpen={() => handleOpenTrip(trip.id)} />
+                  ))}
+                </div>
+              ) : (
+                <Card className="flex flex-col items-center justify-center gap-5 rounded-3xl border border-dashed border-slate-200 bg-white p-10 text-center shadow-sm">
+                  <div className="text-5xl">🌅</div>
+                  <h3 className="text-2xl font-semibold text-slate-900">Ready for your next getaway?</h3>
+                  <p className="max-w-md text-sm text-slate-500">
+                    Start planning a new adventure to see it appear here with all the essentials at a glance.
+                  </p>
+                  <Button
+                    onClick={handlePlanTrip}
+                    className="rounded-full bg-gradient-to-r from-[#ff7e5f] via-[#feb47b] to-[#654ea3] px-6 text-white shadow-md hover:opacity-90"
+                  >
+                    Plan a New Trip
+                  </Button>
+                </Card>
+              )}
+            </section>
 
-      {!isDesktop && (
-        <button
-          onClick={() => setIsConverterOpen(true)}
-          className="fixed bottom-6 right-6 z-30 inline-flex h-14 w-14 items-center justify-center rounded-full bg-sky-500 text-2xl text-white shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300"
-          aria-label="Open currency converter"
-        >
-          💱
-        </button>
-      )}
+            {insights.length > 0 ? (
+              <section aria-labelledby="insights-heading" className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h2 id="insights-heading" className="text-2xl font-semibold text-slate-900">
+                    Helpful insights
+                  </h2>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  {insights.map((insight) => (
+                    <Link key={insight.id} href={insight.href} className="group">
+                      <Card className="flex h-full flex-col justify-between overflow-hidden rounded-3xl border border-slate-100 bg-white p-6 shadow-sm transition-transform group-hover:-translate-y-1 group-hover:shadow-md">
+                        <div className="space-y-3">
+                          <span className="text-2xl" aria-hidden="true">
+                            {insight.icon}
+                          </span>
+                          <h3 className="text-lg font-semibold text-slate-900">{insight.title}</h3>
+                          <p className="text-sm text-slate-500">{insight.description}</p>
+                        </div>
+                        <span className="mt-6 text-sm font-semibold text-[#ff7e5f]">Go to trip →</span>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ) : null}
+          </div>
 
-      <Suspense fallback={null}>
-        <CurrencyConverterSheet
-          open={isConverterOpen}
-          onOpenChange={setIsConverterOpen}
-          isDesktop={isDesktop}
-          lastConversion={lastConversion}
-          onConversion={handleConversionUpdate}
-        />
-      </Suspense>
+          <aside className="space-y-6">
+            <section aria-labelledby="converter-heading">
+              <Card className="overflow-hidden rounded-3xl border border-slate-100 bg-white p-6 shadow-sm">
+                <div className="mb-4 flex items-center justify-between">
+                  <div>
+                    <h2 id="converter-heading" className="text-lg font-semibold text-slate-900">
+                      Currency converter
+                    </h2>
+                    <p className="text-sm text-slate-500">
+                      Quick conversions for the road.
+                    </p>
+                  </div>
+                </div>
+                <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
+                  <CurrencyConverterTool
+                    onClose={() => undefined}
+                    lastConversion={lastConversion}
+                    onConversion={handleConversionUpdate}
+                    mobile={!isDesktop}
+                  />
+                </Suspense>
+              </Card>
+            </section>
 
-      <CreateTripModal open={showCreateModal} onOpenChange={setShowCreateModal} />
+            {primaryTrip ? (
+              <Card className="rounded-3xl border border-slate-100 bg-gradient-to-br from-[#ffecd2] via-white to-[#fcb69f] p-6 shadow-sm">
+                <div className="flex flex-col gap-3">
+                  <span className="text-sm font-semibold uppercase tracking-wide text-slate-700">
+                    Next destination
+                  </span>
+                  <h3 className="text-xl font-semibold text-slate-900">
+                    {primaryTrip.name || primaryTrip.destination}
+                  </h3>
+                  <div className="flex items-center gap-2 text-sm text-slate-700">
+                    <MapPin className="h-4 w-4" />
+                    {primaryTrip.destination}
+                  </div>
+                  <div className="text-sm text-slate-600">
+                    {formatDateRange(
+                      toDateString(primaryTrip.startDate),
+                      toDateString(primaryTrip.endDate),
+                    )}
+                  </div>
+                </div>
+              </Card>
+            ) : null}
+          </aside>
+        </div>
+      </div>
     </div>
   );
 }
 
-type CurrencyConverterSheetProps = {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  isDesktop: boolean;
-  lastConversion: LastConversion | null;
-  onConversion: (conversion: LastConversion) => void;
+type HighlightCardProps = {
+  icon: ReactNode;
+  value: number | string | null;
+  label: string;
+  href: string;
 };
 
-function CurrencyConverterSheet({
-  open,
-  onOpenChange,
-  isDesktop,
-  lastConversion,
-  onConversion,
-}: CurrencyConverterSheetProps) {
-  if (!open) {
-    return null;
-  }
-
-  if (isDesktop) {
-    return (
-      <div className="fixed inset-0 z-40 flex items-start justify-center bg-slate-900/30 p-6">
-        <div className="w-full max-w-md overflow-hidden rounded-3xl bg-white shadow-xl">
-          <CurrencyConverterTool
-            onClose={() => onOpenChange(false)}
-            lastConversion={lastConversion}
-            onConversion={onConversion}
-          />
-        </div>
-      </div>
-    );
-  }
-
+function HighlightCard({ icon, value, label, href }: HighlightCardProps) {
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="bottom" className="h-[85vh] rounded-t-3xl p-0">
-        <SheetHeader className="px-6 pt-6">
-          <SheetTitle className="text-lg font-semibold text-slate-900">
-            Convert currency
-          </SheetTitle>
-        </SheetHeader>
-        <div className="h-full overflow-y-auto px-4 pb-8">
-          <CurrencyConverterTool
-            onClose={() => onOpenChange(false)}
-            lastConversion={lastConversion}
-            onConversion={onConversion}
-            mobile
-          />
+    <Link href={href} className="group">
+      <Card className="flex h-full flex-col justify-between gap-3 rounded-3xl border border-slate-100 bg-white/80 p-6 shadow-sm transition-shadow group-hover:shadow-md">
+        <div className="flex items-center justify-between">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-[#ff7e5f]/15 via-[#feb47b]/10 to-[#654ea3]/15">
+            {icon}
+          </div>
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+            View
+          </span>
         </div>
-      </SheetContent>
-    </Sheet>
+        <div>
+          <div className="text-3xl font-semibold text-slate-900">
+            {value ?? "—"}
+          </div>
+          <p className="mt-1 text-sm text-slate-500">{label}</p>
+        </div>
+      </Card>
+    </Link>
   );
 }
 
-function formatMiniConversion(conversion: LastConversion) {
-  const amountFormatter = new Intl.NumberFormat(undefined, {
-    maximumFractionDigits: 2,
-  });
-  return `${amountFormatter.format(conversion.amount)} ${conversion.from} → ${amountFormatter.format(conversion.result)} ${conversion.to}`;
-}
+type TripCardProps = {
+  trip: TripSummary;
+  onOpen: () => void;
+};
 
+function TripCard({ trip, onOpen }: TripCardProps) {
+  const imageUrl = buildDestinationImageUrl(trip.destination);
+  return (
+    <Card className="group flex h-full flex-col overflow-hidden rounded-3xl border border-slate-100 bg-white shadow-sm transition-transform hover:-translate-y-1 hover:shadow-lg">
+      <div className="relative aspect-video overflow-hidden">
+        <img src={imageUrl} alt="" className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105" loading="lazy" />
+        <div className="absolute inset-0 bg-gradient-to-t from-slate-900/60 via-slate-900/10 to-transparent" aria-hidden="true" />
+        <div className="absolute bottom-3 left-4 right-4 flex flex-wrap items-center gap-2 text-xs font-medium text-white">
+          <Badge className="rounded-full bg-white/80 px-3 py-1 text-xs font-medium text-slate-700 backdrop-blur">
+            {formatDateRange(trip.startDate, trip.endDate)}
+          </Badge>
+          <Badge className="rounded-full bg-white/60 px-3 py-1 text-xs font-medium text-slate-700 backdrop-blur">
+            {getTravelersLabel(trip.travelersCount)}
+          </Badge>
+        </div>
+      </div>
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <div className="space-y-2">
+          <h3 className="text-xl font-semibold text-slate-900" title={trip.name}>
+            {trip.name}
+          </h3>
+          <p className="text-sm text-slate-500">{getCountdownLabel(trip.startDate, trip.endDate)}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <div className="flex -space-x-2">
+            {trip.travelers.slice(0, 3).map((traveler, index) => (
+              <Avatar key={`trip-${trip.id}-traveler-${index}`} className="h-8 w-8 border-2 border-white bg-slate-100">
+                <AvatarImage src={traveler.avatar ?? undefined} alt="" loading="lazy" />
+                <AvatarFallback>{traveler.initial}</AvatarFallback>
+              </Avatar>
+            ))}
+          </div>
+          <Badge variant="secondary" className="rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+            Planning {trip.progressPercent}%
+          </Badge>
+        </div>
+        <Progress value={trip.progressPercent} className="h-2 rounded-full bg-slate-100" />
+        <Button
+          onClick={onOpen}
+          className="mt-auto rounded-full bg-gradient-to-r from-[#ff7e5f] via-[#feb47b] to-[#654ea3] text-white shadow-md hover:opacity-90"
+        >
+          Open trip
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/client/src/pages/plan-trip.tsx
+++ b/client/src/pages/plan-trip.tsx
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { useLocation } from "wouter";
+import { CreateTripModal } from "@/components/create-trip-modal";
+
+export default function PlanTrip() {
+  const [, setLocation] = useLocation();
+  const [open, setOpen] = useState(true);
+
+  useEffect(() => {
+    if (!open) {
+      setLocation("/");
+    }
+  }, [open, setLocation]);
+
+  return (
+    <div className="min-h-screen bg-slate-900/20 backdrop-blur-sm">
+      <CreateTripModal open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- rebuild the dashboard page with a travel-themed hero, highlight stats, updated trip grid, and helpful insights
- embed the currency converter as a utility card and surface next-destination context in the sidebar
- add a dedicated /trips/new route that opens the existing create-trip modal outside of the dashboard

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68dbe0e3e0bc832ea15f2599c22b6879