### PR TITLE
Fix dashboard stat cards with live data and accessible interactions

### DIFF
--- a/client/src/components/dashboard/stat-card.tsx
+++ b/client/src/components/dashboard/stat-card.tsx
@@ -1,0 +1,220 @@
+import { type KeyboardEvent, type MouseEvent, type ReactNode, useMemo } from "react";
+import { useLocation } from "wouter";
+import { RefreshCw } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type StatCardProps = {
+  icon: ReactNode;
+  value: string | number;
+  label: string;
+  description?: string;
+  ariaLabel: string;
+  href?: string;
+  onClick?: () => void;
+  onRetry?: () => void;
+  isLoading?: boolean;
+  isError?: boolean;
+  testId: string;
+};
+
+export function StatCard({
+  icon,
+  value,
+  label,
+  description,
+  ariaLabel,
+  href,
+  onClick,
+  onRetry,
+  isLoading = false,
+  isError = false,
+  testId,
+}: StatCardProps) {
+  const [, setLocation] = useLocation();
+
+  const formattedValue = useMemo(() => {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value.toLocaleString();
+    }
+    return value;
+  }, [value]);
+
+  const isInteractive = !isLoading && !isError && (!!href || typeof onClick === "function");
+
+  const handleNavigate = () => {
+    if (href) {
+      setLocation(href);
+    }
+  };
+
+  const handleActivate = (event: MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+    if (!isInteractive) {
+      event.preventDefault();
+      return;
+    }
+
+    if (href) {
+      event.preventDefault();
+      handleNavigate();
+    }
+
+    onClick?.();
+  };
+
+  const sharedProps = {
+    "data-testid": testId,
+    "aria-label": ariaLabel,
+    className: cn(
+      "group relative flex h-full flex-col justify-between rounded-3xl border border-slate-200/70 bg-white/90 p-6 text-left shadow-sm transition duration-200",
+      "before:pointer-events-none before:absolute before:inset-x-0 before:top-0 before:h-1 before:rounded-t-3xl before:bg-gradient-to-r before:from-[#ff7e5f] before:via-[#feb47b] before:to-[#654ea3]",
+      isInteractive
+        ? "cursor-pointer hover:-translate-y-0.5 hover:shadow-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#654ea3]"
+        : "cursor-default",
+    ),
+    onClick: handleActivate,
+    onKeyDown: (event: KeyboardEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+      if (!isInteractive) {
+        return;
+      }
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        handleNavigate();
+        onClick?.();
+      }
+    },
+    "aria-disabled": isInteractive ? undefined : true,
+  } as const;
+
+  if (href) {
+    return (
+      <a href={href} role="link" {...sharedProps}>
+        <CardContents
+          icon={icon}
+          value={formattedValue}
+          label={label}
+          description={description}
+          href={href}
+          isLoading={isLoading}
+          isError={isError}
+          onRetry={onRetry}
+          onNavigate={handleNavigate}
+        />
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" disabled={!isInteractive} {...sharedProps}>
+      <CardContents
+        icon={icon}
+        value={formattedValue}
+        label={label}
+        description={description}
+        href={href}
+        isLoading={isLoading}
+        isError={isError}
+        onRetry={onRetry}
+        onNavigate={handleNavigate}
+      />
+    </button>
+  );
+}
+
+type CardContentsProps = {
+  icon: ReactNode;
+  value: string | number;
+  label: string;
+  description?: string;
+  href?: string;
+  isLoading: boolean;
+  isError: boolean;
+  onRetry?: () => void;
+  onNavigate?: () => void;
+};
+
+function CardContents({
+  icon,
+  value,
+  label,
+  description,
+  href,
+  isLoading,
+  isError,
+  onRetry,
+  onNavigate,
+}: CardContentsProps) {
+  if (isLoading) {
+    return (
+      <div className="flex h-full flex-col justify-between gap-6">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-10 w-10 rounded-2xl" />
+          <Skeleton className="h-3 w-12 rounded-full" />
+        </div>
+        <div className="space-y-3">
+          <Skeleton className="h-9 w-24 rounded-lg" />
+          <Skeleton className="h-3 w-28 rounded-full" />
+          <Skeleton className="h-3 w-20 rounded-full" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex h-full flex-col gap-4">
+        <div className="flex items-start justify-between">
+          <p className="text-sm font-medium text-rose-600">Couldn't load right now</p>
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              event.preventDefault();
+              onRetry?.();
+            }}
+            aria-label="Retry loading stats"
+            className="rounded-full border border-rose-200 bg-white/90 p-2 text-rose-600 transition hover:bg-rose-50"
+          >
+            <RefreshCw className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+        <p className="text-xs text-rose-500">Please try again in a moment.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-gradient-to-br from-[#ff7e5f]/15 via-[#feb47b]/10 to-[#654ea3]/15 text-[#ff7e5f]">
+          {icon}
+        </div>
+        {href ? (
+          <a
+            href={href}
+            aria-hidden="true"
+            tabIndex={-1}
+            onClick={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              onNavigate?.();
+            }}
+            className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400 transition hover:text-slate-600"
+          >
+            View
+          </a>
+        ) : (
+          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">View</span>
+        )}
+      </div>
+      <div className="space-y-1.5">
+        <div className="text-[30px] font-semibold leading-none text-slate-900">{value}</div>
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{label}</p>
+        {description ? (
+          <p className="text-sm text-slate-500">{description}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/dashboardSelectors.ts
+++ b/client/src/lib/dashboardSelectors.ts
@@ -1,0 +1,161 @@
+import { parseISO, startOfDay, startOfYear, endOfYear } from "date-fns";
+import type { TripWithDetails } from "@shared/schema";
+
+type IsoDate = TripWithDetails["startDate"];
+
+type TripWithMeta = TripWithDetails & {
+  status?: string | null;
+  tripStatus?: string | null;
+  deletedAt?: IsoDate | null;
+  canceledAt?: IsoDate | null;
+  cancelledAt?: IsoDate | null;
+  isDeleted?: boolean | null;
+  archivedAt?: IsoDate | null;
+};
+
+const normalizeDate = (value: IsoDate): Date => {
+  if (value instanceof Date) {
+    return startOfDay(value);
+  }
+  return startOfDay(parseISO(value));
+};
+
+const isTripInactive = (trip: TripWithDetails): boolean => {
+  const candidate = trip as TripWithMeta;
+  const normalizedStatus =
+    candidate.status || candidate.tripStatus || (candidate as { state?: string }).state || null;
+  if (typeof normalizedStatus === "string") {
+    const lowered = normalizedStatus.toLowerCase();
+    if (lowered === "canceled" || lowered === "cancelled" || lowered === "archived") {
+      return true;
+    }
+  }
+
+  return Boolean(
+    candidate.isDeleted ||
+      candidate.deletedAt ||
+      candidate.canceledAt ||
+      candidate.cancelledAt ||
+      candidate.archivedAt,
+  );
+};
+
+export const selectUpcomingTrips = (
+  trips: TripWithDetails[] | null | undefined,
+  today: Date,
+): TripWithDetails[] => {
+  if (!trips || trips.length === 0) {
+    return [];
+  }
+
+  const normalizedToday = startOfDay(today);
+
+  return trips
+    .filter((trip) => {
+      if (isTripInactive(trip)) {
+        return false;
+      }
+
+      const startDate = normalizeDate(trip.startDate);
+      return startDate.getTime() >= normalizedToday.getTime();
+    })
+    .sort((a, b) => normalizeDate(a.startDate).getTime() - normalizeDate(b.startDate).getTime());
+};
+
+export const selectAllDestinationsUnique = (
+  trips: TripWithDetails[] | null | undefined,
+  referenceDate: Date,
+): Set<string | number> => {
+  const unique = new Set<string | number>();
+  if (!trips || trips.length === 0) {
+    return unique;
+  }
+
+  const normalizedToday = startOfDay(referenceDate);
+  const currentYearStart = startOfYear(normalizedToday);
+  const currentYearEnd = endOfYear(normalizedToday);
+
+  const addDestination = (trip: TripWithDetails) => {
+    const key =
+      (trip.geonameId ?? null) !== null
+        ? trip.geonameId!
+        : trip.destination?.trim().toLowerCase() || `trip-${trip.id}`;
+    unique.add(key);
+  };
+
+  let addedForYear = false;
+  for (const trip of trips) {
+    if (isTripInactive(trip)) {
+      continue;
+    }
+
+    const tripStart = normalizeDate(trip.startDate);
+    const tripEnd = normalizeDate(trip.endDate);
+    const overlapsYear =
+      tripStart.getTime() <= currentYearEnd.getTime() &&
+      tripEnd.getTime() >= currentYearStart.getTime();
+
+    if (!overlapsYear) {
+      continue;
+    }
+
+    addDestination(trip);
+    addedForYear = true;
+  }
+
+  if (!addedForYear) {
+    for (const trip of trips) {
+      if (isTripInactive(trip)) {
+        continue;
+      }
+      addDestination(trip);
+    }
+  }
+
+  return unique;
+};
+
+export const selectUniqueTravelersThisYear = (
+  trips: TripWithDetails[] | null | undefined,
+  referenceDate: Date,
+): Set<string> => {
+  const travelerIds = new Set<string>();
+  if (!trips || trips.length === 0) {
+    return travelerIds;
+  }
+
+  const startOfCurrentYear = startOfYear(referenceDate);
+  const endOfCurrentYear = endOfYear(referenceDate);
+
+  for (const trip of trips) {
+    if (isTripInactive(trip)) {
+      continue;
+    }
+
+    const tripStart = normalizeDate(trip.startDate);
+    const tripEnd = normalizeDate(trip.endDate);
+    const overlapsYear =
+      tripStart.getTime() <= endOfCurrentYear.getTime() &&
+      tripEnd.getTime() >= startOfCurrentYear.getTime();
+
+    if (!overlapsYear) {
+      continue;
+    }
+
+    for (const member of trip.members) {
+      if (member.userId) {
+        travelerIds.add(member.userId);
+      }
+    }
+  }
+
+  return travelerIds;
+};
+
+export const selectNextTrip = (
+  trips: TripWithDetails[] | null | undefined,
+  today: Date,
+): TripWithDetails | null => {
+  const upcoming = selectUpcomingTrips(trips, today);
+  return upcoming.length > 0 ? upcoming[0] ?? null : null;
+};


### PR DESCRIPTION
## Summary
- add dashboard selectors to compute upcoming trip, destination, and traveler metrics
- replace the dashboard highlight cards with an accessible StatCard component that handles loading, errors, and navigation
- wire the home dashboard stats to live selector data and show a toast when no upcoming trip exists

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dbf904ae84832ebf65eb1112c2c777