### PR TITLE
refactor: centralize trip cover image management

### DIFF
--- a/client/src/components/cover-photo-section.tsx
+++ b/client/src/components/cover-photo-section.tsx
@@ -5,7 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 
-const MAX_FILE_SIZE_MB = 10;
+const MAX_FILE_SIZE_MB = 5;
 const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
 
 const UNSPLASH_PRESETS: { url: string; label: string; attribution: string }[] = [
@@ -345,9 +345,9 @@ export function CoverPhotoSection({ value, onChange, defaultAltText }: CoverPhot
   return (
     <div className="space-y-4">
       <div className="space-y-1.5">
-        <Label className="text-sm font-semibold text-slate-700">Cover photo (optional)</Label>
+        <Label className="text-sm font-semibold text-slate-700">Cover photo</Label>
         <p className="text-xs text-slate-500">
-          Upload a custom cover or choose one of our curated travel shots. We’ll resize it for the dashboard and trip banner.
+          Upload an image to personalize your trip banner. We’ll optimize it for the dashboard and cards automatically.
         </p>
       </div>
 
@@ -438,11 +438,11 @@ export function CoverPhotoSection({ value, onChange, defaultAltText }: CoverPhot
             onDragOver={(event) => event.preventDefault()}
             onDrop={handleDrop}
           >
-            <p className="text-sm font-semibold text-slate-700">Upload a photo</p>
+            <p className="text-sm font-semibold text-slate-700">Add a cover photo</p>
             <p className="text-xs text-slate-500">Drag & drop or choose a JPG, PNG, or WEBP (max {MAX_FILE_SIZE_MB}MB).</p>
             <div className="flex flex-wrap items-center justify-center gap-2">
               <Button type="button" size="sm" onClick={() => fileInputRef.current?.click()} disabled={isProcessing}>
-                Choose file
+                Upload photo
               </Button>
               <Input
                 ref={fileInputRef}

--- a/client/src/components/create-trip-modal.tsx
+++ b/client/src/components/create-trip-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
@@ -12,7 +12,6 @@ import { z } from "zod";
 import { apiRequest } from "@/lib/queryClient";
 import { useLocation } from "wouter";
 import SmartLocationSearch from "@/components/SmartLocationSearch";
-import { CoverPhotoSection, type CoverPhotoValue } from "@/components/cover-photo-section";
 
 interface CreateTripModalProps {
   open: boolean;
@@ -45,11 +44,6 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
       latitude: null,
       longitude: null,
       population: null,
-      coverPhotoUrl: null,
-      coverPhotoCardUrl: null,
-      coverPhotoThumbUrl: null,
-      coverPhotoAlt: null,
-      coverPhotoAttribution: null,
     },
   });
 
@@ -107,25 +101,6 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
     createTripMutation.mutate(data);
   };
 
-  const handleCoverPhotoChange = useCallback(
-    (next: CoverPhotoValue) => {
-      form.setValue("coverPhotoUrl", next.coverPhotoUrl, { shouldDirty: true });
-      form.setValue("coverPhotoCardUrl", next.coverPhotoCardUrl, { shouldDirty: true });
-      form.setValue("coverPhotoThumbUrl", next.coverPhotoThumbUrl, { shouldDirty: true });
-      form.setValue("coverPhotoAlt", next.coverPhotoAlt, { shouldDirty: true });
-      form.setValue("coverPhotoAttribution", next.coverPhotoAttribution, { shouldDirty: true });
-    },
-    [form],
-  );
-
-  const coverPhotoValue: CoverPhotoValue = {
-    coverPhotoUrl: form.watch("coverPhotoUrl") ?? null,
-    coverPhotoCardUrl: form.watch("coverPhotoCardUrl") ?? null,
-    coverPhotoThumbUrl: form.watch("coverPhotoThumbUrl") ?? null,
-    coverPhotoAlt: form.watch("coverPhotoAlt") ?? null,
-    coverPhotoAttribution: form.watch("coverPhotoAttribution") ?? null,
-  };
-
   const handleDestinationSelect = (location: any) => {
     setSelectedDestination(location);
     form.setValue("destination", location.displayName || location.name);
@@ -173,11 +148,6 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
         </DialogHeader>
 
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-          <input type="hidden" {...form.register("coverPhotoUrl")} />
-          <input type="hidden" {...form.register("coverPhotoCardUrl")} />
-          <input type="hidden" {...form.register("coverPhotoThumbUrl")} />
-          <input type="hidden" {...form.register("coverPhotoAlt")} />
-          <input type="hidden" {...form.register("coverPhotoAttribution")} />
 
           <div>
             <Label htmlFor="name">Trip Name</Label>
@@ -228,12 +198,6 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
               )}
             </div>
           </div>
-
-          <CoverPhotoSection
-            value={coverPhotoValue}
-            onChange={handleCoverPhotoChange}
-            defaultAltText={`Cover photo for ${form.watch("name") || "this trip"}`}
-          />
 
           <div className="flex space-x-3 pt-4">
             <Button

--- a/client/src/components/edit-trip-modal.tsx
+++ b/client/src/components/edit-trip-modal.tsx
@@ -51,6 +51,7 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
       destination: trip.destination,
       startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
       endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+      coverImageUrl: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
       coverPhotoUrl: trip.coverPhotoUrl ?? null,
       coverPhotoCardUrl: trip.coverPhotoCardUrl ?? null,
       coverPhotoThumbUrl: trip.coverPhotoThumbUrl ?? null,
@@ -67,6 +68,7 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
         destination: trip.destination,
         startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
         endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+        coverImageUrl: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
         coverPhotoUrl: trip.coverPhotoUrl ?? null,
         coverPhotoCardUrl: trip.coverPhotoCardUrl ?? null,
         coverPhotoThumbUrl: trip.coverPhotoThumbUrl ?? null,
@@ -74,9 +76,9 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
         coverPhotoAttribution: trip.coverPhotoAttribution ?? null,
       });
       // Set destination for SmartLocationSearch
-      setSelectedDestination({ 
-        name: trip.destination, 
-        displayName: trip.destination 
+      setSelectedDestination({
+        name: trip.destination,
+        displayName: trip.destination
       });
     }
   }, [open, trip, form]);
@@ -102,9 +104,15 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
         return updatedTrip;
       });
       
+      const originalCover = trip.coverImageUrl ?? trip.coverPhotoUrl ?? null;
+      const updatedCover = updatedTrip.coverImageUrl ?? updatedTrip.coverPhotoUrl ?? null;
+      const coverChanged = originalCover !== updatedCover;
+
       toast({
-        title: "Trip updated!",
-        description: "Your trip details have been updated successfully.",
+        title: coverChanged ? "Saved" : "Trip updated!",
+        description: coverChanged
+          ? "Cover photo updated."
+          : "Your trip details have been updated successfully.",
       });
       onOpenChange(false);
     },
@@ -141,6 +149,7 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
 
   const handleCoverPhotoChange = useCallback(
     (next: CoverPhotoValue) => {
+      form.setValue("coverImageUrl", next.coverPhotoUrl, { shouldDirty: true });
       form.setValue("coverPhotoUrl", next.coverPhotoUrl, { shouldDirty: true });
       form.setValue("coverPhotoCardUrl", next.coverPhotoCardUrl, { shouldDirty: true });
       form.setValue("coverPhotoThumbUrl", next.coverPhotoThumbUrl, { shouldDirty: true });
@@ -170,11 +179,17 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
       destination: trip.destination,
       startDate: format(new Date(trip.startDate), "yyyy-MM-dd"),
       endDate: format(new Date(trip.endDate), "yyyy-MM-dd"),
+      coverImageUrl: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
+      coverPhotoUrl: trip.coverPhotoUrl ?? null,
+      coverPhotoCardUrl: trip.coverPhotoCardUrl ?? null,
+      coverPhotoThumbUrl: trip.coverPhotoThumbUrl ?? null,
+      coverPhotoAlt: trip.coverPhotoAlt ?? null,
+      coverPhotoAttribution: trip.coverPhotoAttribution ?? null,
     });
     // Reset selected destination to original
-    setSelectedDestination({ 
-      name: trip.destination, 
-      displayName: trip.destination 
+    setSelectedDestination({
+      name: trip.destination,
+      displayName: trip.destination
     });
     onOpenChange(false);
   };
@@ -190,6 +205,7 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
         </DialogHeader>
 
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <input type="hidden" {...form.register("coverImageUrl")} />
           <input type="hidden" {...form.register("coverPhotoUrl")} />
           <input type="hidden" {...form.register("coverPhotoCardUrl")} />
           <input type="hidden" {...form.register("coverPhotoThumbUrl")} />

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -225,6 +225,7 @@ type TripSummary = {
   travelersCount: number;
   travelers: { avatar?: string | null; initial: string }[];
   progressPercent: number;
+  coverImageUrl?: string | null;
   coverPhotoUrl?: string | null;
   coverPhotoCardUrl?: string | null;
   coverPhotoThumbUrl?: string | null;
@@ -320,9 +321,10 @@ export default function Home() {
       travelersCount: trip.memberCount,
       travelers: buildTravelerData(trip.members),
       progressPercent: calculatePlanningProgress(trip),
+      coverImageUrl: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
       coverPhotoUrl: trip.coverPhotoUrl ?? null,
-      coverPhotoCardUrl: trip.coverPhotoCardUrl ?? trip.coverPhotoUrl ?? null,
-      coverPhotoThumbUrl: trip.coverPhotoThumbUrl ?? trip.coverPhotoCardUrl ?? trip.coverPhotoUrl ?? null,
+      coverPhotoCardUrl: trip.coverPhotoCardUrl ?? trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
+      coverPhotoThumbUrl: trip.coverPhotoThumbUrl ?? trip.coverPhotoCardUrl ?? trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
       coverPhotoAlt: trip.coverPhotoAlt ?? undefined,
     }));
   }, [upcomingTripsForDisplay]);
@@ -378,10 +380,10 @@ export default function Home() {
       )}`
     : null;
 
-  const heroCoverPhoto = primaryTrip?.coverPhotoUrl ?? null;
+  const heroCoverPhoto = primaryTrip?.coverImageUrl ?? primaryTrip?.coverPhotoUrl ?? null;
   const heroImageSrcSet = primaryTrip
     ? buildCoverPhotoSrcSet({
-        full: primaryTrip.coverPhotoUrl ?? null,
+        full: primaryTrip.coverImageUrl ?? primaryTrip.coverPhotoUrl ?? null,
         card: primaryTrip.coverPhotoCardUrl ?? null,
         thumb: primaryTrip.coverPhotoThumbUrl ?? null,
       })
@@ -692,9 +694,9 @@ type TripCardProps = {
 };
 
 function TripCard({ trip, onOpen }: TripCardProps) {
-  const cardImageSrc = trip.coverPhotoCardUrl ?? trip.coverPhotoUrl ?? null;
+  const cardImageSrc = trip.coverPhotoCardUrl ?? trip.coverImageUrl ?? trip.coverPhotoUrl ?? null;
   const cardImageSrcSet = buildCoverPhotoSrcSet({
-    full: trip.coverPhotoUrl ?? null,
+    full: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
     card: trip.coverPhotoCardUrl ?? null,
     thumb: trip.coverPhotoThumbUrl ?? null,
   });

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -44,12 +44,7 @@ import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiFetch } from "@/lib/api";
 import { formatCurrency } from "@/lib/utils";
-import {
-  TRIP_COVER_GRADIENT,
-  buildCoverPhotoAltText,
-  buildCoverPhotoSrcSet,
-  useCoverPhotoImage,
-} from "@/lib/tripCover";
+import { TRIP_COVER_GRADIENT, buildCoverPhotoSrcSet, useCoverPhotoImage } from "@/lib/tripCover";
 import { CalendarGrid } from "@/components/calendar-grid";
 import { AddActivityModal } from "@/components/add-activity-modal";
 import { EditTripModal } from "@/components/edit-trip-modal";
@@ -688,11 +683,6 @@ export default function Trip() {
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showMembersModal, setShowMembersModal] = useState(false);
   const [showWeatherModal, setShowWeatherModal] = useState(false);
-  const coverCalloutKey = useMemo(
-    () => (id ? `trip-${id}-cover-callout-dismissed` : "trip-cover-callout"),
-    [id],
-  );
-  const [showCoverCallout, setShowCoverCallout] = useState(true);
   const [activeTab, setActiveTab] = useState<TripTab>("calendar");
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [categoryFilter, setCategoryFilter] = useState("all");
@@ -721,23 +711,6 @@ export default function Trip() {
       setActiveTab(viewParam);
     }
   }, []);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const stored = window.localStorage.getItem(coverCalloutKey);
-    setShowCoverCallout(stored !== "true");
-  }, [coverCalloutKey]);
-
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (!showCoverCallout) {
-      window.localStorage.setItem(coverCalloutKey, "true");
-    }
-  }, [coverCalloutKey, showCoverCallout]);
 
   const evaluateExternalRedirects = useCallback(() => {
     if (typeof window === "undefined") {
@@ -1271,18 +1244,14 @@ export default function Trip() {
     ? Math.max(differenceInCalendarDays(new Date(trip.endDate), new Date(trip.startDate)) + 1, 1)
     : null;
   const isTripCreator = trip ? user?.id === trip.createdBy : false;
-  const heroCoverPhoto = trip?.coverPhotoUrl ?? null;
+  const heroCoverPhoto = trip?.coverImageUrl ?? trip?.coverPhotoUrl ?? null;
   const heroImageSrcSet = trip
     ? buildCoverPhotoSrcSet({
-        full: trip.coverPhotoUrl ?? null,
+        full: trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
         card: trip.coverPhotoCardUrl ?? null,
         thumb: trip.coverPhotoThumbUrl ?? null,
       })
     : undefined;
-  const hasCustomCoverPhoto = Boolean(trip?.coverPhotoUrl);
-  const heroAltText = trip
-    ? buildCoverPhotoAltText(trip.name || trip.destination)
-    : "Trip cover photo";
   const {
     showImage: showHeroCover,
     isLoaded: heroCoverLoaded,
@@ -1551,7 +1520,8 @@ export default function Trip() {
                         src={heroCoverPhoto ?? undefined}
                         srcSet={heroImageSrcSet}
                         sizes="(max-width: 1024px) 100vw, 960px"
-                        alt={heroAltText}
+                        alt=""
+                        aria-hidden="true"
                         className={`pointer-events-none absolute inset-0 h-full w-full object-cover transition-opacity duration-700 ${
                           heroCoverLoaded ? "opacity-100" : "opacity-0"
                         }`}
@@ -1565,35 +1535,6 @@ export default function Trip() {
                       className="pointer-events-none absolute inset-0 bg-gradient-to-b from-slate-900/70 via-slate-900/30 to-slate-900/80"
                       aria-hidden="true"
                     />
-                    {isTripCreator && !hasCustomCoverPhoto && showCoverCallout ? (
-                      <div className="absolute right-4 top-4 flex max-w-xs flex-col gap-2 rounded-2xl border border-white/30 bg-white/20 p-4 text-white shadow-lg backdrop-blur">
-                        <p className="text-sm font-semibold">Add a cover photo</p>
-                        <p className="text-xs text-white/80">
-                          Personalize this banner with a hero image for your group.
-                        </p>
-                        <div className="flex flex-wrap gap-2">
-                          <Button
-                            type="button"
-                            size="sm"
-                            variant="secondary"
-                            className="bg-white text-slate-900 hover:bg-white/90"
-                            onClick={() => {
-                              setShowEditTrip(true);
-                              setShowCoverCallout(false);
-                            }}
-                          >
-                            Add photo
-                          </Button>
-                          <button
-                            type="button"
-                            className="text-xs text-white/80 underline hover:text-white"
-                            onClick={() => setShowCoverCallout(false)}
-                          >
-                            Dismiss
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
                     <div className="relative p-6 sm:p-10">
                       <div className="flex flex-col gap-8 lg:flex-row lg:items-start lg:justify-between">
                         <div className="max-w-2xl space-y-5">

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -998,6 +998,7 @@ const mapTrip = (row: TripRow): TripCalendar => ({
   latitude: toNumberOrNull(row.latitude),
   longitude: toNumberOrNull(row.longitude),
   population: toNumberOrNull(row.population),
+  coverImageUrl: row.cover_photo_url,
   coverPhotoUrl: row.cover_photo_url,
   coverPhotoCardUrl: row.cover_photo_card_url,
   coverPhotoThumbUrl: row.cover_photo_thumb_url,
@@ -2457,7 +2458,7 @@ export class DatabaseStorage implements IStorage {
         latitudeValue,
         longitudeValue,
         populationValue,
-        trip.coverPhotoUrl ?? null,
+        trip.coverImageUrl ?? trip.coverPhotoUrl ?? null,
         trip.coverPhotoCardUrl ?? null,
         trip.coverPhotoThumbUrl ?? null,
         trip.coverPhotoAlt ?? null,
@@ -2910,7 +2911,11 @@ export class DatabaseStorage implements IStorage {
       index += 1;
     }
 
-    if (data.coverPhotoUrl !== undefined) {
+    if (data.coverImageUrl !== undefined) {
+      setClauses.push(`cover_photo_url = $${index}`);
+      values.push(data.coverImageUrl ?? null);
+      index += 1;
+    } else if (data.coverPhotoUrl !== undefined) {
       setClauses.push(`cover_photo_url = $${index}`);
       values.push(data.coverPhotoUrl ?? null);
       index += 1;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -125,6 +125,7 @@ export interface TripCalendar {
   latitude?: number | null;
   longitude?: number | null;
   population?: number | null;
+  coverImageUrl?: string | null;
   coverPhotoUrl?: string | null;
   coverPhotoCardUrl?: string | null;
   coverPhotoThumbUrl?: string | null;
@@ -152,6 +153,7 @@ export const insertTripCalendarSchema = z.object({
   latitude: nullableNumberInput("Latitude must be a number"),
   longitude: nullableNumberInput("Longitude must be a number"),
   population: nullableNumberInput("Population must be a number"),
+  coverImageUrl: imageUrlSchema.nullable().optional(),
   coverPhotoUrl: imageUrlSchema.nullable().optional(),
   coverPhotoCardUrl: imageUrlSchema.nullable().optional(),
   coverPhotoThumbUrl: imageUrlSchema.nullable().optional(),


### PR DESCRIPTION
## Summary
- add a `coverImageUrl` field to the shared trip schema and database mappers so every surface reads the same cover image source
- scope cover photo editing to the Edit Trip modal with refreshed copy, a 5 MB upload cap, and a toast that confirms when the image changes
- remove the dashboard hero callout, rely on the gradient fallback when no photo is present, and update the home dashboard cards to read `coverImageUrl`

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc036cbec4832e93797a1b87f33016