### PR TITLE
Add dashboard quick actions header bar

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -21,8 +21,19 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Avatar,
   AvatarFallback,
@@ -258,24 +269,36 @@ export default function Home() {
   const [lastConversion, setLastConversion] = useState<LastConversion | null>(null);
   const isDesktop = useMediaQuery("(min-width: 1024px)");
   const converterDialogId = useId();
-  const converterButtonRef = useRef<HTMLButtonElement | null>(null);
+  const converterTriggerRef = useRef<HTMLButtonElement | null>(null);
+  const desktopConverterButtonRef = useRef<HTMLButtonElement | null>(null);
+  const quickActionsButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isConverterOpen, setIsConverterOpen] = useState(false);
-  const [isConverterInfoOpen, setIsConverterInfoOpen] = useState(false);
+  const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false);
   const handleConverterVisibilityChange = useCallback(
     (open: boolean) => {
       setIsConverterOpen(open);
-      if (open) {
-        setIsConverterInfoOpen(false);
-      } else {
-        converterButtonRef.current?.focus();
+      if (!open) {
+        converterTriggerRef.current?.focus();
       }
     },
-    [converterButtonRef, setIsConverterInfoOpen, setIsConverterOpen],
+    [],
   );
   const handleConverterClose = useCallback(() => {
     setIsConverterOpen(false);
-    converterButtonRef.current?.focus();
-  }, [converterButtonRef, setIsConverterOpen]);
+    converterTriggerRef.current?.focus();
+  }, []);
+  const handleOpenConverter = useCallback((trigger?: HTMLButtonElement | null) => {
+    if (trigger) {
+      converterTriggerRef.current = trigger;
+    }
+    setIsConverterOpen(true);
+  }, []);
+  const handleOpenHowItWorks = useCallback(() => {
+    setIsHowItWorksOpen(true);
+  }, []);
+  const handleNavigateToProfile = useCallback(() => {
+    setLocation("/profile");
+  }, [setLocation]);
 
   useEffect(() => {
     setLastConversion(loadLastConversion());
@@ -444,7 +467,137 @@ export default function Home() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
       <div className="mx-auto w-full max-w-[1240px] px-6 pb-20 pt-24">
+        <Dialog open={isHowItWorksOpen} onOpenChange={setIsHowItWorksOpen}>
+          <DialogContent className="w-full max-w-xl rounded-3xl border border-slate-200/80 bg-white p-6 shadow-xl">
+            <DialogHeader className="space-y-2 text-left">
+              <DialogTitle className="text-2xl font-semibold text-slate-900">
+                Welcome to VacationSync
+              </DialogTitle>
+              <DialogDescription className="text-base text-slate-600">
+                VacationSync keeps every part of your group trip organized in one place so
+                you can plan with confidence.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-6 space-y-4 text-left text-slate-600">
+              <p>
+                Start by creating or joining a trip, then invite friends to collaborate.
+                Build day-by-day itineraries, track shared expenses, and manage travel
+                documents with real-time updates for the whole crew.
+              </p>
+              <ul className="list-disc space-y-2 pl-5">
+                <li>See every upcoming journey and key dates from your dashboard.</li>
+                <li>Coordinate flights, stays, activities, and meals with shared tools.</li>
+                <li>Keep budgets in check using the built-in expense tracking and reminders.</li>
+              </ul>
+              <p>
+                Need help getting started? Use the “Plan a New Trip” button on the dashboard or
+                revisit this guide anytime from the quick actions header.
+              </p>
+            </div>
+            <div className="mt-6 flex justify-end">
+              <Button type="button" variant="secondary" onClick={() => setIsHowItWorksOpen(false)}>
+                Got it
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Dialog open={isConverterOpen} onOpenChange={handleConverterVisibilityChange}>
+          <DialogContent
+            id={converterDialogId}
+            className="w-full max-w-[560px] rounded-3xl border border-slate-200/80 bg-white p-6 shadow-2xl [&>button]:hidden"
+          >
+            <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
+              <CurrencyConverterTool
+                onClose={handleConverterClose}
+                lastConversion={lastConversion}
+                onConversion={handleConversionUpdate}
+                mobile={!isDesktop}
+                autoFocusAmount={isConverterOpen}
+              />
+            </Suspense>
+          </DialogContent>
+        </Dialog>
         <div className="flex flex-col gap-8">
+          <section
+            aria-label="Dashboard quick actions"
+            className="rounded-2xl border border-slate-200/70 bg-white/80 px-4 py-3 shadow-sm backdrop-blur"
+          >
+            <div className="hidden lg:flex flex-col items-start gap-2">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-48 justify-start text-sm font-semibold text-slate-700 hover:text-slate-900"
+                onClick={handleOpenHowItWorks}
+              >
+                How It Works
+              </Button>
+              <Button
+                ref={desktopConverterButtonRef}
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-48 justify-start text-sm font-semibold text-slate-700 hover:text-slate-900"
+                aria-controls={converterDialogId}
+                aria-expanded={isConverterOpen}
+                aria-haspopup="dialog"
+                onClick={() => handleOpenConverter(desktopConverterButtonRef.current)}
+              >
+                Currency Converter
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                className="w-48 justify-start text-sm font-semibold text-slate-700 hover:text-slate-900"
+                onClick={handleNavigateToProfile}
+              >
+                Profile & Preferences
+              </Button>
+            </div>
+            <div className="lg:hidden">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    ref={quickActionsButtonRef}
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="w-full justify-center text-sm font-semibold text-slate-700 hover:text-slate-900"
+                    aria-label="Open quick actions"
+                  >
+                    Quick actions
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" className="w-56">
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      handleOpenHowItWorks();
+                    }}
+                  >
+                    How It Works
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      handleOpenConverter(quickActionsButtonRef.current);
+                    }}
+                  >
+                    Currency Converter
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onSelect={(event) => {
+                      event.preventDefault();
+                      handleNavigateToProfile();
+                    }}
+                  >
+                    Profile & Preferences
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </section>
           <section
             aria-labelledby="dashboard-hero"
             className="relative overflow-hidden rounded-[32px] border border-white/20 bg-slate-900 p-8 text-white shadow-xl backdrop-blur-lg sm:p-12"
@@ -478,74 +631,13 @@ export default function Home() {
               <div className="text-sm uppercase tracking-[0.2em] text-white/80">
                 Your travel hub
               </div>
-              <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-                <div className="space-y-4">
-                  <h1 id="dashboard-hero" className="text-4xl font-semibold sm:text-5xl">
-                    Dashboard
-                  </h1>
-                  <p className="text-base text-white/80">
-                    Plan new trips and see what’s next—all in one place.
-                  </p>
-                </div>
-                <div className="flex flex-col items-start gap-3 text-left md:flex-row md:flex-wrap md:items-center md:justify-end lg:items-center lg:justify-end">
-                  <Popover open={isConverterInfoOpen} onOpenChange={setIsConverterInfoOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="rounded-full px-6 text-sm font-semibold text-white/90 hover:text-white"
-                      >
-                        How it works
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent
-                      align="end"
-                      className="w-[360px] max-w-[calc(100vw-48px)] rounded-2xl border border-white/20 bg-white/10 p-4 text-left text-sm text-white/80 backdrop-blur"
-                    >
-                      <p className="font-semibold text-white">Currency converter</p>
-                      <p className="mt-2 text-white/90">Quick conversions for the road.</p>
-                      <p className="mt-1 text-white/80">Live mid-market rates with offline fallbacks.</p>
-                      <div className="mt-3 flex justify-end">
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="ghost"
-                          className="rounded-full px-4 text-xs font-semibold text-white/80 hover:text-white"
-                          onClick={() => setIsConverterInfoOpen(false)}
-                        >
-                          Close
-                        </Button>
-                      </div>
-                    </PopoverContent>
-                  </Popover>
-                  <Dialog open={isConverterOpen} onOpenChange={handleConverterVisibilityChange}>
-                    <Button
-                      ref={converterButtonRef}
-                      type="button"
-                      onClick={() => handleConverterVisibilityChange(true)}
-                      aria-controls={converterDialogId}
-                      aria-expanded={isConverterOpen}
-                      aria-haspopup="dialog"
-                      className="sunset-gradient rounded-full px-6 py-2 text-sm font-semibold text-white shadow-lg transition-transform hover:-translate-y-0.5 hover:shadow-xl"
-                    >
-                      Currency converter
-                    </Button>
-                    <DialogContent
-                      id={converterDialogId}
-                      className="w-full max-w-[560px] rounded-3xl border border-slate-200/80 bg-white p-6 shadow-2xl [&>button]:hidden"
-                    >
-                      <Suspense fallback={<Skeleton className="h-64 w-full rounded-2xl" />}>
-                        <CurrencyConverterTool
-                          onClose={handleConverterClose}
-                          lastConversion={lastConversion}
-                          onConversion={handleConversionUpdate}
-                          mobile={!isDesktop}
-                          autoFocusAmount={isConverterOpen}
-                        />
-                      </Suspense>
-                    </DialogContent>
-                  </Dialog>
-                </div>
+              <div className="space-y-4">
+                <h1 id="dashboard-hero" className="text-4xl font-semibold sm:text-5xl">
+                  Dashboard
+                </h1>
+                <p className="text-base text-white/80">
+                  Plan new trips and see what’s next—all in one place.
+                </p>
               </div>
               <div className="flex flex-wrap items-center gap-3">
                 <Button


### PR DESCRIPTION
## Summary
- add a dedicated quick actions header on the dashboard with desktop buttons and a mobile dropdown
- route the How It Works and Currency Converter experiences through reusable dialogs triggered from the header
- link the Profile & Preferences action to the existing profile settings page for consistent access

## Testing
- npm run check *(fails: pre-existing type errors in client/src/pages/flights.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0f8a8b70832eba7801821b81b2a7