### PR TITLE
Fix allowed types normalization for FlightLocationSearch

### DIFF
--- a/client/src/components/FlightLocationSearch.tsx
+++ b/client/src/components/FlightLocationSearch.tsx
@@ -76,12 +76,12 @@ const FlightLocationSearch = forwardRef<HTMLInputElement, FlightLocationSearchPr
       className = "",
       onQueryChange,
       types,
-      allowedTypes = DEFAULT_ALLOWED_TYPES,
+      allowedTypes,
     },
     ref,
   ) {
     const [query, setQuery] = useState(value);
-    const normalisedAllowedTypes = normalizeAllowedTypes(allowedTypes, types);
+    const normalizedAllowedTypes = normalizeAllowedTypes(allowedTypes, types);
 
     useEffect(() => {
       setQuery(value ?? "");
@@ -94,7 +94,7 @@ const FlightLocationSearch = forwardRef<HTMLInputElement, FlightLocationSearchPr
         placeholder={placeholder}
         value={query}
         className={className}
-        allowedTypes={normalisedAllowedTypes}
+        allowedTypes={normalizedAllowedTypes}
         onQueryChange={(nextValue) => {
           setQuery(nextValue);
           onQueryChange?.(nextValue);


### PR DESCRIPTION
## Summary
- allow the FlightLocationSearch component to respect provided allowedTypes props instead of always defaulting
- ensure legacy types string still normalizes to allowed types when no array is given

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc16b4c1c48329ba8cceba235eddd6