### PR TITLE
Fix FlightLocationSearch legacy allowed types fallback

### DIFF
--- a/client/src/components/FlightLocationSearch.tsx
+++ b/client/src/components/FlightLocationSearch.tsx
@@ -76,7 +76,7 @@ const FlightLocationSearch = forwardRef<HTMLInputElement, FlightLocationSearchPr
       className = "",
       onQueryChange,
       types,
-      allowedTypes = DEFAULT_ALLOWED_TYPES,
+      allowedTypes,
     },
     ref,
   ) {


### PR DESCRIPTION
## Summary
- remove the default allowedTypes value so legacy props can be honored
- continue normalizing allowed types before passing them to SmartLocationSearch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc15e121f88329a697653ea8a2e135