### PR TITLE
Add missing React lazy import on home page

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,4 +1,5 @@
 import {
+  lazy,
   useCallback,
   useEffect,
   useId,


### PR DESCRIPTION
## Summary
- add the lazy export to the React import in the home page so the lazy component resolves properly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc22cb607083298d4a6e9f690aa3c5