### PR TITLE
Refine dashboard modals for accessibility and scroll behavior

### DIFF
--- a/client/src/components/dashboard/currency-converter-tool.tsx
+++ b/client/src/components/dashboard/currency-converter-tool.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import type { ClipboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -21,10 +21,10 @@ import {
   Lock,
   Share2,
   Unlock,
-  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { LastConversion } from "./converter-types";
+import ModalLayout from "@/components/dashboard/modal-layout";
 
 const RECENTS_KEY = "dashboard.converter.recents";
 const RATE_CACHE_KEY = "dashboard.converter.rates";
@@ -70,6 +70,7 @@ type CurrencyConverterToolProps = {
   onConversion: (conversion: LastConversion) => void;
   mobile?: boolean;
   autoFocusAmount?: boolean;
+  closeButtonRef?: RefObject<HTMLButtonElement>;
 };
 
 export default function CurrencyConverterTool({
@@ -78,6 +79,7 @@ export default function CurrencyConverterTool({
   onConversion,
   mobile = false,
   autoFocusAmount = false,
+  closeButtonRef,
 }: CurrencyConverterToolProps) {
   const { toast } = useToast();
   const [amount, setAmount] = useState(() =>
@@ -377,26 +379,25 @@ export default function CurrencyConverterTool({
   }, [fromCurrency, toCurrency]);
 
   return (
-    <div className={cn("flex flex-col gap-6", mobile ? "p-4" : "p-6")}
-      aria-label="Currency converter panel"
-    >
-      <div className="flex items-start justify-between gap-4">
-        <div>
+    <ModalLayout
+      onClose={onClose}
+      closeButtonRef={closeButtonRef}
+      closeLabel="Close currency converter"
+      headerClassName={cn(
+        mobile ? "px-5 pt-6 pb-3" : "px-6 py-5",
+        "sm:px-8",
+      )}
+      bodyClassName={cn(
+        "px-6 pb-6 pt-2 sm:px-8",
+        mobile ? "px-5 sm:px-8" : null,
+      )}
+      header={
+        <div className="space-y-1">
           <h2 className="text-lg font-semibold text-slate-900">Currency converter</h2>
           <p className="text-sm text-slate-500">Live mid-market rates with offline fallbacks.</p>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          type="button"
-          onClick={onClose}
-          className="h-9 w-9 rounded-full text-slate-500 hover:text-slate-700"
-          aria-label="Close converter"
-        >
-          <X className="h-5 w-5" />
-        </Button>
-      </div>
-
+      }
+    >
       <form
         className="flex flex-col gap-5"
         onSubmit={(event) => {
@@ -588,7 +589,7 @@ export default function CurrencyConverterTool({
           </Button>
         </div>
       </form>
-    </div>
+    </ModalLayout>
   );
 }
 

--- a/client/src/components/dashboard/how-it-works-panel.tsx
+++ b/client/src/components/dashboard/how-it-works-panel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react";
+import { type ReactNode, type RefObject } from "react";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -8,10 +8,12 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import ModalLayout from "@/components/dashboard/modal-layout";
 
 interface HowItWorksPanelProps {
   titleId: string;
   descriptionId: string;
+  onClose: () => void;
   onDismiss: () => void;
   onCreateTrip: () => void;
   onInviteMembers: () => void;
@@ -20,6 +22,8 @@ interface HowItWorksPanelProps {
   onOpenExpenses: () => void;
   onOpenPacking: () => void;
   onOpenPreferences: () => void;
+  closeButtonRef?: RefObject<HTMLButtonElement>;
+  mobile?: boolean;
 }
 
 type Benefit = {
@@ -70,6 +74,7 @@ const benefits: Benefit[] = [
 export default function HowItWorksPanel({
   titleId,
   descriptionId,
+  onClose,
   onDismiss,
   onCreateTrip,
   onInviteMembers,
@@ -78,6 +83,8 @@ export default function HowItWorksPanel({
   onOpenExpenses,
   onOpenPacking,
   onOpenPreferences,
+  closeButtonRef,
+  mobile = false,
 }: HowItWorksPanelProps) {
   const flowSteps: FlowStep[] = [
     {
@@ -127,24 +134,57 @@ export default function HowItWorksPanel({
   ];
 
   return (
-    <div className="flex h-full flex-col bg-white">
-      <div className="flex-1 overflow-y-auto px-6 pb-28 pt-10 sm:px-10">
-        <header className="space-y-4">
+    <ModalLayout
+      onClose={onClose}
+      closeButtonRef={closeButtonRef}
+      closeLabel="Close how it works"
+      headerClassName={`px-6 ${mobile ? "pt-6" : "pt-8"} pb-4 sm:px-10 ${mobile ? "sm:pt-8" : "sm:pt-10"}`}
+      bodyClassName={`px-6 pb-10 pt-2 sm:px-10 ${mobile ? "sm:pb-10" : "sm:pb-12"}`}
+      footerClassName="border-t border-slate-200 bg-white/95 px-6 py-5 backdrop-blur sm:px-10"
+      header={
+        <div className="space-y-4">
           <div className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-1.5 text-xs font-medium uppercase tracking-[0.2em] text-slate-600">
             <Sparkles className="h-3.5 w-3.5 text-sky-600" aria-hidden="true" />
             How it works
           </div>
           <div className="space-y-3">
-            <h1 id={titleId} className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+            <h1
+              id={titleId}
+              className="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl"
+            >
               How TripSync Works
             </h1>
-            <p id={descriptionId} className="max-w-2xl text-base text-slate-600 sm:text-lg">
+            <p
+              id={descriptionId}
+              className="max-w-2xl text-base text-slate-600 sm:text-lg"
+            >
               Plan amazing group trips with collaborative tools — all in one place.
             </p>
           </div>
-        </header>
-
-        <section aria-labelledby="how-it-works-why" className="mt-10 space-y-4">
+        </div>
+      }
+      footer={
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-11 rounded-full px-5 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 hover:text-slate-900"
+            onClick={onCreateTrip}
+          >
+            Create a trip
+          </Button>
+          <Button
+            type="button"
+            className="h-11 rounded-full bg-sky-600 px-6 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700"
+            onClick={onDismiss}
+          >
+            Got it
+          </Button>
+        </div>
+      }
+    >
+      <div className="space-y-12">
+        <section aria-labelledby="how-it-works-why" className="space-y-4">
           <div className="flex flex-wrap items-end justify-between gap-2">
             <h2 id="how-it-works-why" className="text-lg font-semibold text-slate-900">
               Why TripSync
@@ -165,7 +205,7 @@ export default function HowItWorksPanel({
           </div>
         </section>
 
-        <section aria-labelledby="how-it-works-flow" className="mt-12 space-y-5">
+        <section aria-labelledby="how-it-works-flow" className="space-y-5">
           <div className="space-y-2">
             <h2 id="how-it-works-flow" className="text-lg font-semibold text-slate-900">
               The flow
@@ -202,7 +242,7 @@ export default function HowItWorksPanel({
           </div>
         </section>
 
-        <section aria-labelledby="how-it-works-tips" className="mt-12 space-y-4">
+        <section aria-labelledby="how-it-works-tips" className="space-y-4">
           <h2 id="how-it-works-tips" className="text-lg font-semibold text-slate-900">
             Tips
           </h2>
@@ -229,26 +269,6 @@ export default function HowItWorksPanel({
           </div>
         </section>
       </div>
-
-      <footer className="sticky bottom-0 border-t border-slate-200 bg-white/95 px-6 py-5 backdrop-blur sm:px-10">
-        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-11 rounded-full px-5 text-sm font-semibold text-slate-700 hover:bg-slate-100 hover:text-slate-900"
-            onClick={onCreateTrip}
-          >
-            Create a trip
-          </Button>
-          <Button
-            type="button"
-            className="h-11 rounded-full bg-sky-600 px-6 text-sm font-semibold text-white shadow-sm transition hover:bg-sky-700"
-            onClick={onDismiss}
-          >
-            Got it
-          </Button>
-        </div>
-      </footer>
-    </div>
+    </ModalLayout>
   );
 }

--- a/client/src/components/dashboard/modal-layout.tsx
+++ b/client/src/components/dashboard/modal-layout.tsx
@@ -1,0 +1,70 @@
+import { type ReactNode, type RefObject } from "react";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ModalLayoutProps = {
+  header: ReactNode;
+  children: ReactNode;
+  footer?: ReactNode;
+  onClose: () => void;
+  closeLabel?: string;
+  closeButtonRef?: RefObject<HTMLButtonElement>;
+  className?: string;
+  headerClassName?: string;
+  bodyClassName?: string;
+  footerClassName?: string;
+};
+
+export default function ModalLayout({
+  header,
+  children,
+  footer,
+  onClose,
+  closeLabel = "Close dialog",
+  closeButtonRef,
+  className,
+  headerClassName,
+  bodyClassName,
+  footerClassName,
+}: ModalLayoutProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-full min-h-0 flex-col overflow-hidden bg-white",
+        className,
+      )}
+    >
+      <div
+        className={cn(
+          "flex items-start justify-between gap-4 border-b border-slate-200/80 px-6 py-5",
+          headerClassName,
+        )}
+      >
+        <div className="min-w-0 flex-1">{header}</div>
+        <button
+          type="button"
+          ref={closeButtonRef}
+          onClick={onClose}
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-500 transition hover:border-slate-300 hover:text-slate-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2"
+          aria-label={closeLabel}
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+      <div className={cn("flex-1 overflow-y-auto px-6 py-6", bodyClassName)}>
+        {children}
+      </div>
+      {footer ? (
+        <div
+          className={cn(
+            "shrink-0 border-t border-slate-200/80 px-6 py-5",
+            footerClassName,
+          )}
+        >
+          {footer}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -358,6 +358,8 @@ export default function Home() {
   const howItWorksDescriptionId = useId();
   const converterButtonRef = useRef<HTMLButtonElement | null>(null);
   const howItWorksButtonRef = useRef<HTMLButtonElement | null>(null);
+  const howItWorksCloseButtonRef = useRef<HTMLButtonElement | null>(null);
+  const converterCloseButtonRef = useRef<HTMLButtonElement | null>(null);
   const shouldRestoreHowItWorksFocus = useRef(true);
   const upcomingSectionRef = useRef<HTMLHeadingElement | null>(null);
   const [isConverterOpen, setIsConverterOpen] = useState(false);
@@ -379,11 +381,6 @@ export default function Home() {
     },
     [converterButtonRef, setIsConverterOpen],
   );
-  const handleConverterClose = useCallback(() => {
-    setIsConverterOpen(false);
-    converterButtonRef.current?.focus();
-  }, [converterButtonRef, setIsConverterOpen]);
-
   const handleOpenProfile = useCallback(() => {
     setLocation("/profile");
   }, [setLocation]);
@@ -392,6 +389,39 @@ export default function Home() {
     setHowItWorksLoaded(true);
     setIsHowItWorksOpen(true);
   }, []);
+
+  const focusElement = useCallback((element: HTMLElement | null) => {
+    if (!element) {
+      return;
+    }
+    if (typeof window === "undefined") {
+      element.focus();
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      element.focus();
+    });
+  }, []);
+
+  const handleHowItWorksOpenAutoFocus = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      focusElement(howItWorksCloseButtonRef.current);
+    },
+    [focusElement],
+  );
+
+  const handleDialogCloseAutoFocus = useCallback((event: Event) => {
+    event.preventDefault();
+  }, []);
+
+  const handleConverterOpenAutoFocus = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      focusElement(converterCloseButtonRef.current);
+    },
+    [focusElement],
+  );
 
   const handleHowItWorksOpenChange = useCallback(
     (open: boolean) => {
@@ -839,6 +869,9 @@ export default function Home() {
         onOpenExpenses={handleHowItWorksOpenExpenses}
         onOpenPacking={handleHowItWorksOpenPacking}
         onOpenPreferences={handleHowItWorksPreferences}
+        onClose={() => handleHowItWorksOpenChange(false)}
+        closeButtonRef={howItWorksCloseButtonRef}
+        mobile={!isDesktop}
       />
     </Suspense>
   ) : (
@@ -897,6 +930,8 @@ export default function Home() {
                 className="w-full max-w-3xl gap-0 overflow-hidden rounded-[32px] border border-slate-200/80 bg-white p-0 shadow-2xl"
                 aria-labelledby={howItWorksTitleId}
                 aria-describedby={howItWorksDescriptionId}
+                onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
+                onCloseAutoFocus={handleDialogCloseAutoFocus}
               >
                 {howItWorksContent}
               </DialogContent>
@@ -905,29 +940,54 @@ export default function Home() {
             <Sheet open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
               <SheetContent
                 side="bottom"
-                className="h-[100dvh] max-h-[100dvh] w-full max-w-full gap-0 overflow-hidden rounded-t-[32px] border-none bg-white p-0 shadow-2xl"
+                className="flex h-[100dvh] max-h-[100dvh] w-full max-w-full flex-col gap-0 overflow-hidden rounded-t-[32px] border-none bg-white p-0 shadow-2xl"
                 aria-labelledby={howItWorksTitleId}
                 aria-describedby={howItWorksDescriptionId}
+                onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
+                onCloseAutoFocus={handleDialogCloseAutoFocus}
               >
                 {howItWorksContent}
               </SheetContent>
             </Sheet>
           )}
 
-          <Dialog open={isConverterOpen} onOpenChange={handleConverterVisibilityChange}>
-            <DialogContent
-              id={converterDialogId}
-              className="w-full max-w-[560px] rounded-3xl border border-slate-200/80 bg-white p-6 shadow-2xl"
-            >
-              <CurrencyConverterTool
-                onClose={handleConverterClose}
-                lastConversion={lastConversion}
-                onConversion={handleConversionUpdate}
-                mobile={!isDesktop}
-                autoFocusAmount={isConverterOpen}
-              />
-            </DialogContent>
-          </Dialog>
+          {isDesktop ? (
+            <Dialog open={isConverterOpen} onOpenChange={handleConverterVisibilityChange}>
+              <DialogContent
+                id={converterDialogId}
+                className="w-full max-w-[560px] gap-0 overflow-hidden rounded-3xl border border-slate-200/80 bg-white p-0 shadow-2xl"
+                onOpenAutoFocus={handleConverterOpenAutoFocus}
+                onCloseAutoFocus={handleDialogCloseAutoFocus}
+              >
+                <CurrencyConverterTool
+                  onClose={() => handleConverterVisibilityChange(false)}
+                  lastConversion={lastConversion}
+                  onConversion={handleConversionUpdate}
+                  mobile={!isDesktop}
+                  autoFocusAmount={isConverterOpen}
+                  closeButtonRef={converterCloseButtonRef}
+                />
+              </DialogContent>
+            </Dialog>
+          ) : (
+            <Sheet open={isConverterOpen} onOpenChange={handleConverterVisibilityChange}>
+              <SheetContent
+                side="bottom"
+                className="flex h-[100dvh] max-h-[100dvh] w-full max-w-full flex-col gap-0 overflow-hidden rounded-t-[32px] border-none bg-white p-0 shadow-2xl"
+                onOpenAutoFocus={handleConverterOpenAutoFocus}
+                onCloseAutoFocus={handleDialogCloseAutoFocus}
+              >
+                <CurrencyConverterTool
+                  onClose={() => handleConverterVisibilityChange(false)}
+                  lastConversion={lastConversion}
+                  onConversion={handleConversionUpdate}
+                  mobile={!isDesktop}
+                  autoFocusAmount={isConverterOpen}
+                  closeButtonRef={converterCloseButtonRef}
+                />
+              </SheetContent>
+            </Sheet>
+          )}
 
           <section
             aria-labelledby="dashboard-hero"


### PR DESCRIPTION
## Summary
- add a reusable modal layout shell that keeps headers and footers fixed while making content scrollable
- update the How It Works and Currency Converter experiences to share the new layout on both desktop dialogs and mobile bottom sheets
- ensure focus is managed when the overlays open or close and align the currency converter sheet with the modal experience

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dc276d1d90832e848cdf751c7c6184