### PR TITLE
Fix cover photo picker interactions in Edit Trip modal

### DIFF
--- a/client/src/components/edit-trip-modal.tsx
+++ b/client/src/components/edit-trip-modal.tsx
@@ -196,7 +196,7 @@ export function EditTripModal({ open, onOpenChange, trip }: EditTripModalProps) 
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md" onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogContent className="w-full max-w-xl max-h-[calc(100vh-3rem)] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit Trip Details</DialogTitle>
           <DialogDescription>

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -21,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-40 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- keep the cover photo file input inside the dialog, support HEIC uploads up to 10 MB, clear errors, and show a processing overlay during crop generation
- wire upload buttons to a reusable picker helper so Replace/Upload consistently open the OS chooser with keyboard support
- adjust the edit trip dialog to be scrollable within the viewport and lower the backdrop z-index so the modal stays interactive

## Testing
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68dc333556e4832e8cf7f2f1c3abc418