### PR TITLE
Stop auto-opening How It Works panel

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -459,24 +459,6 @@ export default function Home() {
     setLastConversion(loadLastConversion());
   }, []);
 
-  useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
-    try {
-      const dismissed = window.localStorage.getItem(HOW_IT_WORKS_DISMISSED_KEY);
-      if (!dismissed) {
-        setHowItWorksLoaded(true);
-        setIsHowItWorksOpen(true);
-      }
-    } catch (error) {
-      console.error("Failed to read how it works dismissal state", error);
-      setHowItWorksLoaded(true);
-      setIsHowItWorksOpen(true);
-    }
-  }, []);
-
   const {
     data: trips,
     isLoading,
@@ -925,14 +907,14 @@ export default function Home() {
           </nav>
 
           {isDesktop ? (
-            <Dialog open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
-              <DialogContent
-                className="w-full max-w-3xl gap-0 overflow-hidden rounded-[32px] border border-slate-200/80 bg-white p-0 shadow-2xl"
-                aria-labelledby={howItWorksTitleId}
-                aria-describedby={howItWorksDescriptionId}
-                onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
-                onCloseAutoFocus={handleDialogCloseAutoFocus}
-              >
+              <Dialog open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
+                <DialogContent
+                  className="w-full max-w-3xl gap-0 overflow-hidden rounded-[32px] border border-slate-200/80 bg-white p-0 shadow-2xl max-h-[calc(100vh-4rem)] sm:max-h-[calc(100vh-6rem)]"
+                  aria-labelledby={howItWorksTitleId}
+                  aria-describedby={howItWorksDescriptionId}
+                  onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
+                  onCloseAutoFocus={handleDialogCloseAutoFocus}
+                >
                 {howItWorksContent}
               </DialogContent>
             </Dialog>


### PR DESCRIPTION
## Summary
- prevent the How It Works panel from opening automatically when visiting the dashboard
- constrain the desktop dialog height so the content fits in the viewport and remains scrollable

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68dc345406e0832ea4516cc53e87b255