### PR TITLE
Add dashboard header with responsive quick actions

### DIFF
--- a/client/src/assets/tripsync-logo.svg
+++ b/client/src/assets/tripsync-logo.svg
@@ -1,0 +1,11 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paint0_linear" x1="10" y1="6" x2="54" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#38BDF8"/>
+      <stop offset="0.5" stop-color="#818CF8"/>
+      <stop offset="1" stop-color="#F472B6"/>
+    </linearGradient>
+  </defs>
+  <rect x="6" y="6" width="52" height="52" rx="16" fill="url(#paint0_linear)"/>
+  <path d="M19.5 36.2L28.4 32.9L22.6 23.3C22.3 22.8 22.6 22.1 23.2 22L27.4 21.2C27.9 21.1 28.4 21.4 28.6 21.9L33.6 31.3L42.5 28C43.2 27.8 43.9 28.3 43.9 29.1L44 33.4C44 33.9 43.6 34.4 43.1 34.5L34.2 36.8L38.4 44.6C38.7 45.1 38.4 45.8 37.8 45.9L33.6 46.7C33.1 46.8 32.6 46.5 32.4 46L27.4 36.6L18.5 39.9C17.8 40.1 17.1 39.6 17.1 38.8L17 34.5C17 34 17.4 33.5 17.9 33.4L19.5 33Z" fill="white" fill-opacity="0.95"/>
+</svg>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -42,6 +42,12 @@
   --chart-4: hsl(340 75% 60%);
   --chart-5: hsl(226 83% 60%);
 
+  --header-gradient-start: hsl(200 88% 60%);
+  --header-gradient-end: hsl(278 82% 66%);
+  --on-header: #f8faff;
+  --on-header-muted: rgba(248, 250, 255, 0.65);
+  --header-shadow: 0 8px 24px -12px rgba(15, 23, 42, 0.35);
+
   /* Neutral tokens tuned for light UI */
   --neutral-900: hsl(222 47% 12%);
   --neutral-600: hsl(215 16% 45%);
@@ -71,6 +77,12 @@
   --destructive-foreground: hsl(210 40% 98%);
   --ring: hsl(199 89% 58%);
   --radius: 0.875rem;
+
+  --header-gradient-start: hsl(200 88% 55%);
+  --header-gradient-end: hsl(278 82% 62%);
+  --on-header: #f8faff;
+  --on-header-muted: rgba(248, 250, 255, 0.58);
+  --header-shadow: 0 10px 28px -14px rgba(15, 23, 42, 0.6);
 }
 
 @layer base {
@@ -197,6 +209,70 @@ body.dark .page-shell::after {
 .page-shell .border-slate-300,
 .page-shell .border-white {
   border-color: rgba(148, 163, 184, 0.45);
+}
+
+.dashboard-header {
+  background: linear-gradient(
+    90deg,
+    var(--header-gradient-start) 0%,
+    var(--header-gradient-end) 100%
+  );
+  color: var(--on-header);
+  box-shadow: var(--header-shadow);
+}
+
+.dashboard-header__link {
+  color: var(--on-header);
+  transition: color 0.2s ease;
+}
+
+.dashboard-header__link:hover {
+  color: color-mix(in srgb, var(--on-header) 90%, transparent);
+}
+
+.dashboard-header__link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--on-header) 85%, transparent);
+  outline-offset: 3px;
+}
+
+.dashboard-header__button {
+  color: var(--on-header);
+  border-color: var(--on-header-muted);
+  background-color: transparent;
+  transition: background-color 0.2s ease, border-color 0.2s ease,
+    color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-header__button:hover,
+.dashboard-header__button:focus-visible {
+  background-color: color-mix(in srgb, var(--on-header) 16%, transparent);
+  border-color: color-mix(in srgb, var(--on-header) 68%, transparent);
+}
+
+.dashboard-header__button:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--on-header) 85%, transparent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.18);
+}
+
+.dashboard-quick-actions-menu {
+  color: var(--on-header);
+  border-color: color-mix(in srgb, var(--on-header) 42%, transparent);
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(18px);
+  box-shadow: var(--header-shadow);
+}
+
+.dashboard-quick-actions-item {
+  color: var(--on-header);
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.dashboard-quick-actions-item[data-highlighted],
+.dashboard-quick-actions-item[data-state="open"] {
+  background-color: color-mix(in srgb, var(--on-header) 18%, transparent);
+  color: var(--on-header);
 }
 
 .page-shell .divide-slate-200,

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -26,6 +26,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { Sheet, SheetContent } from "@/components/ui/sheet";
 import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
   Avatar,
   AvatarFallback,
   AvatarImage,
@@ -42,6 +48,7 @@ import {
   MapPin,
 } from "lucide-react";
 import { Link } from "wouter";
+import tripSyncLogo from "@/assets/tripsync-logo.svg";
 import { StatCard } from "@/components/dashboard/stat-card";
 import {
   selectAllDestinationsUnique,
@@ -356,14 +363,16 @@ export default function Home() {
   const travelersCardRegionId = useId();
   const howItWorksTitleId = useId();
   const howItWorksDescriptionId = useId();
-  const converterButtonRef = useRef<HTMLButtonElement | null>(null);
-  const howItWorksButtonRef = useRef<HTMLButtonElement | null>(null);
+  const converterButtonRef = useRef<HTMLElement | null>(null);
+  const howItWorksButtonRef = useRef<HTMLElement | null>(null);
   const howItWorksCloseButtonRef = useRef<HTMLButtonElement | null>(null);
   const converterCloseButtonRef = useRef<HTMLButtonElement | null>(null);
   const shouldRestoreHowItWorksFocus = useRef(true);
   const upcomingSectionRef = useRef<HTMLHeadingElement | null>(null);
+  const quickActionsButtonRef = useRef<HTMLButtonElement | null>(null);
   const [isConverterOpen, setIsConverterOpen] = useState(false);
   const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false);
+  const [isQuickActionsOpen, setIsQuickActionsOpen] = useState(false);
   const [howItWorksLoaded, setHowItWorksLoaded] = useState(false);
   const [expandedCard, setExpandedCard] = useState<ExpandedCardKey | null>(null);
   const handleToggleCard = useCallback((card: ExpandedCardKey) => {
@@ -385,10 +394,16 @@ export default function Home() {
     setLocation("/profile");
   }, [setLocation]);
 
-  const handleHowItWorksButtonClick = useCallback(() => {
-    setHowItWorksLoaded(true);
-    setIsHowItWorksOpen(true);
-  }, []);
+  const handleHowItWorksButtonClick = useCallback(
+    (trigger?: HTMLElement | null) => {
+      if (trigger) {
+        howItWorksButtonRef.current = trigger;
+      }
+      setHowItWorksLoaded(true);
+      setIsHowItWorksOpen(true);
+    },
+    [],
+  );
 
   const focusElement = useCallback((element: HTMLElement | null) => {
     if (!element) {
@@ -421,6 +436,16 @@ export default function Home() {
       focusElement(converterCloseButtonRef.current);
     },
     [focusElement],
+  );
+
+  const handleConverterOpen = useCallback(
+    (trigger?: HTMLElement | null) => {
+      if (trigger) {
+        converterButtonRef.current = trigger;
+      }
+      handleConverterVisibilityChange(true);
+    },
+    [handleConverterVisibilityChange],
   );
 
   const handleHowItWorksOpenChange = useCallback(
@@ -458,6 +483,18 @@ export default function Home() {
   useEffect(() => {
     setLastConversion(loadLastConversion());
   }, []);
+
+  useEffect(() => {
+    if (isDesktop) {
+      setIsQuickActionsOpen(false);
+      return;
+    }
+
+    if (quickActionsButtonRef.current) {
+      howItWorksButtonRef.current = quickActionsButtonRef.current;
+      converterButtonRef.current = quickActionsButtonRef.current;
+    }
+  }, [isDesktop]);
 
   const {
     data: trips,
@@ -862,49 +899,126 @@ export default function Home() {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-50 via-white to-slate-100">
-      <div className="mx-auto w-full max-w-[1240px] px-6 pb-20 pt-24">
-        <div className="flex flex-col gap-8">
-          <nav
-            aria-label="Dashboard quick actions"
-            className="rounded-full border border-slate-200/80 bg-white/90 px-4 py-2 text-sm shadow-sm backdrop-blur"
+      <header role="banner" className="dashboard-header sticky top-0 z-50">
+        <div className="mx-auto flex w-full max-w-[1240px] items-center gap-4 px-4 py-3 sm:px-6 lg:px-8">
+          <Link
+            href="/"
+            className="dashboard-header__link inline-flex items-center gap-3 rounded-full px-2 py-1 text-sm font-semibold tracking-tight sm:text-base"
           >
-            <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-between">
-              <div className="flex flex-wrap items-center gap-2">
+            <img
+              src={tripSyncLogo}
+              alt="TripSync"
+              className="h-6 w-6 flex-shrink-0 sm:h-7 sm:w-7"
+              loading="lazy"
+              width={28}
+              height={28}
+            />
+            <span>TripSync</span>
+          </Link>
+          <div className="flex-1" />
+          {isDesktop ? (
+            <div className="flex items-center gap-3 sm:gap-4">
+              <Button
+                ref={(node) => {
+                  if (node) {
+                    howItWorksButtonRef.current = node;
+                  }
+                }}
+                type="button"
+                variant="outline"
+                className="dashboard-header__button h-10 rounded-full border bg-transparent px-4 text-sm font-medium text-[color:var(--on-header)] hover:text-[color:var(--on-header)] focus-visible:ring-0 focus-visible:ring-offset-0"
+                onClick={() => handleHowItWorksButtonClick()}
+                aria-controls={howItWorksTitleId}
+                aria-expanded={isHowItWorksOpen}
+                aria-haspopup="dialog"
+              >
+                How It Works
+              </Button>
+              <Button
+                ref={(node) => {
+                  if (node) {
+                    converterButtonRef.current = node;
+                  }
+                }}
+                type="button"
+                variant="outline"
+                className="dashboard-header__button h-10 rounded-full border bg-transparent px-4 text-sm font-medium text-[color:var(--on-header)] hover:text-[color:var(--on-header)] focus-visible:ring-0 focus-visible:ring-offset-0"
+                onClick={() => handleConverterOpen()}
+                aria-controls={converterDialogId}
+                aria-expanded={isConverterOpen}
+                aria-haspopup="dialog"
+              >
+                Currency Converter
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                className="dashboard-header__button h-10 rounded-full border bg-transparent px-4 text-sm font-medium text-[color:var(--on-header)] hover:text-[color:var(--on-header)] focus-visible:ring-0 focus-visible:ring-offset-0"
+                onClick={handleOpenProfile}
+              >
+                Profile & Preferences
+              </Button>
+            </div>
+          ) : (
+            <DropdownMenu open={isQuickActionsOpen} onOpenChange={setIsQuickActionsOpen}>
+              <DropdownMenuTrigger asChild>
                 <Button
-                  ref={howItWorksButtonRef}
+                  ref={quickActionsButtonRef}
                   type="button"
-                  variant="ghost"
-                  className="rounded-full px-4 text-sm font-medium text-slate-700 hover:text-slate-900"
-                  onClick={handleHowItWorksButtonClick}
+                  variant="outline"
+                  className="dashboard-header__button h-10 rounded-full border bg-transparent px-4 text-sm font-semibold text-[color:var(--on-header)] hover:text-[color:var(--on-header)] focus-visible:ring-0 focus-visible:ring-offset-0"
+                  aria-haspopup="menu"
+                  aria-expanded={isQuickActionsOpen}
+                >
+                  Quick actions
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                sideOffset={12}
+                className="dashboard-quick-actions-menu w-56 rounded-2xl border px-2 py-2 text-sm"
+                aria-label="Quick actions"
+              >
+                <DropdownMenuItem
+                  className="dashboard-quick-actions-item cursor-pointer rounded-xl px-3 py-2 text-sm focus:bg-transparent focus:text-inherit"
+                  onSelect={() => {
+                    setIsQuickActionsOpen(false);
+                    handleHowItWorksButtonClick(quickActionsButtonRef.current);
+                  }}
+                  aria-haspopup="dialog"
                   aria-controls={howItWorksTitleId}
                   aria-expanded={isHowItWorksOpen}
-                  aria-haspopup="dialog"
                 >
                   How It Works
-                </Button>
-                <Button
-                  ref={converterButtonRef}
-                  type="button"
-                  variant="ghost"
-                  className="rounded-full px-4 text-sm font-medium text-slate-700 hover:text-slate-900"
-                  onClick={() => handleConverterVisibilityChange(true)}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="dashboard-quick-actions-item cursor-pointer rounded-xl px-3 py-2 text-sm focus:bg-transparent focus:text-inherit"
+                  onSelect={() => {
+                    setIsQuickActionsOpen(false);
+                    handleConverterOpen(quickActionsButtonRef.current);
+                  }}
+                  aria-haspopup="dialog"
                   aria-controls={converterDialogId}
                   aria-expanded={isConverterOpen}
-                  aria-haspopup="dialog"
                 >
                   Currency Converter
-                </Button>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="rounded-full px-4 text-sm font-medium text-slate-700 hover:text-slate-900"
-                  onClick={handleOpenProfile}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="dashboard-quick-actions-item cursor-pointer rounded-xl px-3 py-2 text-sm focus:bg-transparent focus:text-inherit"
+                  onSelect={() => {
+                    setIsQuickActionsOpen(false);
+                    handleOpenProfile();
+                  }}
                 >
                   Profile & Preferences
-                </Button>
-              </div>
-            </div>
-          </nav>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </header>
+      <main className="mx-auto w-full max-w-[1240px] px-6 pb-20 pt-24 lg:pt-28">
+        <div className="flex flex-col gap-8">
 
           {isDesktop ? (
               <Dialog open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
@@ -1550,7 +1664,7 @@ export default function Home() {
             </section>
           )}
         </div>
-      </div>
+      </main>
     </div>
   );
 }

--- a/types/svg.d.ts
+++ b/types/svg.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: string
+  export default content
+}


### PR DESCRIPTION
## Summary
- add a gradient banner header to the dashboard with the TripSync logo and action buttons that respect focus restoration
- provide a quick actions dropdown on small screens while keeping modal triggers accessible and state-aware
- introduce shared header design tokens, styles, and an inline SVG logo asset for consistent contrast

## Testing
- npm run check
- npm run build:client

------
https://chatgpt.com/codex/tasks/task_e_68dc57aa2a04832e9e6bb806a1e6bd92