### PR TITLE
Make How It Works modal scrollable

### DIFF
--- a/client/src/components/dashboard/modal-layout.tsx
+++ b/client/src/components/dashboard/modal-layout.tsx
@@ -37,7 +37,7 @@ export default function ModalLayout({
     >
       <div
         className={cn(
-          "flex items-start justify-between gap-4 border-b border-slate-200/80 px-6 py-5",
+          "sticky top-0 z-10 flex items-start justify-between gap-4 border-b border-slate-200/80 bg-white/95 px-6 py-5 backdrop-blur",
           headerClassName,
         )}
       >
@@ -58,7 +58,7 @@ export default function ModalLayout({
       {footer ? (
         <div
           className={cn(
-            "shrink-0 border-t border-slate-200/80 px-6 py-5",
+            "sticky bottom-0 z-10 border-t border-slate-200/80 bg-white/95 px-6 py-5 backdrop-blur",
             footerClassName,
           )}
         >

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1021,14 +1021,14 @@ export default function Home() {
         <div className="flex flex-col gap-8">
 
           {isDesktop ? (
-              <Dialog open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
-                <DialogContent
-                  className="w-full max-w-3xl gap-0 overflow-hidden rounded-[32px] border border-slate-200/80 bg-white p-0 shadow-2xl max-h-[calc(100vh-4rem)] sm:max-h-[calc(100vh-6rem)]"
-                  aria-labelledby={howItWorksTitleId}
-                  aria-describedby={howItWorksDescriptionId}
-                  onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
-                  onCloseAutoFocus={handleDialogCloseAutoFocus}
-                >
+            <Dialog open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
+              <DialogContent
+                className="flex w-full max-w-3xl flex-col gap-0 overflow-hidden rounded-[32px] border border-slate-200/80 bg-white p-0 shadow-2xl max-h-[min(90vh,calc(100vh-4rem))] sm:max-h-[min(90vh,calc(100vh-6rem))]"
+                aria-labelledby={howItWorksTitleId}
+                aria-describedby={howItWorksDescriptionId}
+                onOpenAutoFocus={handleHowItWorksOpenAutoFocus}
+                onCloseAutoFocus={handleDialogCloseAutoFocus}
+              >
                 {howItWorksContent}
               </DialogContent>
             </Dialog>
@@ -1036,7 +1036,7 @@ export default function Home() {
             <Sheet open={isHowItWorksOpen} onOpenChange={handleHowItWorksOpenChange}>
               <SheetContent
                 side="bottom"
-                className="flex h-[100dvh] max-h-[100dvh] w-full max-w-full flex-col gap-0 overflow-hidden rounded-t-[32px] border-none bg-white p-0 shadow-2xl"
+                className="flex h-[min(90vh,100dvh)] max-h-[min(90vh,100dvh)] w-full max-w-full flex-col gap-0 overflow-hidden rounded-t-[32px] border-none bg-white p-0 shadow-2xl"
                 aria-labelledby={howItWorksTitleId}
                 aria-describedby={howItWorksDescriptionId}
                 onOpenAutoFocus={handleHowItWorksOpenAutoFocus}


### PR DESCRIPTION
## Summary
- allow the How It Works dialog to flex vertically with a 90% viewport max height so its body can scroll on desktop and mobile
- keep the modal header and footer visible while scrolling by making them sticky within the shared layout

## Testing
- npm exec vite -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68dc5d97661c832e870bcec4f5f4e24b