### PR TITLE
Fix calendar filters stacking context

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -1769,7 +1769,7 @@ export default function Trip() {
                             </Button>
                           </div>
                         </div>
-                        <div className="flex flex-wrap items-end gap-6">
+                        <div className="relative z-[1] flex flex-wrap items-end gap-6">
                             <div className="flex flex-col gap-1">
                               <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-neutral-900 dark:text-neutral-100">
                                 <Filter className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- ensure the group calendar filter row has a stacking context so dropdowns render above the header overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc8a7862f4832ea5cbdf872c8d93ef