### PR TITLE
Fix calendar overflow interactions

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -13,8 +13,14 @@ interface CalendarGridProps {
   selectedDate?: Date | null;
   onDayClick?: (date: Date) => void;
   onActivityClick?: (activity: ActivityWithDetails) => void;
+  onOverflowClick?: (day: Date, context: DayOverflowClickContext) => void;
   currentUserId?: string;
   highlightPersonalProposals?: boolean;
+}
+
+export interface DayOverflowClickContext {
+  hiddenCount: number;
+  trigger?: HTMLButtonElement | null;
 }
 
 const categoryIcons = {
@@ -163,6 +169,7 @@ export function CalendarGrid({
   selectedDate,
   onDayClick,
   onActivityClick,
+  onOverflowClick,
   currentUserId,
   highlightPersonalProposals,
 }: CalendarGridProps) {
@@ -315,6 +322,7 @@ export function CalendarGrid({
                       activities={dayActivities}
                       onActivityClick={onActivityClick}
                       onDayClick={onDayClick}
+                      onOverflowClick={onOverflowClick}
                       highlightPersonalProposals={highlightPersonalProposals}
                       currentUserId={currentUserId}
                     />
@@ -334,6 +342,7 @@ interface DayActivityListProps {
   activities: ActivityWithDetails[];
   onActivityClick?: (activity: ActivityWithDetails) => void;
   onDayClick?: (day: Date) => void;
+  onOverflowClick?: (day: Date, context: DayOverflowClickContext) => void;
   highlightPersonalProposals?: boolean;
   currentUserId?: string;
 }
@@ -342,7 +351,7 @@ function DayActivityList({
   day,
   activities,
   onActivityClick,
-  onDayClick,
+  onOverflowClick,
   highlightPersonalProposals,
   currentUserId,
 }: DayActivityListProps) {
@@ -719,7 +728,18 @@ function DayActivityList({
             data-hidden={hiddenCount > 0 ? "false" : "true"}
             onClick={event => {
               event.stopPropagation();
-              onDayClick?.(day);
+              onOverflowClick?.(day, {
+                hiddenCount,
+                trigger: event.currentTarget,
+              });
+            }}
+            onKeyDown={event => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.stopPropagation();
+                if (event.key === " ") {
+                  event.preventDefault();
+                }
+              }
             }}
             className={cn(
               "flex w-full items-center justify-center rounded-full bg-[color:var(--calendar-canvas-accent)]/80 px-3 py-1.5 text-[12px] font-semibold tracking-tight text-[color:var(--calendar-ink)] shadow-[0_12px_22px_-16px_rgba(15,23,42,0.5)] transition-all duration-200",


### PR DESCRIPTION
## Summary
- add a dedicated overflow click callback in the calendar grid so the +N control no longer bubbles to the add-activity handler and supports keyboard activation
- track +N activations and open a focus-managed day details dialog that reuses the day view list for the selected date
- surface all events for the chosen day, including in personal view, with analytics logging and restored focus on close

## Testing
- npm run check *(fails: existing type errors in server/locationService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dc8ec900ac832eb0b0e6e275077bdf