### PR TITLE
Add logging to SmartLocationSearch for debugging results

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -389,6 +389,9 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
           types: locationUtilsTypes ?? undefined,
         });
 
+        console.log("🔎 SmartLocationSearch: rawResults from API", rawResults);
+        console.log("🔎 Query:", currentQuery, "Allowed types:", locationUtilsTypes);
+
         const safeResults = Array.isArray(rawResults) ? rawResults.slice(0, 7) : [];
         const processedResults = safeResults.reduce<
           Array<{ normalized: LocationResult; typeForFilter: LocationTypeUpper }>
@@ -396,8 +399,11 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
           (accumulator, rawLocation) => {
             const normalized = normalizeFetchedLocation(rawLocation);
             if (!normalized) {
+              console.log("⚠️ Skipped rawLocation", rawLocation);
               return accumulator;
             }
+
+            console.log("✅ Normalized result:", normalized);
 
             let typeForFilter = toUpperLocationType(normalized.type);
 
@@ -426,6 +432,9 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
               return normalisedAllowedTypes.includes(typeForFilter);
             })
           : processedResults;
+
+        console.log("📊 Processed results before filtering:", processedResults);
+        console.log("📊 Filtered results (by allowedTypes):", filteredResults);
 
         setResults(
           filteredResults.map(({ normalized, typeForFilter }) => ({
@@ -684,6 +693,7 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
                   </div>
                 ) : null}
                 {results.map((rawLocation, index) => {
+                  console.log("🎨 Rendering result:", rawLocation);
                   if (!rawLocation || typeof rawLocation !== "object") {
                     return null;
                   }


### PR DESCRIPTION
## Summary
- add console logs to capture API results, query, and allowed types during searches
- log normalization decisions and filtered results before updating component state
- log each result rendered in the dropdown for display diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd47b5cad0832982a9b417a373ecd7