### PR TITLE
Allow searches to run after typing

### DIFF
--- a/client/src/components/SmartLocationSearch.tsx
+++ b/client/src/components/SmartLocationSearch.tsx
@@ -365,14 +365,6 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
       return;
     }
 
-    if (!isUserEditingRef.current && lastSelectedQueryRef.current === trimmedQuery) {
-      console.log(
-        "⛔ Skipping search, query matches last selected while not editing:",
-        trimmedQuery,
-      );
-      return;
-    }
-
     if (selectedLocation) {
       setSelectedLocation(null);
     }
@@ -382,14 +374,6 @@ const SmartLocationSearch = forwardRef<HTMLInputElement, SmartLocationSearchProp
       const currentQuery = internalInputRef.current?.value?.trim() ?? "";
       if (currentQuery.length < 2) {
         console.log("⛔ Skipping debounced search, query too short:", currentQuery);
-        return;
-      }
-
-      if (!isUserEditingRef.current && lastSelectedQueryRef.current === currentQuery) {
-        console.log(
-          "⛔ Skipping debounced search, query matches last selected while not editing:",
-          currentQuery,
-        );
         return;
       }
 


### PR DESCRIPTION
## Summary
- allow SmartLocationSearch to execute queries while typing by removing the guard that skipped searches when the query matched the last selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5943d29883299ce9ae3041a77934