### PR TITLE
Fix flight dropdowns to resolve airport codes

### DIFF
--- a/client/src/components/FlightLocationSearch.tsx
+++ b/client/src/components/FlightLocationSearch.tsx
@@ -20,7 +20,7 @@ interface FlightLocationSearchProps {
   allowedTypes?: Array<LocationType>;
 }
 
-const CITY_SEARCH_TYPES: LocationType[] = ["city"];
+const DEFAULT_FLIGHT_TYPES: LocationType[] = ["city", "airport"];
 const AIRPORT_SEARCH_TYPES: LocationType[] = ["airport"];
 const VALID_TYPES = new Set<LocationType>([
   "airport",
@@ -34,7 +34,7 @@ const IATA_PATTERN = /^[A-Za-z]{3}$/;
 
 const parseTypes = (value?: string): LocationType[] => {
   if (!value) {
-    return CITY_SEARCH_TYPES;
+    return DEFAULT_FLIGHT_TYPES;
   }
 
   const parsed = value
@@ -43,7 +43,7 @@ const parseTypes = (value?: string): LocationType[] => {
     .filter((type): type is LocationType => VALID_TYPES.has(type as LocationType));
 
   if (parsed.length === 0) {
-    return CITY_SEARCH_TYPES;
+    return DEFAULT_FLIGHT_TYPES;
   }
 
   return parsed;
@@ -75,7 +75,7 @@ const resolveBaseTypes = (
     return parsedLegacy;
   }
 
-  return CITY_SEARCH_TYPES;
+  return DEFAULT_FLIGHT_TYPES;
 };
 
 const shouldUseAirportSearch = (query: string): boolean => {
@@ -138,6 +138,7 @@ const FlightLocationSearch = forwardRef<HTMLInputElement, FlightLocationSearchPr
         value={query}
         className={className}
         allowedTypes={activeTypes}
+        enrichWithNearbyAirports
         onQueryChange={(nextValue) => {
           console.log("⌨️ FlightLocationSearch query changed:", nextValue);
           setQuery(nextValue);

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3622,6 +3622,7 @@ function FlightCoordination({
                   placeholder="Search departure city or airport"
                   value={departureQuery}
                   allowedTypes={['city', 'airport']}
+                  enrichWithNearbyAirports
                   onQueryChange={handleDepartureQueryChange}
                   onLocationSelect={(loc) => {
                     console.log("🔍 trip.tsx: Flight FROM selected", loc);
@@ -3662,6 +3663,7 @@ function FlightCoordination({
                   placeholder="Search arrival city or airport"
                   value={arrivalQuery}
                   allowedTypes={['city', 'airport']}
+                  enrichWithNearbyAirports
                   onQueryChange={handleArrivalQueryChange}
                   onLocationSelect={(loc) => {
                     console.log("🔍 trip.tsx: Flight TO selected", loc);
@@ -4008,6 +4010,8 @@ function FlightCoordination({
                 <SmartLocationSearch
                   placeholder="Departure airport"
                   value={manualFlightData.departureAirport}
+                  allowedTypes={['city', 'airport']}
+                  enrichWithNearbyAirports
                   onQueryChange={(value) => {
                     setManualFlightData((prev) => ({
                       ...prev,
@@ -4033,6 +4037,8 @@ function FlightCoordination({
                 <SmartLocationSearch
                   placeholder="Arrival airport"
                   value={manualFlightData.arrivalAirport}
+                  allowedTypes={['city', 'airport']}
+                  enrichWithNearbyAirports
                   onQueryChange={(value) => {
                     setManualFlightData((prev) => ({
                       ...prev,

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3402,19 +3402,34 @@ function FlightCoordination({
 
     const normalizedFlightNumber = manualFlightData.flightNumber.trim().toUpperCase();
     const normalizedAirline = manualFlightData.airline.trim();
+    const airlineCodeFromFlightNumber = (value: string): string | null => {
+      const match = value.match(/^([A-Z0-9]{2,3})\d+/);
+      return match ? match[1] : null;
+    };
+
     const deriveAirlineCode = (): string | null => {
       const fromState = manualFlightData.airlineCode?.trim().toUpperCase();
       if (fromState && /^[A-Z0-9]{2,3}$/.test(fromState)) {
         return fromState;
       }
 
-      const fromFlightNumber = normalizedFlightNumber.match(/^([A-Z]{2,3})\d+/);
+      const fromFlightNumber = airlineCodeFromFlightNumber(normalizedFlightNumber);
       if (fromFlightNumber) {
-        return fromFlightNumber[1];
+        return fromFlightNumber;
       }
 
       return null;
     };
+
+    if (process.env.NODE_ENV !== "production") {
+      const sampleMatches = {
+        AA: airlineCodeFromFlightNumber("AA123"),
+        DL: airlineCodeFromFlightNumber("DL4567"),
+        B6: airlineCodeFromFlightNumber("B61234"),
+        U2: airlineCodeFromFlightNumber("U21234"),
+      };
+      console.debug("[Flights] Airline code parsing samples", sampleMatches);
+    }
 
     const airlineCode = deriveAirlineCode();
     if (!airlineCode) {


### PR DESCRIPTION
## Summary
- default flight-specific searches to include both city and airport suggestions and enable airport enrichment
- resolve SmartLocationSearch selections with nearby airport lookups so city choices return IATA codes
- apply the enriched search to trip flight forms so both search and manual entries store airport codes

## Testing
- Attempted `npx tsc --noEmit --pretty false` *(hangs in this environment; manually interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68dd649b08048329ad0ff7f08745e3e8