### PR TITLE
Persist activity status and honor cancellations in proposal filters

### DIFF
--- a/client/src/pages/__tests__/proposalStatusFilters.test.ts
+++ b/client/src/pages/__tests__/proposalStatusFilters.test.ts
@@ -1,0 +1,27 @@
+import { filterProposalsByStatus } from "../proposalStatusFilters";
+
+describe("filterProposalsByStatus", () => {
+  const proposals = [
+    { id: 1, status: "canceled" },
+    { id: 2, status: "active" },
+    { id: 3, status: "scheduled" },
+  ];
+
+  it("includes canceled proposals when the canceled filter is active", () => {
+    const result = filterProposalsByStatus(proposals, "canceled");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([1]);
+  });
+
+  it("excludes canceled proposals from the active filter results", () => {
+    const result = filterProposalsByStatus(proposals, "active");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([2, 3]);
+  });
+
+  it("returns everything when using the all filter", () => {
+    const result = filterProposalsByStatus(proposals, "all");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([1, 2, 3]);
+  });
+});

--- a/client/src/pages/proposalStatusFilters.ts
+++ b/client/src/pages/proposalStatusFilters.ts
@@ -1,0 +1,23 @@
+export type StatusFilter = "all" | "active" | "canceled";
+
+export const normalizeProposalStatus = (status?: string | null): string =>
+  (status ?? "active").toLowerCase();
+
+export const filterProposalsByStatus = <T extends { status?: string | null }>(
+  items: T[],
+  statusFilter: StatusFilter,
+): T[] => {
+  if (statusFilter === "all") {
+    return items;
+  }
+
+  return items.filter((item) => {
+    const normalizedStatus = normalizeProposalStatus(item.status);
+
+    if (statusFilter === "canceled") {
+      return normalizedStatus === "canceled" || normalizedStatus === "cancelled";
+    }
+
+    return normalizedStatus !== "canceled" && normalizedStatus !== "cancelled";
+  });
+};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -2,7 +2,7 @@
 const config = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  roots: ['<rootDir>/shared', '<rootDir>/server'],
+  roots: ['<rootDir>/shared', '<rootDir>/server', '<rootDir>/client'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/client/src/$1',
     '^@shared/(.*)$': '<rootDir>/shared/$1',

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -233,6 +233,7 @@ export interface Activity {
   cost: number | null;
   maxCapacity: number | null;
   category: string;
+  status: string;
   createdAt: IsoDate | null;
   updatedAt: IsoDate | null;
 }


### PR DESCRIPTION
## Summary
- persist an activity status across storage, defaulting new activities to active and exposing it through the shared schema
- mark activities as canceled instead of deleting them and keep status information when building proposal cards
- reuse a shared proposal status filter helper in the client and add regression coverage to ensure canceled proposals only appear under the canceled filter

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddc78bd0f0832ead798fdb8cac8c09