### PR TITLE
Add CRUD endpoints for manual flights and hotels

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3464,7 +3464,18 @@ function FlightCoordination({
         method: "DELETE",
       });
     },
-    onSuccess: async () => {
+    onSuccess: async (_response, flightId) => {
+      queryClient.setQueryData<FlightWithDetails[] | undefined>(
+        [`/api/trips/${tripId}/flights`],
+        (existing) => {
+          if (!Array.isArray(existing)) {
+            return existing;
+          }
+
+          return existing.filter((flight) => flight.id !== flightId);
+        },
+      );
+
       await queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/flights`] });
       toast({
         title: "Flight removed",
@@ -4886,8 +4897,19 @@ function HotelBooking({
         method: "DELETE",
       });
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotels`] });
+    onSuccess: async (_response, hotelId) => {
+      queryClient.setQueryData<HotelWithDetails[] | undefined>(
+        [`/api/trips/${tripId}/hotels`],
+        (existing) => {
+          if (!Array.isArray(existing)) {
+            return existing;
+          }
+
+          return existing.filter((hotel) => hotel.id !== hotelId);
+        },
+      );
+
+      await queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotels`] });
       toast({
         title: "Hotel removed",
         description: "The hotel entry has been deleted.",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3088,17 +3088,17 @@ export function setupRoutes(app: Express) {
     try {
       const tripId = parseInt(req.params.id);
       const userId = getRequestUserId(req);
-      
+
       if (!userId) {
         return res.status(401).json({ message: "User ID not found" });
       }
-      
+
       const validatedData = insertFlightSchema.parse({
         ...req.body,
         tripId,
         bookedBy: userId
       });
-      
+
       const flight = await storage.addFlight(validatedData, userId);
       res.json(flight);
     } catch (error: unknown) {
@@ -3108,6 +3108,66 @@ export function setupRoutes(app: Express) {
       } else {
         res.status(500).json({ message: "Failed to add flight" });
       }
+    }
+  });
+
+  app.put('/api/flights/:id', isAuthenticated, async (req: any, res) => {
+    const flightId = Number.parseInt(req.params.id, 10);
+    if (Number.isNaN(flightId)) {
+      return res.status(400).json({ error: "Invalid flight id" });
+    }
+
+    const userId = getRequestUserId(req);
+    if (!userId) {
+      return res.status(401).json({ error: "User ID not found" });
+    }
+
+    try {
+      await storage.updateFlight(flightId, req.body ?? {}, userId);
+      res.json({ success: true });
+    } catch (error: unknown) {
+      console.error("Error updating flight:", error);
+      if (error instanceof Error) {
+        if (error.message.includes('Flight not found')) {
+          return res.status(404).json({ error: "Flight not found" });
+        }
+
+        if (error.message.includes('Only the creator')) {
+          return res.status(403).json({ error: error.message });
+        }
+      }
+
+      res.status(500).json({ error: "Failed to update flight" });
+    }
+  });
+
+  app.delete('/api/flights/:id', isAuthenticated, async (req: any, res) => {
+    const flightId = Number.parseInt(req.params.id, 10);
+    if (Number.isNaN(flightId)) {
+      return res.status(400).json({ error: "Invalid flight id" });
+    }
+
+    const userId = getRequestUserId(req);
+    if (!userId) {
+      return res.status(401).json({ error: "User ID not found" });
+    }
+
+    try {
+      await storage.deleteFlight(flightId, userId);
+      res.json({ success: true });
+    } catch (error: unknown) {
+      console.error("Error deleting flight:", error);
+      if (error instanceof Error) {
+        if (error.message.includes('Flight not found')) {
+          return res.status(404).json({ error: "Flight not found" });
+        }
+
+        if (error.message.includes('Only the creator')) {
+          return res.status(403).json({ error: error.message });
+        }
+      }
+
+      res.status(500).json({ error: "Failed to delete flight" });
     }
   });
 
@@ -3209,7 +3269,7 @@ export function setupRoutes(app: Express) {
     try {
       const tripId = parseInt(req.params.id);
       const userId = getRequestUserId(req);
-      
+
       if (!userId) {
         return res.status(401).json({ message: "User ID not found" });
       }
@@ -3271,6 +3331,66 @@ export function setupRoutes(app: Express) {
       } else {
         res.status(500).json({ message: "Failed to add hotel" });
       }
+    }
+  });
+
+  app.put('/api/hotels/:id', isAuthenticated, async (req: any, res) => {
+    const hotelId = Number.parseInt(req.params.id, 10);
+    if (Number.isNaN(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+
+    const userId = getRequestUserId(req);
+    if (!userId) {
+      return res.status(401).json({ error: "User ID not found" });
+    }
+
+    try {
+      await storage.updateHotel(hotelId, req.body ?? {}, userId);
+      res.json({ success: true });
+    } catch (error: unknown) {
+      console.error("Error updating hotel:", error);
+      if (error instanceof Error) {
+        if (error.message.includes('Hotel not found')) {
+          return res.status(404).json({ error: "Hotel not found" });
+        }
+
+        if (error.message.includes('Only the creator')) {
+          return res.status(403).json({ error: error.message });
+        }
+      }
+
+      res.status(500).json({ error: "Failed to update hotel" });
+    }
+  });
+
+  app.delete('/api/hotels/:id', isAuthenticated, async (req: any, res) => {
+    const hotelId = Number.parseInt(req.params.id, 10);
+    if (Number.isNaN(hotelId)) {
+      return res.status(400).json({ error: "Invalid hotel id" });
+    }
+
+    const userId = getRequestUserId(req);
+    if (!userId) {
+      return res.status(401).json({ error: "User ID not found" });
+    }
+
+    try {
+      await storage.deleteHotel(hotelId, userId);
+      res.json({ success: true });
+    } catch (error: unknown) {
+      console.error("Error deleting hotel:", error);
+      if (error instanceof Error) {
+        if (error.message.includes('Hotel not found')) {
+          return res.status(404).json({ error: "Hotel not found" });
+        }
+
+        if (error.message.includes('Only the creator')) {
+          return res.status(403).json({ error: error.message });
+        }
+      }
+
+      res.status(500).json({ error: "Failed to delete hotel" });
     }
   });
 


### PR DESCRIPTION
## Summary
- add authenticated PUT and DELETE endpoints for flights and hotels returning success responses
- reuse storage helpers to update and remove records with proper error handling
- update trip page mutations to optimistically drop removed flights and hotels before refetching

## Testing
- `npm run lint` *(fails: Missing script "lint" – command not defined in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68de7032afc48329b894885ad64027e5