### PR TITLE
Add manual flight and hotel proposal support

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -552,6 +552,8 @@ export interface Flight {
   aircraft: string | null;
   flightDuration: number | null;
   baggage: JsonValue | null;
+  proposalId?: number | null;
+  proposalStatus?: string | null;
   createdAt: IsoDate | null;
   updatedAt: IsoDate | null;
 }
@@ -621,6 +623,8 @@ export interface Hotel {
   bookingUrl: string | null;
   cancellationPolicy: string | null;
   notes: string | null;
+  proposalId?: number | null;
+  proposalStatus?: string | null;
   createdAt: IsoDate | null;
   updatedAt: IsoDate | null;
 }


### PR DESCRIPTION
## Summary
- add UI and React Query mutations so manually saved flights and hotels can be proposed to the group with appropriate feedback
- extend shared schema and storage to expose proposal linkage for saved items and add backend routes to turn manual entries into proposals

## Testing
- npm run check *(fails: existing TypeScript errors in server/index.ts and server/locationService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68de73dbb9d08329a7726e2691a4d00f