### PR TITLE
Handle filtered proposal fetching and stub proposal routes

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -3532,7 +3532,10 @@ function FlightCoordination({
     onSuccess: async () => {
       toast({ title: "Flight proposed to group." });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/flight-proposals`] }),
+        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/flights`] }),
+        queryClient.invalidateQueries({
+          queryKey: [`/api/trips/${tripId}/proposals/flights?mineOnly=true`],
+        }),
         queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/flights`] }),
       ]);
     },
@@ -4808,7 +4811,7 @@ function HotelBooking({
   });
 
   const { data: hotelProposals = [] } = useQuery<HotelProposalWithDetails[]>({
-    queryKey: [`/api/trips/${tripId}/hotel-proposals`],
+    queryKey: [`/api/trips/${tripId}/proposals/hotels`],
     enabled: !!tripId,
   });
 
@@ -4871,7 +4874,10 @@ function HotelBooking({
     onSuccess: async () => {
       toast({ title: "Hotel proposed to group." });
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotel-proposals`] }),
+        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/hotels`] }),
+        queryClient.invalidateQueries({
+          queryKey: [`/api/trips/${tripId}/proposals/hotels?mineOnly=true`],
+        }),
         queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotels`] }),
       ]);
     },
@@ -4925,7 +4931,12 @@ function HotelBooking({
           description: `${hotel.name} is now ready for everyone to review and rank.`,
         });
 
-        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotel-proposals`] });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/hotels`] }),
+          queryClient.invalidateQueries({
+            queryKey: [`/api/trips/${tripId}/proposals/hotels?mineOnly=true`],
+          }),
+        ]);
       } catch (error) {
         const errorObj = error instanceof Error ? error : new Error(String(error));
         if (isUnauthorizedError(errorObj)) {
@@ -5406,7 +5417,10 @@ function HotelBooking({
         tripId={tripId}
         onSuccess={() => {
           queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotels`] });
-          queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/hotel-proposals`] });
+          queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/hotels`] });
+          queryClient.invalidateQueries({
+            queryKey: [`/api/trips/${tripId}/proposals/hotels?mineOnly=true`],
+          });
         }}
       />
     </>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -8070,6 +8070,7 @@ ${selectUserColumns("participant_user", "participant_user_")}
       tripId?: number;
       proposalIds?: number[];
       currentUserId?: string;
+      proposedBy?: string;
     },
   ): Promise<HotelProposalWithDetails[]> {
     const conditions: string[] = [];
@@ -8085,6 +8086,12 @@ ${selectUserColumns("participant_user", "participant_user_")}
     if (options.proposalIds && options.proposalIds.length > 0) {
       conditions.push(`hp.id = ANY($${index}::int[])`);
       values.push(options.proposalIds);
+      index += 1;
+    }
+
+    if (options.proposedBy) {
+      conditions.push(`hp.proposed_by = $${index}`);
+      values.push(options.proposedBy);
       index += 1;
     }
 
@@ -8167,6 +8174,7 @@ ${selectUserColumns("participant_user", "participant_user_")}
       tripId?: number;
       proposalIds?: number[];
       currentUserId?: string;
+      proposedBy?: string;
     },
   ): Promise<FlightProposalWithDetails[]> {
     const conditions: string[] = [];
@@ -8182,6 +8190,12 @@ ${selectUserColumns("participant_user", "participant_user_")}
     if (options.proposalIds && options.proposalIds.length > 0) {
       conditions.push(`fp.id = ANY($${index}::int[])`);
       values.push(options.proposalIds);
+      index += 1;
+    }
+
+    if (options.proposedBy) {
+      conditions.push(`fp.proposed_by = $${index}`);
+      values.push(options.proposedBy);
       index += 1;
     }
 
@@ -8551,10 +8565,15 @@ ${selectUserColumns("participant_user", "participant_user_")}
   async getTripHotelProposals(
     tripId: number,
     currentUserId: string,
+    options: { proposedBy?: string } = {},
   ): Promise<HotelProposalWithDetails[]> {
     // PROPOSALS FEATURE: ensure manually saved hotels are represented as proposals.
     await this.ensureManualHotelsHaveProposals(tripId);
-    return this.fetchHotelProposals({ tripId, currentUserId });
+    return this.fetchHotelProposals({
+      tripId,
+      currentUserId,
+      proposedBy: options.proposedBy,
+    });
   }
 
   async getHotelProposalById(
@@ -9045,8 +9064,13 @@ ${selectUserColumns("participant_user", "participant_user_")}
   async getTripFlightProposals(
     tripId: number,
     currentUserId: string,
+    options: { proposedBy?: string } = {},
   ): Promise<FlightProposalWithDetails[]> {
-    return this.fetchFlightProposals({ tripId, currentUserId });
+    return this.fetchFlightProposals({
+      tripId,
+      currentUserId,
+      proposedBy: options.proposedBy,
+    });
   }
 
   async getFlightProposalById(


### PR DESCRIPTION
## Summary
- add GET proposal endpoints for flights and hotels that accept a mineOnly filter and stub missing restaurant/activity proposal routes
- extend storage helpers so proposal queries can be filtered by the proposing user
- update proposal UI logic to call the new endpoints, fetch mineOnly data for “My Proposals”, and refresh both shared and personal caches

## Testing
- npm run check *(fails: pre-existing TypeScript errors in server/index.ts and server/locationService.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68de7f567a4c832982a31dd6576f4370