### PR TITLE
Normalize attendee IDs when creating activities

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -64,7 +64,7 @@ export function AddActivityModal({ open, onOpenChange, tripId, selectedDate, mem
   const memberOptions = useMemo(
     () =>
       members.map((member) => ({
-        id: member.userId,
+        id: String(member.userId),
         name: getMemberDisplayName(member.user),
       })),
     [members],
@@ -115,11 +115,12 @@ export function AddActivityModal({ open, onOpenChange, tripId, selectedDate, mem
   }, [selectedDate, form, getDefaultValues]);
 
   const handleToggleAttendee = (userId: string, checked: boolean | "indeterminate") => {
-    const current = new Set(form.getValues("attendeeIds") ?? []);
+    const normalizedId = String(userId);
+    const current = new Set((form.getValues("attendeeIds") ?? []).map(String));
     if (checked === true) {
-      current.add(userId);
+      current.add(normalizedId);
     } else if (checked === false) {
-      current.delete(userId);
+      current.delete(normalizedId);
     }
     form.setValue("attendeeIds", Array.from(current), { shouldDirty: true });
   };
@@ -164,13 +165,17 @@ export function AddActivityModal({ open, onOpenChange, tripId, selectedDate, mem
         ...rest
       } = data;
 
+      const normalizedAttendeeIds = Array.from(
+        new Set((attendeeIds ?? []).map((id: string) => String(id))),
+      );
+
       const activityData = {
         ...rest,
         startTime: startDateTime.toISOString(),
         endTime: endDateTime?.toISOString() || null,
         cost: cost ? parseFloat(cost) : null,
         maxCapacity: maxCapacity ? parseInt(maxCapacity) : null,
-        attendeeIds: Array.from(new Set(attendeeIds)),
+        attendeeIds: normalizedAttendeeIds,
       };
 
       await apiRequest(`/api/trips/${tripId}/activities`, {


### PR DESCRIPTION
## Summary
- normalize trip member IDs to strings before storing them in the Add Activity form
- ensure attendee selections are coerced to string IDs before submitting the create activity request

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de8ebc0380832e838183bd915b1e31