### PR TITLE
Add manual activity workflow with external search prompts

### DIFF
--- a/client/src/lib/externalRedirects.ts
+++ b/client/src/lib/externalRedirects.ts
@@ -1,5 +1,6 @@
 export const FLIGHT_REDIRECT_STORAGE_KEY = "vacationsync:flight_redirect";
 export const HOTEL_REDIRECT_STORAGE_KEY = "vacationsync:hotel_redirect";
+export const ACTIVITY_REDIRECT_STORAGE_KEY = "vacationsync:activity_redirect";
 
 export const markExternalRedirect = (storageKey: string) => {
   if (typeof window === "undefined") {


### PR DESCRIPTION
## Summary
- add an activity-specific redirect flag and trip-level confirmation flow after returning from external searches
- extend the Discover Activities tab with Viator/Airbnb search shortcuts, a manual entry modal, and a list of saved manual activities
- persist manual activities via the existing API and surface them ahead of discovery results

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68de8f4040cc83298995b967dbe73875