### PR TITLE
Handle unscheduled activity proposals gracefully

### DIFF
--- a/client/src/components/__tests__/calendar-grid.proposal.test.tsx
+++ b/client/src/components/__tests__/calendar-grid.proposal.test.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { CalendarGrid } from "../calendar-grid";
+import type { ActivityWithDetails, TripWithDetails, User } from "@shared/schema";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+let useLayoutEffectSpy: jest.SpiedFunction<typeof React.useLayoutEffect>;
+
+beforeAll(() => {
+  useLayoutEffectSpy = jest
+    .spyOn(React, "useLayoutEffect")
+    .mockImplementation(React.useEffect);
+});
+
+afterAll(() => {
+  useLayoutEffectSpy.mockRestore();
+});
+
+describe("CalendarGrid proposal handling", () => {
+  it("renders proposals without a start time as Time TBD without epoch dates", () => {
+    const user: User = {
+      id: "user-1",
+      email: "user@example.com",
+      username: "tester",
+      firstName: "Test",
+      lastName: "User",
+      phoneNumber: null,
+      passwordHash: null,
+      profileImageUrl: null,
+      cashAppUsername: null,
+      cashAppUsernameLegacy: null,
+      cashAppPhone: null,
+      cashAppPhoneLegacy: null,
+      venmoUsername: null,
+      venmoPhone: null,
+      timezone: null,
+      defaultLocation: null,
+      defaultLocationCode: null,
+      defaultCity: null,
+      defaultCountry: null,
+      authProvider: null,
+      notificationPreferences: null,
+      hasSeenHomeOnboarding: false,
+      hasSeenTripOnboarding: false,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    const activity = {
+      id: 1,
+      tripCalendarId: 1,
+      postedBy: user.id,
+      name: "Sunset Cruise",
+      description: null,
+      startTime: null as unknown as string,
+      endTime: null,
+      location: "Harbor",
+      cost: null,
+      maxCapacity: null,
+      category: "activities",
+      status: "active",
+      type: "PROPOSE" as ActivityWithDetails["type"],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      poster: user,
+      invites: [],
+      acceptances: [],
+      comments: [],
+      acceptedCount: 0,
+      pendingCount: 0,
+      declinedCount: 0,
+      waitlistedCount: 0,
+      timeOptions: [
+        new Date(Date.UTC(2024, 0, 15, 18, 0)),
+      ] as unknown as string[],
+    } as ActivityWithDetails & { timeOptions?: (string | Date)[] };
+
+    const trip: TripWithDetails = {
+      id: 1,
+      name: "Demo Trip",
+      destination: "Testville",
+      startDate: new Date(Date.UTC(2024, 0, 1)).toISOString(),
+      endDate: new Date(Date.UTC(2024, 0, 31)).toISOString(),
+      shareCode: "share-code",
+      createdBy: user.id,
+      createdAt: new Date().toISOString(),
+      geonameId: null,
+      cityName: null,
+      countryName: null,
+      latitude: null,
+      longitude: null,
+      population: null,
+      coverImageUrl: null,
+      coverPhotoUrl: null,
+      coverPhotoCardUrl: null,
+      coverPhotoThumbUrl: null,
+      coverPhotoAlt: null,
+      coverPhotoAttribution: null,
+      coverPhotoStorageKey: null,
+      coverPhotoOriginalUrl: null,
+      coverPhotoFocalX: null,
+      coverPhotoFocalY: null,
+      coverPhotoUploadSize: null,
+      coverPhotoUploadType: null,
+      creator: user,
+      members: [
+        {
+          id: 1,
+          tripCalendarId: 1,
+          userId: user.id,
+          role: "member",
+          departureLocation: null,
+          departureAirport: null,
+          joinedAt: null,
+          user,
+        },
+      ],
+      memberCount: 1,
+    };
+
+    const markup = renderToString(
+      <TooltipProvider>
+        <CalendarGrid
+          currentMonth={new Date(Date.UTC(2024, 0, 1))}
+          activities={[activity]}
+          trip={trip}
+          selectedDate={new Date(Date.UTC(2024, 0, 15))}
+          currentUserId={user.id}
+          highlightPersonalProposals
+        />
+      </TooltipProvider>,
+    );
+
+    const textContent = markup.replace(/<[^>]*>/g, " ");
+
+    expect(textContent).toContain("Sunset Cruise");
+    expect(textContent).toContain("Proposed");
+    expect(textContent).toContain("TBD");
+    expect(textContent).not.toContain("1970");
+  });
+});

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -238,6 +238,92 @@ const parseTripDateToLocal = (value?: string | Date | null): Date | null => {
   return Number.isNaN(fallback.getTime()) ? null : fallback;
 };
 
+type ActivityWithSchedulingDetails = Omit<ActivityWithDetails, "startTime" | "endTime"> & {
+  startTime?: string | Date | null;
+  endTime?: string | Date | null;
+  timeOptions?: (string | Date | null | undefined)[] | null;
+};
+
+const parseActivityDate = (value: unknown): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : value;
+  }
+
+  if (typeof value === "string" || typeof value === "number") {
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  return null;
+};
+
+const getActivityStartDate = (activity: ActivityWithSchedulingDetails): Date | null => {
+  const rawStart = activity.startTime ?? (activity as ActivityWithDetails).startTime ?? null;
+  return parseActivityDate(rawStart);
+};
+
+const getActivityEndDate = (activity: ActivityWithSchedulingDetails): Date | null => {
+  const rawEnd = activity.endTime ?? (activity as ActivityWithDetails).endTime ?? null;
+  return parseActivityDate(rawEnd);
+};
+
+const getActivityTimeOptions = (activity: ActivityWithSchedulingDetails): Date[] => {
+  const rawOptions = activity.timeOptions;
+  if (!Array.isArray(rawOptions)) {
+    return [];
+  }
+
+  const seen = new Set<number>();
+
+  return rawOptions
+    .map(option => parseActivityDate(option))
+    .filter((option): option is Date => Boolean(option))
+    .filter(option => {
+      const time = option.getTime();
+      if (seen.has(time)) {
+        return false;
+      }
+      seen.add(time);
+      return true;
+    });
+};
+
+const getActivityPrimaryDate = (activity: ActivityWithSchedulingDetails): Date | null => {
+  const start = getActivityStartDate(activity);
+  if (start) {
+    return start;
+  }
+
+  const [firstOption] = getActivityTimeOptions(activity);
+  return firstOption ?? null;
+};
+
+const getActivityDateCandidates = (activity: ActivityWithSchedulingDetails): Date[] => {
+  const primary = getActivityPrimaryDate(activity);
+  const candidates: Date[] = [];
+
+  if (primary) {
+    candidates.push(primary);
+  }
+
+  for (const option of getActivityTimeOptions(activity)) {
+    if (!primary || option.getTime() !== primary.getTime()) {
+      candidates.push(option);
+    }
+  }
+
+  return candidates;
+};
+
+const getActivityComparisonPoint = (activity: ActivityWithSchedulingDetails): Date | null => {
+  const end = getActivityEndDate(activity);
+  return end ?? getActivityPrimaryDate(activity);
+};
+
 interface DayViewProps {
   date: Date;
   activities: ActivityWithDetails[];
@@ -251,6 +337,7 @@ interface DayViewProps {
   onSubmitRsvp?: (activity: ActivityWithDetails, action: ActivityRsvpAction) => void;
   isRsvpPending?: boolean;
   viewMode?: "group" | "personal";
+  proposalFallbackDate?: Date | null;
 }
 
 const getParticipantDisplayName = (user: User) => {
@@ -272,10 +359,22 @@ const getParticipantDisplayName = (user: User) => {
   return user.email || "Trip member";
 };
 
-const formatActivityTimeRange = (startTime: string | Date, endTime?: string | Date | null) => {
-  const startDate = new Date(startTime);
+const formatActivityTimeRange = (
+  startTime: string | Date | null | undefined,
+  endTime?: string | Date | null | undefined,
+  timeOptions?: (string | Date | null | undefined)[] | null,
+) => {
+  const startDate = parseActivityDate(startTime);
 
-  if (Number.isNaN(startDate.getTime())) {
+  if (!startDate) {
+    const firstOption = Array.isArray(timeOptions)
+      ? timeOptions.map(option => parseActivityDate(option)).find((value): value is Date => Boolean(value))
+      : null;
+
+    if (firstOption) {
+      return `Time TBD (proposed ${format(firstOption, "MMM d, h:mm a")})`;
+    }
+
     return "Time TBD";
   }
 
@@ -285,9 +384,9 @@ const formatActivityTimeRange = (startTime: string | Date, endTime?: string | Da
     return startLabel;
   }
 
-  const endDate = new Date(endTime);
+  const endDate = parseActivityDate(endTime);
 
-  if (Number.isNaN(endDate.getTime())) {
+  if (!endDate) {
     return startLabel;
   }
 
@@ -296,6 +395,40 @@ const formatActivityTimeRange = (startTime: string | Date, endTime?: string | Da
   }
 
   return `${startLabel} - ${format(endDate, "MMM d, h:mm a")}`;
+};
+
+const activityMatchesDay = (
+  activity: ActivityWithSchedulingDetails,
+  day: Date,
+  proposalFallbackDate: Date | null,
+) => {
+  const candidates = getActivityDateCandidates(activity);
+  if (candidates.some(candidate => isSameDay(candidate, day))) {
+    return true;
+  }
+
+  if (proposalFallbackDate && activity.type === "PROPOSE") {
+    return isSameDay(proposalFallbackDate, day);
+  }
+
+  return false;
+};
+
+const compareActivitiesByPrimaryDate = (
+  a: ActivityWithSchedulingDetails,
+  b: ActivityWithSchedulingDetails,
+) => {
+  const aDate = getActivityPrimaryDate(a);
+  const bDate = getActivityPrimaryDate(b);
+
+  if (aDate && bDate) {
+    return aDate.getTime() - bDate.getTime();
+  }
+
+  if (aDate) return -1;
+  if (bDate) return 1;
+
+  return a.name.localeCompare(b.name);
 };
 
 function DayView({
@@ -311,12 +444,14 @@ function DayView({
   onSubmitRsvp,
   isRsvpPending,
   viewMode = "group",
+  proposalFallbackDate = null,
 }: DayViewProps) {
   const dayActivities = activities
-    .filter((activity) => isSameDay(new Date(activity.startTime), date))
-    .sort(
-      (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-    );
+    .filter(activity => activityMatchesDay(activity as ActivityWithSchedulingDetails, date, proposalFallbackDate))
+    .sort((a, b) => compareActivitiesByPrimaryDate(
+      a as ActivityWithSchedulingDetails,
+      b as ActivityWithSchedulingDetails,
+    ));
 
   const now = new Date();
   const isPersonalView = viewMode === "personal";
@@ -361,6 +496,7 @@ function DayView({
       ) : (
         <div className="space-y-4">
           {dayActivities.map((activity) => {
+            const activityWithScheduling = activity as ActivityWithSchedulingDetails;
             const waitlistedCount =
               activity.waitlistedCount
                 ?? activity.invites.filter((invite) => invite.status === "waitlisted").length;
@@ -381,17 +517,11 @@ function DayView({
             const statusBadgeClasses = showPersonalProposalChip
               ? "bg-blue-100 text-blue-800 border-blue-200"
               : inviteStatusBadgeClasses[derivedStatus];
-            const isPastActivity = (() => {
-              const end = activity.endTime ? new Date(activity.endTime) : null;
-              const start = new Date(activity.startTime);
-              const comparisonTarget = end && !Number.isNaN(end.getTime()) ? end : start;
-              return Number.isNaN(comparisonTarget.getTime())
-                ? false
-                : comparisonTarget.getTime() < now.getTime();
-            })();
-            const rsvpCloseDate = activity.rsvpCloseTime
-              ? new Date(activity.rsvpCloseTime)
-              : null;
+            const comparisonTarget = getActivityComparisonPoint(activityWithScheduling);
+            const isPastActivity = Boolean(
+              comparisonTarget && comparisonTarget.getTime() < now.getTime(),
+            );
+            const rsvpCloseDate = parseActivityDate(activity.rsvpCloseTime ?? null);
             const isRsvpClosed = Boolean(
               rsvpCloseDate && !Number.isNaN(rsvpCloseDate.getTime()) && rsvpCloseDate < now,
             );
@@ -610,7 +740,11 @@ function DayView({
                     <div className="flex flex-wrap items-center justify-end gap-2">
                       <span className="inline-flex items-center">
                         <Clock className="mr-2 h-4 w-4" aria-hidden="true" />
-                        {formatActivityTimeRange(activity.startTime, activity.endTime)}
+                        {formatActivityTimeRange(
+                          activityWithScheduling.startTime ?? activity.startTime ?? null,
+                          activityWithScheduling.endTime ?? activity.endTime ?? null,
+                          activityWithScheduling.timeOptions ?? null,
+                        )}
                       </span>
                       <Badge className="bg-primary/10 text-primary" variant="secondary">
                         {activity.acceptedCount} going
@@ -1049,8 +1183,10 @@ export default function Trip() {
   };
 
   const handleViewOnCalendar = (activity: ActivityWithDetails) => {
-    const targetDate = clampDateToTrip(new Date(activity.startTime));
-    if (targetDate) {
+    const activityWithScheduling = activity as ActivityWithSchedulingDetails;
+    const primaryDate = getActivityPrimaryDate(activityWithScheduling);
+    if (primaryDate) {
+      const targetDate = clampDateToTrip(primaryDate);
       setActiveTab("calendar");
       setGroupCalendarView("day");
       setGroupViewDate(targetDate);
@@ -1093,6 +1229,18 @@ export default function Trip() {
     const parsed = parseTripDateToLocal(trip?.endDate);
     return parsed ? startOfDay(parsed) : null;
   }, [trip?.endDate]);
+
+  const proposalFallbackDate = useMemo(() => {
+    if (tripStartDate) {
+      return tripStartDate;
+    }
+
+    if (tripEndDate) {
+      return tripEndDate;
+    }
+
+    return null;
+  }, [tripEndDate, tripStartDate]);
 
   const clampDateToTrip = (date: Date) => {
     if (!tripStartDate && !tripEndDate) {
@@ -1202,17 +1350,19 @@ export default function Trip() {
   const sortedMyInvitedActivities = useMemo(() => {
     const now = Date.now();
     return [...filteredMyInvitedActivities].sort((a, b) => {
-      const aTime = new Date(a.startTime).getTime();
-      const bTime = new Date(b.startTime).getTime();
-      const aIsPast = Number.isNaN(aTime) ? 1 : aTime < now ? 1 : 0;
-      const bIsPast = Number.isNaN(bTime) ? 1 : bTime < now ? 1 : 0;
+      const aDate = getActivityPrimaryDate(a as ActivityWithSchedulingDetails);
+      const bDate = getActivityPrimaryDate(b as ActivityWithSchedulingDetails);
+      const aTime = aDate ? aDate.getTime() : Number.POSITIVE_INFINITY;
+      const bTime = bDate ? bDate.getTime() : Number.POSITIVE_INFINITY;
+      const aIsPast = aDate ? (aTime < now ? 1 : 0) : 0;
+      const bIsPast = bDate ? (bTime < now ? 1 : 0) : 0;
 
       if (aIsPast !== bIsPast) {
         return aIsPast - bIsPast;
       }
 
-      if (Number.isNaN(aTime) || Number.isNaN(bTime)) {
-        return 0;
+      if (!Number.isFinite(aTime) && !Number.isFinite(bTime)) {
+        return a.name.localeCompare(b.name);
       }
 
       return aTime - bTime;
@@ -1349,11 +1499,18 @@ export default function Trip() {
   const upcomingActivities = useMemo(() => {
     const now = new Date();
     return filteredActivities
-      .map((activity) => ({
-        activity,
-        start: new Date(activity.startTime),
-      }))
-      .filter(({ start }) => !Number.isNaN(start.getTime()) && start.getTime() >= now.getTime())
+      .map((activity) => {
+        const activityWithScheduling = activity as ActivityWithSchedulingDetails;
+        const start = getActivityPrimaryDate(activityWithScheduling);
+        return { activity, start };
+      })
+      .filter((entry): entry is { activity: ActivityWithDetails; start: Date } => {
+        if (!entry.start) {
+          return false;
+        }
+
+        return entry.start.getTime() >= now.getTime();
+      })
       .sort((a, b) => a.start.getTime() - b.start.getTime());
   }, [filteredActivities]);
 
@@ -1956,6 +2113,7 @@ export default function Trip() {
                             currentUser={user}
                             onSubmitRsvp={(activity, action) => submitRsvpAction(activity.id, action)}
                             isRsvpPending={respondToInviteMutation.isPending}
+                            proposalFallbackDate={proposalFallbackDate}
                           />
                         ) : (
                           <div className="rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-8 text-center text-sm text-neutral-600">
@@ -2063,6 +2221,7 @@ export default function Trip() {
                             onSubmitRsvp={(activity, action) => submitRsvpAction(activity.id, action)}
                             isRsvpPending={respondToInviteMutation.isPending}
                             viewMode="personal"
+                            proposalFallbackDate={proposalFallbackDate}
                           />
                         ) : (
                           <div className="rounded-lg border border-dashed border-neutral-300 bg-neutral-50 p-8 text-center text-sm text-neutral-600">
@@ -2302,13 +2461,12 @@ export default function Trip() {
                     <ScrollArea className="max-h-[60vh] pr-4">
                       <div className="space-y-3 py-1">
                         {sortedMyInvitedActivities.map((activity) => {
+                          const activityWithScheduling = activity as ActivityWithSchedulingDetails;
                           const invite = activity.invites?.find((entry) => entry.userId === user.id);
                           const status: ActivityInviteStatus = invite?.status ?? "pending";
-                          const start = new Date(activity.startTime);
-                          const dateLabel = Number.isNaN(start.getTime())
-                            ? null
-                            : format(start, "EEEE, MMM d");
-                          const timeLabel = Number.isNaN(start.getTime()) ? null : format(start, "h:mm a");
+                          const start = getActivityPrimaryDate(activityWithScheduling);
+                          const dateLabel = start ? format(start, "EEEE, MMM d") : null;
+                          const timeLabel = start ? format(start, "h:mm a") : null;
                           const locationLabel = activity.location?.trim();
                           const waitlistedCount =
                             activity.waitlistedCount
@@ -2335,12 +2493,14 @@ export default function Trip() {
                               <div className="flex items-start justify-between gap-4">
                                 <div>
                                   <p className="text-base font-semibold text-neutral-900">{activity.name}</p>
-                                  {(dateLabel || timeLabel) && (
+                                  {dateLabel || timeLabel ? (
                                     <p className="mt-1 text-sm text-neutral-600">
                                       {dateLabel}
                                       {dateLabel && timeLabel ? " • " : ""}
                                       {timeLabel}
                                     </p>
+                                  ) : (
+                                    <p className="mt-1 text-sm text-neutral-600">Time TBD</p>
                                   )}
                                   {locationLabel && (
                                     <p className="mt-2 flex items-center gap-2 text-xs text-neutral-500">
@@ -2622,6 +2782,7 @@ export default function Trip() {
                 canGoNext={false}
                 onActivityClick={handleActivityClick}
                 viewMode={dayDetailsState.viewMode}
+                proposalFallbackDate={proposalFallbackDate}
                 {...(dayDetailsState.viewMode === "personal"
                   ? {
                       currentUser: user,

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true
+    "noEmit": true,
+    "jsx": "react-jsx"
   },
   "include": [
     "client/src/**/*",


### PR DESCRIPTION
## Summary
- show "Time TBD" for calendar chips whose activities lack scheduled start times while still surfacing proposals via time options
- reuse scheduling helpers across the trip page so day views, summaries, and navigation skip epoch dates for unscheduled proposals
- add a regression test for PROPOSE activities without start times and configure Jest to compile JSX fixtures

## Testing
- npm test -- calendar-grid.proposal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de908a8648832e9581bca0f4ad1a33