### PR TITLE
Ensure activities proposed from discovery include trip members

### DIFF
--- a/client/src/pages/activities.tsx
+++ b/client/src/pages/activities.tsx
@@ -281,6 +281,19 @@ export default function Activities() {
       // Combine date and time into ISO string
       const startDateTime = new Date(`${startDate}T${startTime}`).toISOString();
       
+      const attendeeIds = trip?.members
+        ? Array.from(
+            new Set(
+              trip.members
+                .map((member) => member.userId)
+                .filter((memberId): memberId is string => Boolean(memberId))
+                .concat(user?.id ? [user.id] : []),
+            ),
+          )
+        : user
+          ? [user.id]
+          : [];
+
       const response = await apiFetch(`/api/trips/${tripId}/activities`, {
         method: 'POST',
         headers: {
@@ -297,7 +310,7 @@ export default function Activities() {
           cost: activity.price ? parseFloat(activity.price) : null,
           maxCapacity: 10,
           tripCalendarId: parseInt(tripId!),
-          attendeeIds: user ? [user.id] : [],
+          attendeeIds,
         }),
       });
 


### PR DESCRIPTION
## Summary
- update the discovery activity proposal flow to include all trip members in the attendee list so invitations reach the rest of the group

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/calendar-grid.proposal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68de9c7a1708832eba497c9113a3794d