### PR TITLE
Ensure activity invite creation is transactional

### DIFF
--- a/server/__tests__/createActivityWithInvites.test.ts
+++ b/server/__tests__/createActivityWithInvites.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+import type { InsertActivity } from "@shared/schema";
+
+process.env.DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgres://user:pass@localhost:5432/test";
+
+const queryMock = jest.fn();
+
+let storage: typeof import("../storage")["storage"];
+let dbQuerySpy: jest.SpiedFunction<typeof import("../db")["query"]>;
+
+beforeAll(async () => {
+  jest.resetModules();
+  const dbModule: any = await import("../db");
+  dbQuerySpy = jest.spyOn(dbModule, "query").mockImplementation(queryMock as any);
+  const storageModule: any = await import("../storage");
+  storage = storageModule.storage;
+});
+
+beforeEach(() => {
+  queryMock.mockReset();
+  dbQuerySpy.mockImplementation(queryMock as any);
+  (storage as any).activityTypeColumnInitialized = true;
+  (storage as any).activityInvitesInitialized = true;
+});
+
+describe("createActivityWithInvites", () => {
+  it("rolls back the activity creation when invite persistence fails", async () => {
+    const error = new Error("failed to persist invites");
+
+    const activityInput: InsertActivity = {
+      tripCalendarId: 42,
+      name: "Beach Bonfire",
+      description: null,
+      startTime: new Date().toISOString(),
+      endTime: null,
+      location: null,
+      cost: null,
+      maxCapacity: null,
+      category: "fun",
+      type: "SCHEDULED",
+    };
+
+    const activityRow = {
+      id: 99,
+      trip_calendar_id: 42,
+      posted_by: "organizer",
+      name: activityInput.name,
+      description: null,
+      start_time: activityInput.startTime,
+      end_time: null,
+      location: null,
+      cost: null,
+      max_capacity: null,
+      category: activityInput.category,
+      status: "active",
+      type: activityInput.type,
+      created_at: new Date(),
+      updated_at: new Date(),
+    };
+
+    queryMock
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [activityRow] }) // insert activity
+      .mockRejectedValueOnce(error) // insert invites
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    await expect(
+      storage.createActivityWithInvites(activityInput, "organizer", ["friend"]),
+    ).rejects.toThrow("failed to persist invites");
+
+    expect(queryMock).toHaveBeenNthCalledWith(1, "BEGIN");
+    expect(queryMock).toHaveBeenNthCalledWith(
+      4,
+      "ROLLBACK",
+    );
+    expect(
+      queryMock.mock.calls.map(([sql]) => sql),
+    ).not.toContain("COMMIT");
+  });
+});

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1930,9 +1930,11 @@ export function setupRoutes(app: Express) {
       attendeeIdSet.delete(userId);
       const inviteeIds = Array.from(attendeeIdSet);
 
-      const activity = await storage.createActivity(validationResult.data, userId, inviteeIds);
-
-      await storage.setActivityInviteStatus(activity.id, userId, "accepted");
+      const activity = await storage.createActivityWithInvites(
+        validationResult.data,
+        userId,
+        inviteeIds,
+      );
 
       const attendeesToNotify = inviteeIds.filter((attendeeId) => attendeeId !== userId);
 


### PR DESCRIPTION
## Summary
- add a transactional helper that wraps activity creation, invite persistence, and organizer acceptance
- update the trips activity creation route to rely on the transactional helper
- add a regression test that verifies invite failures roll back the activity insert

## Testing
- npm test -- --runTestsByPath server/__tests__/createActivityWithInvites.test.ts
- npm test -- --runTestsByPath server/__tests__/applyActivityResponse.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dea75268bc832e9175187dd2b86278