### PR TITLE
Handle activity invite constraint violations

### DIFF
--- a/server/__mocks__/vite.ts
+++ b/server/__mocks__/vite.ts
@@ -1,9 +1,12 @@
-export const log = {
-  info: (..._args: unknown[]) => {},
-  error: (..._args: unknown[]) => {},
-  warn: (..._args: unknown[]) => {},
-  debug: (..._args: unknown[]) => {},
-};
+export const log = Object.assign(
+  (..._args: unknown[]) => {},
+  {
+    info: (..._args: unknown[]) => {},
+    error: (..._args: unknown[]) => {},
+    warn: (..._args: unknown[]) => {},
+    debug: (..._args: unknown[]) => {},
+  },
+);
 
 export const setupVite = async () => ({
   app: { use: () => {} },

--- a/shared/activityValidation.ts
+++ b/shared/activityValidation.ts
@@ -17,6 +17,8 @@ export const ACTIVITY_CATEGORY_MESSAGE = `Category must be one of: ${ACTIVITY_CA
 export const COST_NUMBER_MESSAGE = "Cost per person must be a number (e.g., 12.50).";
 export const MAX_CAPACITY_MESSAGE = "Max participants must be at least 1 or left blank.";
 export const ATTENDEE_REQUIRED_MESSAGE = "Include at least one attendee.";
+export const INVITEE_NOT_MEMBER_MESSAGE =
+  "Some selected invitees are no longer part of this trip.";
 export const END_TIME_AFTER_START_MESSAGE = "End time must be after start time.";
 export const MAX_ACTIVITY_NAME_LENGTH = 120;
 export const MAX_ACTIVITY_DESCRIPTION_LENGTH = 2000;
@@ -302,6 +304,11 @@ export const validateActivityInput = (
   attendeeSet.add(userId);
 
   const filteredAttendees = Array.from(attendeeSet).filter((id) => validMemberIds.has(id));
+  const invalidAttendeeIds = attendeeResult.value.filter((id) => !validMemberIds.has(id));
+
+  if (invalidAttendeeIds.length > 0) {
+    errors.push({ field: "attendeeIds", message: INVITEE_NOT_MEMBER_MESSAGE });
+  }
   if (filteredAttendees.length === 0) {
     errors.push({ field: "attendeeIds", message: ATTENDEE_REQUIRED_MESSAGE });
   }


### PR DESCRIPTION
## Summary
- surface a 422 response with offending invitee IDs when Postgres constraint violations occur during activity creation
- tighten activity validation to report invitees who are no longer trip members and align the vite mock with the runtime logger shape
- add a regression test that exercises the constraint-violation path for the activity creation route

## Testing
- npm test -- --runTestsByPath server/__tests__/createActivityRoute.test.ts
- npm test *(fails: SyntaxError: Cannot use 'import.meta' outside a module in server/__tests__/getTripActivities.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dea7559d64832e952a00c2615d50f6