### PR TITLE
Add activity proposal API endpoint and refresh caches

### DIFF
--- a/client/src/components/activity-search.tsx
+++ b/client/src/components/activity-search.tsx
@@ -359,6 +359,7 @@ export default function ActivitySearch({ tripId, trip, user: _user, manualFormOp
         description: "We added your manual activity to the trip.",
       });
       queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
+      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
       closeManualForm();
     },
     onError: (error: unknown) => {

--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -336,9 +336,11 @@ export function AddActivityModal({
       };
 
       updateCache([`/api/trips/${tripId}/activities`]);
+      updateCache([`/api/trips/${tripId}/proposals/activities`]);
       updateCache(["/api/trips", tripId.toString(), "activities"]);
 
       queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
+      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
       queryClient.invalidateQueries({ queryKey: ["/api/trips", tripId.toString(), "activities"] });
 
       toast({

--- a/client/src/components/booking-confirmation-modal.tsx
+++ b/client/src/components/booking-confirmation-modal.tsx
@@ -190,6 +190,8 @@ export function BookingConfirmationModal({
       });
 
       // Invalidate relevant queries
+      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
+      queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
       queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId.toString(), 'activities'] });
       queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId.toString()] });
 

--- a/client/src/pages/proposals.tsx
+++ b/client/src/pages/proposals.tsx
@@ -266,15 +266,14 @@ function ProposalsPage({
     enabled: !!tripId && isAuthenticated,
   });
 
-  // For now, activity and restaurant proposals use placeholder data
-  // TODO: Implement API routes for activity and restaurant proposals
+  // Fetch activity and restaurant proposals
   const {
     data: rawActivityProposalsData,
     isLoading: activityProposalsLoading,
     error: activityProposalsError,
     refetch: refetchActivityProposals,
   } = useQuery<unknown>({
-    queryKey: [`/api/trips/${tripId}/activities`],
+    queryKey: [`/api/trips/${tripId}/proposals/activities`],
     enabled: !!tripId && isAuthenticated,
   });
 
@@ -493,10 +492,10 @@ function ProposalsPage({
         queryClient.invalidateQueries({ queryKey: ["/api/trips", tripId, "restaurant-proposals"] });
       } else if (type === "activity") {
         queryClient.setQueryData<ActivityWithDetails[] | undefined>(
-          [`/api/trips/${tripId}/activities`],
+          [`/api/trips/${tripId}/proposals/activities`],
           (previous) => previous?.filter((proposal) => proposal.id !== proposalId),
         );
-        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
+        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
       }
 
       toast({
@@ -559,7 +558,7 @@ function ProposalsPage({
         return {};
       }
 
-      const queryKey = [`/api/trips/${tripId}/activities`] as const;
+      const queryKey = [`/api/trips/${tripId}/proposals/activities`] as const;
       await queryClient.cancelQueries({ queryKey });
 
       const previousActivities = queryClient.getQueryData<ActivityWithDetails[]>(queryKey) ?? null;
@@ -596,7 +595,7 @@ function ProposalsPage({
     },
     onSuccess: () => {
       if (tripId) {
-        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
+        queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
       }
     },
   });


### PR DESCRIPTION
## Summary
- implement `/api/trips/:tripId/proposals/activities` so activity proposals respect membership checks and optional personal filtering
- load the proposals page from the new endpoint and update activity invite mutations to target the refreshed query key
- invalidate the new proposals cache after creating activities through the various booking and manual flows

## Testing
- npm test -- --runTestsByPath server/__tests__/getTripActivities.test.ts *(fails: Jest cannot parse import.meta without ESM config)*

------
https://chatgpt.com/codex/tasks/task_e_68deab54ecd0832e976734b7ebbf14d8