### PR TITLE
Fix Add Activity modal mode reset

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -245,9 +245,13 @@ export function AddActivityModal({
       });
     } else {
       form.reset(getDefaultValues());
-      setMode(defaultMode);
     }
-  }, [selectedDate, form, getDefaultValues, defaultMode]);
+  }, [selectedDate, form, getDefaultValues]);
+
+  useEffect(() => {
+    setMode(defaultMode);
+    form.setValue("type", defaultMode, { shouldDirty: false, shouldValidate: true });
+  }, [defaultMode, form]);
 
   const handleToggleAttendee = (userId: string, checked: boolean | "indeterminate") => {
     const normalizedId = String(userId);


### PR DESCRIPTION
## Summary
- ensure the add activity modal resets its mode when the caller changes the default
- keep the form's type value aligned with the active mode selection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deb02c9584832ebf603d4176a3a22f