### PR TITLE
Fix activity creation flows and add proposal endpoint

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -63,17 +63,34 @@ export async function apiRequest(
     body?: any;
   } = { method: "GET" },
 ): Promise<Response> {
-  const body = options.body ? (typeof options.body === 'string' ? options.body : JSON.stringify(options.body)) : undefined;
-  
-  const res = await fetch(buildApiUrl(url), {
-    method: options.method,
-    headers: body ? { "Content-Type": "application/json" } : {},
-    body,
-    credentials: "include",
-  });
+  const body =
+    options.body !== undefined
+      ? typeof options.body === "string"
+        ? options.body
+        : JSON.stringify(options.body)
+      : undefined;
 
-  await throwIfResNotOk(res);
-  return res;
+  try {
+    const res = await fetch(buildApiUrl(url), {
+      method: options.method,
+      headers: body ? { "Content-Type": "application/json" } : {},
+      body,
+      credentials: "include",
+    });
+
+    await throwIfResNotOk(res);
+    return res;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new Error("We couldn’t reach the server. Check your connection and try again.");
+    }
+
+    throw error;
+  }
 }
 
 type UnauthorizedBehavior = "returnNull" | "throw";


### PR DESCRIPTION
## Summary
- add separate proposal and scheduled submission paths in the add activity modal and refresh the right caches
- improve API request error handling and expand observability metrics for activity creation flows
- refactor the activity creation route to support proposal creation, richer notifications, and new metrics

## Testing
- npm test *(fails: Jest cannot parse import.meta in server/__tests__/getTripActivities.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68deb35359bc832e9aa4a2283d73682d