### PR TITLE
Ensure activity invite timestamps exist

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2156,6 +2156,42 @@ export class DatabaseStorage implements IStorage {
       `);
 
       await query(
+        `ALTER TABLE activity_invites ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ`,
+      );
+
+      await query(
+        `UPDATE activity_invites SET created_at = NOW() WHERE created_at IS NULL`,
+      );
+
+      await query(
+        `UPDATE activity_invites SET updated_at = NOW() WHERE updated_at IS NULL`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ALTER COLUMN created_at SET DEFAULT NOW()`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ALTER COLUMN updated_at SET DEFAULT NOW()`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ALTER COLUMN created_at SET NOT NULL`,
+      );
+
+      await query(
+        `ALTER TABLE activity_invites ALTER COLUMN updated_at SET NOT NULL`,
+      );
+
+      await query(
         `CREATE INDEX IF NOT EXISTS idx_activity_invites_activity ON activity_invites(activity_id)`,
       );
 


### PR DESCRIPTION
## Summary
- harden the activity invite table initialization so expected timestamp columns are always present with defaults
- backfill missing created_at and updated_at values before enforcing NOT NULL so invite inserts no longer fail on older databases

## Testing
- npm test -- --runTestsByPath server/__tests__/createActivityRoute.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68debf38334c832e9baa3faffff94ff1