### PR TITLE
Improve manual activity creation flow

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -2904,6 +2904,7 @@ export default function Trip() {
           members={trip?.members ?? []}
           defaultMode={addActivityMode}
           allowModeToggle={isAddActivityModeToggleEnabled}
+          currentUserId={user?.id}
         />
 
         {trip && (


### PR DESCRIPTION
## Summary
- clarify the add activity modal copy and toggles so users understand the difference between scheduling and proposing
- ensure the creator stays selected for scheduled activities, while allowing proposals to target any invitees
- surface a duplicate warning when another activity shares the same title and start time and wire the modal up with the current user id

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68dec452ee94832e9b03bae0b32751de