### PR TITLE
Update Viator link builder to drop date parameters

### DIFF
--- a/client/src/components/activity-search.tsx
+++ b/client/src/components/activity-search.tsx
@@ -250,31 +250,21 @@ export default function ActivitySearch({ tripId, trip, user: _user, manualFormOp
       return;
     }
 
-    const { start, end } = getTripDateRange();
-    if (!start) {
-      toast({
-        title: "Add trip dates",
-        description: "Add trip dates to build a Viator search link.",
-        variant: "destructive",
-      });
-      return;
-    }
-
     if (typeof window === "undefined") {
       return;
     }
 
-    const url = new URL("https://www.viator.com/search");
-    url.searchParams.set("q", location);
-    url.searchParams.set("startDate", start);
-    if (end) {
-      url.searchParams.set("endDate", end);
-    }
-    url.searchParams.set("sort", "relevance");
+    const url = new URL("https://www.viator.com/searchResults/all");
+    url.searchParams.set("text", location);
+    url.searchParams.set("vs_source", "tripsync");
+    url.searchParams.set("vs_vendor", "viator");
+    url.searchParams.set("vs_city", location);
+    url.searchParams.set("vs_return", "1");
+    url.searchParams.set("vs_trip", String(tripId));
 
     markExternalRedirect(ACTIVITY_REDIRECT_STORAGE_KEY);
     window.open(url.toString(), "_blank", "noopener,noreferrer");
-  }, [getTripDateRange, locationSearch, toast, trip?.destination]);
+  }, [locationSearch, toast, trip?.destination, tripId]);
 
   const handleAirbnbLink = useCallback(() => {
     const location = (locationSearch.trim() || trip?.destination || "").trim();


### PR DESCRIPTION
## Summary
- update the Viator activity link so it targets the TripSync tracking URL with the city as the only search input
- remove the requirement for trip start/end dates when generating the Viator link while leaving other builders untouched

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deed0393b08329bc8b786b91e86ec7