### PR TITLE
Normalize flight proposal date display

### DIFF
--- a/client/src/pages/proposals.tsx
+++ b/client/src/pages/proposals.tsx
@@ -133,6 +133,7 @@ interface ProposalsPageProps {
   tripId?: number;
   embedded?: boolean;
   includeUserProposalsInCategories?: boolean;
+  formatFlightDateTime?: (value?: string | Date | null) => string;
 }
 
 type ProposalTab = "my-proposals" | "hotels" | "flights" | "activities" | "restaurants";
@@ -185,6 +186,7 @@ function ProposalsPage({
   tripId,
   embedded = false,
   includeUserProposalsInCategories = true,
+  formatFlightDateTime,
 }: ProposalsPageProps = {}) {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
   const { toast } = useToast();
@@ -1578,6 +1580,31 @@ function ProposalsPage({
     );
   };
 
+  const getFlightDateLabel = useCallback(
+    (value?: string | Date | null) => {
+      if (formatFlightDateTime) {
+        return formatFlightDateTime(value);
+      }
+
+      if (!value) {
+        return "TBD";
+      }
+
+      const date = value instanceof Date ? value : new Date(value);
+
+      if (Number.isNaN(date.getTime())) {
+        return "TBD";
+      }
+
+      try {
+        return format(date, "MMM d, yyyy, h:mm a");
+      } catch {
+        return "TBD";
+      }
+    },
+    [formatFlightDateTime],
+  );
+
   // Flight proposal card component
   const FlightProposalCard = ({ proposal }: { proposal: FlightProposalWithDetails }) => {
     const userRanking = getUserRanking(proposal.rankings || [], user?.id || "");
@@ -1628,10 +1655,10 @@ function ProposalsPage({
               <Clock className="w-4 h-4 text-blue-600" />
               <div>
                 <div className="font-medium" data-testid={`text-flight-departure-${proposal.id}`}>
-                  Departs: {proposal.departureTime}
+                  Departs: {getFlightDateLabel(proposal.departureTime)}
                 </div>
                 <div className="text-sm text-neutral-600" data-testid={`text-flight-arrival-${proposal.id}`}>
-                  Arrives: {proposal.arrivalTime}
+                  Arrives: {getFlightDateLabel(proposal.arrivalTime)}
                 </div>
               </div>
             </div>

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -167,6 +167,38 @@ const isTripTab = (value: string): value is TripTab =>
 
 type SummaryPanel = "activities" | "rsvps" | "next";
 
+const formatFlightProposalDateTime = (
+  value?: string | Date | null,
+  locale: string = "en-US",
+): string => {
+  if (!value) {
+    return "TBD";
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "TBD";
+  }
+
+  try {
+    return date.toLocaleString(locale, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    });
+  } catch {
+    try {
+      return format(date, "MMM d, yyyy, h:mm a");
+    } catch {
+      return "TBD";
+    }
+  }
+};
+
 const inviteStatusLabelMap: Record<ActivityInviteStatus, string> = {
   accepted: "Accepted",
   pending: "Pending",
@@ -2311,7 +2343,12 @@ export default function Trip() {
 
                 {activeTab === "proposals" && trip && (
                   <div className="space-y-6" data-testid="proposals-section">
-                    <Proposals tripId={trip.id} embedded includeUserProposalsInCategories />
+                    <Proposals
+                      tripId={trip.id}
+                      embedded
+                      includeUserProposalsInCategories
+                      formatFlightDateTime={formatFlightProposalDateTime}
+                    />
                   </div>
                 )}
 
@@ -4104,12 +4141,8 @@ function FlightCoordination({
               const formattedArrivalLabel = flight.arrivalCode
                 ? `${flight.arrivalAirport ?? flight.arrivalCode} (${flight.arrivalCode})`
                 : flight.arrivalAirport || flight.arrivalCode || "TBD";
-              const departureTimeLabel = flight.departureTime
-                ? format(new Date(flight.departureTime), "MMM d, yyyy h:mm a")
-                : "Time TBD";
-              const arrivalTimeLabel = flight.arrivalTime
-                ? format(new Date(flight.arrivalTime), "MMM d, yyyy h:mm a")
-                : "Time TBD";
+              const departureTimeLabel = formatFlightProposalDateTime(flight.departureTime);
+              const arrivalTimeLabel = formatFlightProposalDateTime(flight.arrivalTime);
               const priceLabel = formatCurrency(flight.price, {
                 currency: flight.currency ?? "USD",
                 fallback: "—",


### PR DESCRIPTION
## Summary
- add a shared formatter for flight proposal date/times on the trip page so manual entries and proposals use a friendly string
- update the proposals view to consume the formatter and fall back to a localized "TBD" label when dates are missing or invalid

## Testing
- npm run check *(fails: existing type errors in server/locationService.ts and server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68df1d90f04c8329a9cabf9e4dd2f485