### PR TITLE
Remove duplicate manual flight CTA

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -4068,9 +4068,7 @@ function FlightCoordination({
           <h2 className="text-xl font-semibold">Flight Coordination</h2>
           <p className="text-gray-600">Coordinate flights with your group</p>
         </div>
-        <Button variant="outline" onClick={openManualFlightForm}>
-          Manual Entry
-        </Button>
+        {/* Top-right Manual Entry button removed per requirements */}
       </div>
 
       <div className="space-y-4">


### PR DESCRIPTION
## Summary
- remove the redundant Manual Entry button from the Flight Coordination header so only the lower CTA remains

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df1eda8a20832ea30c06ae54d7f102