### PR TITLE
Normalize trip member IDs when validating manual activity invites

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2008,9 +2008,23 @@ export function setupRoutes(app: Express) {
         return;
       }
 
-      const validMemberIds = new Set(trip.members.map((member) => member.userId));
+      const validMemberIds = new Set(
+        trip.members
+          .map((member) => member.userId)
+          .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+          .map((id) => id.trim()),
+      );
       if (trip.createdBy) {
-        validMemberIds.add(trip.createdBy);
+        const creatorId = String(trip.createdBy).trim();
+        if (creatorId) {
+          validMemberIds.add(creatorId);
+        }
+      }
+      if (userId) {
+        const normalizedUserId = String(userId).trim();
+        if (normalizedUserId) {
+          validMemberIds.add(normalizedUserId);
+        }
       }
 
       const rawData = {


### PR DESCRIPTION
## Summary
- normalize trip member and requester IDs to trimmed strings before validating activity submissions
- ensure invitee IDs are consistently trimmed strings when creating activity invites to avoid false non-member errors

## Testing
- npm test -- server/__tests__/createActivityRoute.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df25fe088c832ebc7b4a77764b501e