### PR TITLE
Fix activity form submit button disabled state

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -838,7 +838,8 @@ export function AddActivityModal({
             <Button
               type="submit"
               className="flex-1 bg-primary hover:bg-red-600 text-white"
-              disabled={isSubmitting || !form.formState.isValid}
+              disabled={isSubmitting}
+              aria-disabled={isSubmitting || !form.formState.isValid}
             >
               {isSubmitting
                 ? "Submitting..."


### PR DESCRIPTION
## Summary
- allow the Create Activity form to submit even when client-side validation fails so errors display instead of blocking interaction
- keep an aria-disabled hint for accessibility while preventing the button from being focus-trapped when invalid

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df31fb64b8832e96efddf4b5d5a157