### PR TITLE
Handle blank end time in activity submissions

### DIFF
--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -60,4 +60,13 @@ describe("buildActivitySubmission", () => {
       }),
     ).toThrow();
   });
+
+  it("treats a blank end time as optional", () => {
+    const { payload } = buildActivitySubmission({
+      ...baseInput,
+      endTime: "",
+    });
+
+    expect(payload.endTime).toBeNull();
+  });
 });

--- a/client/src/lib/activitySubmission.ts
+++ b/client/src/lib/activitySubmission.ts
@@ -109,9 +109,16 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
 
   const baseDate = toDateInput(input.date, "Date");
   const startTimeString = toTimeString(input.startTime, "Start time");
-  const endTimeString = input.endTime === null || input.endTime === undefined
-    ? null
-    : toTimeString(input.endTime, "End time");
+  const endTimeInput = input.endTime;
+  const shouldUseEndTime = !(
+    endTimeInput === null
+    || endTimeInput === undefined
+    || (typeof endTimeInput === "string" && endTimeInput.trim() === "")
+  );
+
+  const endTimeString = shouldUseEndTime
+    ? toTimeString(endTimeInput, "End time")
+    : null;
 
   const startDateTime = buildDateTime(baseDate, startTimeString, "Start time");
   const endDateTime = endTimeString ? buildDateTime(baseDate, endTimeString, "End time") : null;


### PR DESCRIPTION
## Summary
- treat blank end time input as optional when building activity submissions
- add a regression test covering blank end time normalization

## Testing
- npm test -- activitySubmission

------
https://chatgpt.com/codex/tasks/task_e_68df339c911c832eb981082acfb33161