### PR TITLE
Handle client-side validation errors when creating activities

### DIFF
--- a/client/src/lib/activities/__tests__/createActivity.test.ts
+++ b/client/src/lib/activities/__tests__/createActivity.test.ts
@@ -1,0 +1,30 @@
+import { ATTENDEE_REQUIRED_MESSAGE, END_TIME_AFTER_START_MESSAGE } from "@shared/activityValidation";
+
+import { mapClientErrorToValidation } from "../clientValidation";
+
+describe("mapClientErrorToValidation", () => {
+  it("maps known validation messages to the correct field", () => {
+    const attendeeError = mapClientErrorToValidation(new Error(ATTENDEE_REQUIRED_MESSAGE));
+    expect(attendeeError.fieldErrors).toEqual([
+      { field: "attendeeIds", message: ATTENDEE_REQUIRED_MESSAGE },
+    ]);
+    expect(attendeeError.formMessage).toBeUndefined();
+
+    const endTimeError = mapClientErrorToValidation(new Error(END_TIME_AFTER_START_MESSAGE));
+    expect(endTimeError.fieldErrors).toEqual([
+      { field: "endTime", message: END_TIME_AFTER_START_MESSAGE },
+    ]);
+  });
+
+  it("falls back to a form-level message for unknown errors", () => {
+    const unexpectedError = mapClientErrorToValidation(new Error("Something odd"));
+    expect(unexpectedError.fieldErrors).toEqual([]);
+    expect(unexpectedError.formMessage).toBe("Something odd");
+  });
+
+  it("returns a helpful fallback message when the error is not an Error", () => {
+    const fallback = mapClientErrorToValidation(null);
+    expect(fallback.fieldErrors).toEqual([]);
+    expect(fallback.formMessage).toMatch(/We couldn’t prepare your activity/);
+  });
+});

--- a/client/src/lib/activities/clientValidation.ts
+++ b/client/src/lib/activities/clientValidation.ts
@@ -1,0 +1,79 @@
+import type { ActivityCreateFormValues, ActivityValidationError } from "./createActivity";
+
+import {
+  ACTIVITY_CATEGORY_MESSAGE,
+  ATTENDEE_REQUIRED_MESSAGE,
+  COST_NUMBER_MESSAGE,
+  END_TIME_AFTER_START_MESSAGE,
+  MAX_ACTIVITY_DESCRIPTION_LENGTH,
+  MAX_ACTIVITY_LOCATION_LENGTH,
+  MAX_CAPACITY_MESSAGE,
+} from "@shared/activityValidation";
+
+export const CLIENT_VALIDATION_FALLBACK_MESSAGE =
+  "We couldn’t prepare your activity. Please review the details and try again.";
+
+const clientValidationMessageMap: Array<{
+  field: keyof ActivityCreateFormValues;
+  messages: string[];
+}> = [
+  { field: "name", messages: ["Activity name is required."] },
+  {
+    field: "description",
+    messages: [`Description must be ${MAX_ACTIVITY_DESCRIPTION_LENGTH} characters or fewer.`],
+  },
+  { field: "startDate", messages: ["Date is required.", "Date must be a valid date/time."] },
+  {
+    field: "startTime",
+    messages: [
+      "Start time is required.",
+      "Start time must be in HH:MM format.",
+      "Start time must be a valid date/time.",
+    ],
+  },
+  {
+    field: "endTime",
+    messages: [
+      "End time must be in HH:MM format.",
+      "End time must be a valid date/time.",
+      END_TIME_AFTER_START_MESSAGE,
+    ],
+  },
+  {
+    field: "location",
+    messages: [`Location must be ${MAX_ACTIVITY_LOCATION_LENGTH} characters or fewer.`],
+  },
+  { field: "cost", messages: [COST_NUMBER_MESSAGE] },
+  { field: "maxCapacity", messages: [MAX_CAPACITY_MESSAGE] },
+  { field: "attendeeIds", messages: [ATTENDEE_REQUIRED_MESSAGE] },
+  { field: "category", messages: [ACTIVITY_CATEGORY_MESSAGE] },
+];
+
+export const mapClientErrorToValidation = (error: unknown): ActivityValidationError => {
+  if (!(error instanceof Error)) {
+    return { fieldErrors: [], formMessage: CLIENT_VALIDATION_FALLBACK_MESSAGE };
+  }
+
+  const message = error.message?.trim();
+  if (!message) {
+    return { fieldErrors: [], formMessage: CLIENT_VALIDATION_FALLBACK_MESSAGE };
+  }
+
+  const matchedField = clientValidationMessageMap.find(({ messages }) => messages.includes(message));
+
+  if (matchedField) {
+    return {
+      fieldErrors: [
+        {
+          field: matchedField.field,
+          message,
+        },
+      ],
+    } satisfies ActivityValidationError;
+  }
+
+  return {
+    fieldErrors: [],
+    formMessage: message,
+  } satisfies ActivityValidationError;
+};


### PR DESCRIPTION
## Summary
- surface client-side validation failures from `useCreateActivity` so the modal can show field errors instead of silently failing
- extract a reusable mapper for activity submission errors and cover it with unit tests

## Testing
- npm test -- --runTestsByPath client/src/lib/activities/__tests__/createActivity.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e01647f98c832ea70c2d0332937e4f