### PR TITLE
Expand local development origins for CORS

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -24,8 +24,13 @@ const envConfiguredOrigins = new Set([
 
 const defaultOrigins = new Set([
   "http://localhost:3000",
+  "http://127.0.0.1:3000",
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+  "http://localhost:4173",
+  "http://127.0.0.1:4173",
   "https://www.tripsyncbeta.com",
-  "https://tripsyncbeta.com"
+  "https://tripsyncbeta.com",
 ]);
 
 if (defaultClientUrl) {


### PR DESCRIPTION
## Summary
- add common localhost development origins (3000, 5173, 4173) to the server's default CORS allowlist so activity creation requests succeed in the browser

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e033596f30832e925f7d6773ec8ab7