### PR TITLE
Fix inconsistent calendar activity cache keys

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -233,7 +233,7 @@ export function AddActivityModal({
     [tripId],
   );
   const calendarActivitiesQueryKey = useMemo(
-    () => ["/api/trips", tripId.toString(), "activities"],
+    () => ["/api/trips", tripId, "activities"],
     [tripId],
   );
 
@@ -394,13 +394,13 @@ export function AddActivityModal({
 
         queryClient.invalidateQueries({ queryKey: proposalActivitiesQueryKey });
         queryClient.invalidateQueries({ queryKey: scheduledActivitiesQueryKey });
-        queryClient.invalidateQueries({ queryKey: ["/api/trips", tripId.toString(), "activities"] });
+        queryClient.invalidateQueries({ queryKey: calendarActivitiesQueryKey });
       } else {
         updateCache(scheduledActivitiesQueryKey);
-        updateCache(["/api/trips", tripId.toString(), "activities"]);
+        updateCache(calendarActivitiesQueryKey);
 
         queryClient.invalidateQueries({ queryKey: scheduledActivitiesQueryKey });
-        queryClient.invalidateQueries({ queryKey: ["/api/trips", tripId.toString(), "activities"] });
+        queryClient.invalidateQueries({ queryKey: calendarActivitiesQueryKey });
       }
 
       toast({

--- a/client/src/components/booking-confirmation-modal.tsx
+++ b/client/src/components/booking-confirmation-modal.tsx
@@ -215,8 +215,8 @@ export function BookingConfirmationModal({
       // Invalidate relevant queries
       queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/activities`] });
       queryClient.invalidateQueries({ queryKey: [`/api/trips/${tripId}/proposals/activities`] });
-      queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId.toString(), 'activities'] });
-      queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId.toString()] });
+      queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId, 'activities'] });
+      queryClient.invalidateQueries({ queryKey: ['/api/trips', tripId] });
 
       toast({
         title: "Booking Added",


### PR DESCRIPTION
## Summary
- align the calendar invalidation key in the add activity modal with the numeric trip id used elsewhere
- update the booking confirmation modal to use the same calendar cache key so shared updates reach all views

## Testing
- npm run check *(fails: existing TypeScript definition errors in unrelated test and server files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b9e7dc80832ea618ac14150a8575