### PR TITLE
Improve trip creation UX and validation

### DIFF
--- a/client/src/components/create-trip-modal.tsx
+++ b/client/src/components/create-trip-modal.tsx
@@ -9,19 +9,51 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertTripCalendarSchema } from "@shared/schema";
 import { z } from "zod";
-import { apiRequest } from "@/lib/queryClient";
+import { ApiError, apiRequest } from "@/lib/queryClient";
 import { useLocation } from "wouter";
 import SmartLocationSearch from "@/components/SmartLocationSearch";
+import { Loader2 } from "lucide-react";
 
 interface CreateTripModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-const formSchema = insertTripCalendarSchema.extend({
-  startDate: z.string().min(1, "Start date is required"),
-  endDate: z.string().min(1, "End date is required"),
-});
+const formSchema = insertTripCalendarSchema
+  .extend({
+    name: z.string().trim().min(1, "Trip name is required"),
+    destination: z.string().trim().min(1, "Destination is required"),
+    startDate: z.string().min(1, "Start date is required"),
+    endDate: z.string().min(1, "End date is required"),
+  })
+  .superRefine((data, ctx) => {
+    const startDate = new Date(data.startDate);
+    const endDate = new Date(data.endDate);
+
+    if (Number.isNaN(startDate.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Start date must be a valid date",
+        path: ["startDate"],
+      });
+    }
+
+    if (Number.isNaN(endDate.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "End date must be a valid date",
+        path: ["endDate"],
+      });
+    }
+
+    if (!Number.isNaN(startDate.getTime()) && !Number.isNaN(endDate.getTime()) && endDate < startDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "End date cannot be before the start date",
+        path: ["endDate"],
+      });
+    }
+  });
 
 type FormData = z.infer<typeof formSchema>;
 
@@ -30,6 +62,7 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
   const queryClient = useQueryClient();
   const [, setLocation] = useLocation();
   const [selectedDestination, setSelectedDestination] = useState<any>(null);
+  const [formError, setFormError] = useState<string | null>(null);
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -49,22 +82,26 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
 
   const createTripMutation = useMutation({
     mutationFn: async (data: FormData) => {
-      const response = await apiRequest('/api/trips', {
-        method: 'POST',
-        body: JSON.stringify(data),
+      const response = await apiRequest("/api/trips", {
+        method: "POST",
+        body: {
+          ...data,
+          name: data.name.trim(),
+          destination: data.destination.trim(),
+        },
       });
       return response.json();
     },
     onSuccess: async (trip) => {
       // Invalidate and refetch trips query to show new trip on home page
       await queryClient.invalidateQueries({ queryKey: ["/api/trips"] });
-      
+
       // Pre-populate the cache with the new trip data for immediate display
       queryClient.setQueryData(["/api/trips"], (oldData: any) => {
         if (!oldData) return [trip];
         return [...oldData, trip];
       });
-      
+
       toast({
         title: "Trip created!",
         description: "Your new trip has been created successfully.",
@@ -72,22 +109,39 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
       onOpenChange(false);
       form.reset();
       setSelectedDestination(null);
-      
+      setFormError(null);
+
       // Small delay to ensure cache is updated before navigation
       setTimeout(() => {
         setLocation(`/trip/${trip.id}`);
       }, 100);
     },
-    onError: (error: any) => {
+    onError: (error: unknown) => {
       console.error("Trip creation error:", error);
       let errorMessage = "Failed to create trip. Please try again.";
-      
-      if (error.message === "Unauthorized" || error.message.includes("401")) {
-        errorMessage = "Your session has expired. Redirecting to login...";
-        // The redirect will happen automatically from the queryClient
-        return;
+
+      if (error instanceof ApiError) {
+        if (error.status === 401) {
+          errorMessage = "Your session has expired. Redirecting to login...";
+          toast({
+            title: "Session expired",
+            description: errorMessage,
+            variant: "destructive",
+          });
+          return;
+        }
+
+        if (error.data && typeof error.data === "object" && "message" in error.data && typeof error.data.message === "string") {
+          errorMessage = error.data.message;
+        } else if (typeof error.message === "string" && error.message.trim().length > 0) {
+          errorMessage = error.message;
+        }
+      } else if (error instanceof Error && error.message.trim().length > 0) {
+        errorMessage = error.message;
       }
-      
+
+      setFormError(errorMessage);
+
       toast({
         title: "Error",
         description: errorMessage,
@@ -97,8 +151,17 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
   });
 
   const onSubmit = (data: FormData) => {
-    console.log("Submitting trip data:", data);
-    createTripMutation.mutate(data);
+    if (createTripMutation.isPending) {
+      return;
+    }
+
+    setFormError(null);
+
+    createTripMutation.mutate({
+      ...data,
+      name: data.name.trim(),
+      destination: data.destination.trim(),
+    });
   };
 
   const destinationValue = form.watch("destination");
@@ -144,22 +207,22 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
         typeof location?.latitude === "number"
           ? location.latitude
           : location?.latitude
-          ? Number(location.latitude)
-          : null;
+            ? Number(location.latitude)
+            : null;
       const longitudeValue =
         typeof location?.longitude === "number"
           ? location.longitude
           : location?.longitude
-          ? Number(location.longitude)
-          : null;
+            ? Number(location.longitude)
+            : null;
       form.setValue("latitude", Number.isFinite(latitudeValue ?? NaN) ? latitudeValue : null);
       form.setValue("longitude", Number.isFinite(longitudeValue ?? NaN) ? longitudeValue : null);
       const populationValue =
         typeof location?.population === "number"
           ? location.population
           : location?.population
-          ? Number(location.population)
-          : null;
+            ? Number(location.population)
+            : null;
       form.setValue("population", Number.isFinite(populationValue ?? NaN) ? populationValue : null);
     },
     [form],
@@ -203,7 +266,10 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md" onPointerDownOutside={(e) => e.preventDefault()}>
+      <DialogContent
+        className="max-w-md max-h-[85vh] overflow-y-auto focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+        onPointerDownOutside={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>Create New Trip</DialogTitle>
           <DialogDescription>
@@ -211,8 +277,7 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" aria-busy={createTripMutation.isPending}>
           <div>
             <Label htmlFor="name">Trip Name</Label>
             <Input
@@ -231,7 +296,7 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
               id="destination"
               placeholder="e.g., Tokyo, Japan"
               value={destinationValue ?? ""}
-              allowedTypes={['city']}
+              allowedTypes={["city"]}
               onLocationSelect={handleDestinationSelect}
               onQueryChange={handleDestinationQueryChange}
             />
@@ -265,12 +330,23 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
             </div>
           </div>
 
+          {formError && (
+            <div role="alert" aria-live="polite" className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+              {formError}
+            </div>
+          )}
+
           <div className="flex space-x-3 pt-4">
             <Button
               type="button"
               variant="outline"
               className="flex-1"
-              onClick={() => onOpenChange(false)}
+              onClick={() => {
+                onOpenChange(false);
+                form.reset();
+                setSelectedDestination(null);
+                setFormError(null);
+              }}
             >
               Cancel
             </Button>
@@ -278,8 +354,16 @@ export function CreateTripModal({ open, onOpenChange }: CreateTripModalProps) {
               type="submit"
               className="flex-1 bg-primary hover:bg-red-600 text-white"
               disabled={createTripMutation.isPending}
+              aria-live="polite"
             >
-              {createTripMutation.isPending ? "Creating..." : "Create Trip"}
+              {createTripMutation.isPending ? (
+                <span className="flex items-center justify-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Creating...
+                </span>
+              ) : (
+                "Create Trip"
+              )}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- add stricter client-side validation, inline error messaging, and loading state to the Create Trip modal
- preserve form input on failures while surfacing detailed API errors for easier recovery
- validate trip payloads on the server and return descriptive responses when dates or data are invalid

## Testing
- npm run check *(fails: existing TypeScript issues in unrelated test and activity modules)*

------
https://chatgpt.com/codex/tasks/task_e_68e3c4bcde14832eb345ee99f4850bcf