### PR TITLE
Fix trip creation insert placeholders and improve modal errors

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -2656,7 +2656,8 @@ export class DatabaseStorage implements IStorage {
         $17,
         $18,
         $19,
-        $20
+        $20,
+        $21
       )
       RETURNING
         id,


### PR DESCRIPTION
## Summary
- fix the trip creation INSERT statement so all cover photo columns receive bound values
- add user-friendly error mapping for trip creation failures and surface them as a global alert
- show the create-trip error banner below the modal header instead of an inline field error

## Testing
- npm run test *(fails: Jest cannot process import.meta in server/__tests__/getTripActivities.test.ts because DATABASE_URL/config is not set up for the test runner)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d01e2f7c832ea197ecc7f2092304