### PR TITLE
Allow creating activities without extra attendees

### DIFF
--- a/client/src/components/activity-search.tsx
+++ b/client/src/components/activity-search.tsx
@@ -29,7 +29,6 @@ import { formatCurrency } from "@/lib/utils";
 import { markExternalRedirect, ACTIVITY_REDIRECT_STORAGE_KEY } from "@/lib/externalRedirects";
 import { format } from "date-fns";
 import type { ActivityWithDetails, ActivityType, TripWithDetails, User } from "@shared/schema";
-import { ATTENDEE_REQUIRED_MESSAGE } from "@shared/activityValidation";
 
 const MANUAL_ACTIVITY_CATEGORY = "manual";
 
@@ -490,7 +489,7 @@ export default function ActivitySearch({ tripId, trip, user: _user, manualFormOp
 
       createManualActivityMutation.mutate({ payload, submissionType: manualMode });
     } catch (error) {
-      const message = error instanceof Error ? error.message : ATTENDEE_REQUIRED_MESSAGE;
+      const message = error instanceof Error ? error.message : "Please try again.";
       toast({
         title: "Unable to save activity",
         description: message,
@@ -923,11 +922,7 @@ export default function ActivitySearch({ tripId, trip, user: _user, manualFormOp
                   Clear
                 </Button>
               </div>
-              <ScrollArea
-                className={`mt-3 max-h-40 rounded-lg border ${
-                  manualAttendeeIds.length === 0 ? "border-red-300" : "border-neutral-200"
-                }`}
-              >
+              <ScrollArea className="mt-3 max-h-40 rounded-lg border border-neutral-200">
                 <div className="p-3 space-y-2">
                   {memberOptions.length === 0 ? (
                     <p className="text-sm text-neutral-500">
@@ -952,11 +947,6 @@ export default function ActivitySearch({ tripId, trip, user: _user, manualFormOp
                   )}
                 </div>
               </ScrollArea>
-              {manualAttendeeIds.length === 0 && (
-                <p className="text-sm text-red-600">
-                  {ATTENDEE_REQUIRED_MESSAGE}
-                </p>
-              )}
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">

--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -81,7 +81,9 @@ const formSchema = z
       .transform((value) => value ?? ""),
     cost: z.string().optional(),
     maxCapacity: z.string().optional(),
-    attendeeIds: z.array(z.string(), { invalid_type_error: ATTENDEE_REQUIRED_MESSAGE }).min(1, ATTENDEE_REQUIRED_MESSAGE),
+    attendeeIds: z
+      .array(z.string(), { invalid_type_error: ATTENDEE_REQUIRED_MESSAGE })
+      .default([]),
     category: z
       .string()
       .refine((value) => ACTIVITY_CATEGORY_VALUES.includes(value as (typeof ACTIVITY_CATEGORY_VALUES)[number]), {
@@ -119,7 +121,7 @@ const formSchema = z
 
     const { value: normalizedCapacity } = normalizeMaxCapacityInput(data.maxCapacity);
     if (normalizedCapacity !== null) {
-      const attendeeCount = new Set([...data.attendeeIds]).size;
+      const attendeeCount = new Set([...(data.attendeeIds ?? [])]).size;
       if (normalizedCapacity < attendeeCount) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,

--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -45,14 +45,16 @@ describe("buildActivitySubmission", () => {
     ).toThrow(END_TIME_AFTER_START_MESSAGE);
   });
 
-  it("validates categories and attendee ids", () => {
-    expect(() =>
-      buildActivitySubmission({
-        ...baseInput,
-        attendeeIds: [],
-      }),
-    ).toThrow("Include at least one attendee.");
+  it("allows scheduling without inviting other travelers", () => {
+    const { payload } = buildActivitySubmission({
+      ...baseInput,
+      attendeeIds: [],
+    });
 
+    expect(payload.attendeeIds).toEqual([]);
+  });
+
+  it("validates categories", () => {
     expect(() =>
       buildActivitySubmission({
         ...baseInput,

--- a/client/src/lib/activitySubmission.ts
+++ b/client/src/lib/activitySubmission.ts
@@ -142,10 +142,6 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
     throw new Error(attendeeResult.error ?? ATTENDEE_REQUIRED_MESSAGE);
   }
 
-  if (attendeeResult.value.length === 0) {
-    throw new Error(ATTENDEE_REQUIRED_MESSAGE);
-  }
-
   const categoryResult = normalizeCategoryInput(input.category);
   if (!categoryResult.value) {
     throw new Error(categoryResult.error ?? ACTIVITY_CATEGORY_MESSAGE);

--- a/shared/activityValidation.ts
+++ b/shared/activityValidation.ts
@@ -150,10 +150,6 @@ export const normalizeAttendeeIds = (
     ),
   );
 
-  if (normalized.length === 0) {
-    return { value: [], error: ATTENDEE_REQUIRED_MESSAGE };
-  }
-
   return { value: normalized };
 };
 


### PR DESCRIPTION
## Summary
- allow attendee normalization to accept an empty invite list while still validating invalid inputs
- update client submission logic and composer forms so travelers can schedule or enter activities without selecting additional attendees
- adjust manual activity UI feedback and add regression coverage for invite-free submissions

## Testing
- npm test -- client/src/lib/__tests__/activitySubmission.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3d77e52a8832ea51a9822a67d3ca6