### PR TITLE
Allow creating activities without extra invitees

### DIFF
--- a/shared/activitiesV2.ts
+++ b/shared/activitiesV2.ts
@@ -101,7 +101,7 @@ export const createActivityRequestSchema = z.object({
       const parsed = typeof value === "number" ? value : Number(value);
       return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
     }),
-  invitee_ids: z.array(z.string().min(1)).min(1),
+  invitee_ids: z.array(z.string().min(1)).default([]),
   idempotency_key: z.string().min(1),
 });
 


### PR DESCRIPTION
## Summary
- allow the create-activity schema to accept an empty invitee list and rely on the creator being added server-side
- trim and validate the creator id while building the participant list so scheduled activities default to the organizer only
- relax the route-level required field validation to no longer block activity creation without invitees and update the error messaging

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e3e2cf9ee0832e95d2d52213fe7692