### PR TITLE
Fix activity creation payload for production API

### DIFF
--- a/client/src/components/leave-trip-button.tsx
+++ b/client/src/components/leave-trip-button.tsx
@@ -58,63 +58,48 @@ export function LeaveTripButton({ trip, user }: LeaveTripButtonProps) {
 
   const isCreator = trip.createdBy === user?.id;
 
-  // For testing, let's temporarily allow creators to see the button but with a different dialog
+  if (isCreator) {
+    return null;
+  }
+
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button 
-          variant="outline" 
-          size="sm" 
-          className={isCreator ? "text-gray-600 border-gray-200" : "text-red-600 border-red-200 hover:bg-red-50"}
+        <Button
+          variant="outline"
+          size="sm"
+          className="text-red-600 border-red-200 hover:bg-red-50"
         >
           <LogOut className="w-4 h-4 mr-2" />
-          {isCreator ? "Trip Creator" : "Leave Trip"}
+          Leave Trip
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>{isCreator ? "Trip Creator" : "Leave Trip"}</AlertDialogTitle>
+          <AlertDialogTitle>Leave Trip</AlertDialogTitle>
           <AlertDialogDescription>
-            {isCreator ? (
-              <>
-                As the trip creator, you cannot leave "{trip.name}". 
-                <br /><br />
-                If you no longer want to manage this trip, you can:
-                <br />
-                • Transfer ownership to another member
-                <br />
-                • Delete the entire trip (this will remove it for everyone)
-                <br /><br />
-                This protects the trip from being left without an organizer.
-              </>
-            ) : (
-              <>
-                Are you sure you want to leave "{trip.name}"? This action will:
-                <br /><br />
-                • Remove you from the trip group
-                <br />
-                • Remove your access to trip activities and planning
-                <br />
-                • Keep your activity suggestions and responses visible to others
-                <br />
-                • Preserve the shared calendar for remaining members
-                <br /><br />
-                You won't be able to rejoin without a new invitation link.
-              </>
-            )}
+            Are you sure you want to leave "{trip.name}"? This action will:
+            <br /><br />
+            • Remove you from the trip group
+            <br />
+            • Remove your access to trip activities and planning
+            <br />
+            • Keep your activity suggestions and responses visible to others
+            <br />
+            • Preserve the shared calendar for remaining members
+            <br /><br />
+            You won't be able to rejoin without a new invitation link.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          {!isCreator && (
-            <AlertDialogAction
-              onClick={() => leaveTripMutation.mutate()}
-              disabled={leaveTripMutation.isPending}
-              className="bg-red-600 hover:bg-red-700"
-            >
-              {leaveTripMutation.isPending ? "Leaving..." : "Yes, leave trip"}
-            </AlertDialogAction>
-          )}
+          <AlertDialogAction
+            onClick={() => leaveTripMutation.mutate()}
+            disabled={leaveTripMutation.isPending}
+            className="bg-red-600 hover:bg-red-700"
+          >
+            {leaveTripMutation.isPending ? "Leaving..." : "Yes, leave trip"}
+          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -26,14 +26,27 @@ describe("buildActivitySubmission", () => {
       description: "Enjoy the bay",
       location: "Pier 39",
       cost: 49.99,
+      cost_per_person: 49.99,
       maxCapacity: 12,
+      max_participants: 12,
       category: "entertainment",
       attendeeIds: ["abc", "def"],
+      invitee_ids: ["abc", "def"],
       type: "SCHEDULED",
+      mode: "scheduled",
+      title: "Sunset Cruise",
+      date: "2025-07-04",
+      start_time: "18:00",
+      end_time: "20:00",
+      startDate: "2025-07-04",
     });
 
     expect(payload.startTime).toBe(new Date("2025-07-04T18:00:00").toISOString());
     expect(payload.endTime).toBe(new Date("2025-07-04T20:00:00").toISOString());
+    expect(payload.timezone).toEqual(payload.timeZone);
+    expect(payload.timezone).not.toHaveLength(0);
+    expect(payload.idempotency_key).toEqual(payload.idempotencyKey);
+    expect(payload.idempotency_key).not.toHaveLength(0);
   });
 
   it("throws when the end time is before the start time", () => {

--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -79,15 +79,23 @@ const duplicateActivityErrorMessage = "This looks like a duplicate activity.";
 
 const serverFieldMap: Partial<Record<string, keyof ActivityCreateFormValues>> = {
   name: "name",
+  title: "name",
   description: "description",
   startTime: "startTime",
+  start_time: "startTime",
   endTime: "endTime",
+  end_time: "endTime",
   location: "location",
   cost: "cost",
+  cost_per_person: "cost",
   maxCapacity: "maxCapacity",
+  max_participants: "maxCapacity",
   category: "category",
   attendeeIds: "attendeeIds",
+  invitee_ids: "attendeeIds",
   startDate: "startDate",
+  date: "startDate",
+  mode: "type",
 };
 
 const createAnalyticsTracker = () => {

--- a/client/src/lib/activitySubmission.ts
+++ b/client/src/lib/activitySubmission.ts
@@ -24,6 +24,8 @@ interface BaseActivitySubmissionInput {
   category: string;
   attendeeIds: Array<string | number>;
   type: ActivityType;
+  timezone?: string | null;
+  idempotencyKey?: string | null;
 }
 
 interface ActivitySubmissionPayload {
@@ -38,6 +40,24 @@ interface ActivitySubmissionPayload {
   category: ActivityCategoryValue;
   attendeeIds: string[];
   type: ActivityType;
+  /**
+   * Fields required by the Activities V2 API. Duplicates are intentional so the
+   * server can consume either camelCase or snake_case payloads while we phase
+   * out the legacy endpoint.
+   */
+  title: string;
+  mode: "scheduled" | "proposed";
+  date: string;
+  start_time: string;
+  end_time: string | null;
+  timezone: string;
+  timeZone: string;
+  cost_per_person: number | null;
+  max_participants: number | null;
+  invitee_ids: string[];
+  idempotency_key: string;
+  idempotencyKey: string;
+  startDate: string;
 }
 
 export interface ActivitySubmissionResult {
@@ -92,6 +112,47 @@ const buildDateTime = (date: Date, time: string, label: string): Date => {
     throw new Error(`${label} must be a valid date/time.`);
   }
   return combined;
+};
+
+const resolveTimezone = (explicit?: string | null): string => {
+  const candidate = typeof explicit === "string" ? explicit.trim() : "";
+  if (candidate.length > 0) {
+    return candidate;
+  }
+
+  if (typeof Intl !== "undefined" && typeof Intl.DateTimeFormat === "function") {
+    try {
+      const resolved = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      if (resolved && resolved.trim().length > 0) {
+        return resolved;
+      }
+    } catch (error) {
+      // Swallow resolution errors and fall back to UTC.
+    }
+  }
+
+  return "UTC";
+};
+
+const generateIdempotencyKey = (provided?: string | null): string => {
+  const candidate = typeof provided === "string" ? provided.trim() : "";
+  if (candidate.length > 0) {
+    return candidate;
+  }
+
+  try {
+    const globalCrypto = typeof globalThis !== "undefined" ? (globalThis as typeof globalThis & {
+      crypto?: { randomUUID?: () => string };
+    }).crypto : undefined;
+
+    if (globalCrypto && typeof globalCrypto.randomUUID === "function") {
+      return globalCrypto.randomUUID();
+    }
+  } catch (error) {
+    // Swallow generation errors and fall back to a timestamp-based key.
+  }
+
+  return `activity-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 };
 
 export function buildActivitySubmission(input: BaseActivitySubmissionInput): ActivitySubmissionResult {
@@ -153,6 +214,10 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
   const trimmedLocation = location.length > 0 ? location : null;
 
   const type = input.type === "PROPOSE" ? "PROPOSE" : "SCHEDULED";
+  const mode = type === "PROPOSE" ? "proposed" : "scheduled";
+  const timezone = resolveTimezone(input.timezone);
+  const idempotencyKey = generateIdempotencyKey(input.idempotencyKey);
+  const startDate = format(baseDate, "yyyy-MM-dd");
 
   return {
     payload: {
@@ -167,6 +232,19 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
       category: categoryResult.value,
       attendeeIds: attendeeResult.value,
       type,
+      title: name,
+      mode,
+      date: startDate,
+      start_time: startTimeString,
+      end_time: endTimeString,
+      timezone,
+      timeZone: timezone,
+      cost_per_person: costResult.value,
+      max_participants: capacityResult.value,
+      invitee_ids: attendeeResult.value,
+      idempotency_key: idempotencyKey,
+      idempotencyKey,
+      startDate,
     },
   };
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -811,12 +811,6 @@ export function setupRoutes(app: Express) {
     }
   });
 
-  // Simple test route to verify Express is working
-  app.get("/api/test", (req, res) => {
-    console.log("Test route called");
-    res.json({ message: "API is working", timestamp: new Date().toISOString() });
-  });
-
   // 🚨 SECURITY FIX: Google Maps Photo Proxy Endpoint
   // This endpoint prevents API key exposure by proxying photo requests server-side
   app.get("/api/gmaps/photo", async (req, res) => {


### PR DESCRIPTION
## Summary
- update the activity submission helper to generate idempotent, timezone-aware payloads that satisfy both the legacy and V2 activity endpoints
- map new backend validation fields on the create activity mutation and expand the helper unit tests to cover the richer payload
- remove test-only UI and server routes, including the creator leave-trip dialog variant and the `/api/test` endpoint

## Testing
- npm test -- activitySubmission

------
https://chatgpt.com/codex/tasks/task_e_68e3e6c2f830832e8d8d8424ac755718