### PR TITLE
Restrict flight deletion permissions and record audits

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4196,11 +4196,11 @@ export function setupRoutes(app: Express) {
       console.error("Error updating flight:", error);
       if (error instanceof Error) {
         if (error.message.includes('Flight not found')) {
-          return res.status(404).json({ error: "Flight not found" });
+          return res.status(404).json({ error: "Flight not found", message: "Flight not found" });
         }
 
         if (error.message.includes('Only the creator')) {
-          return res.status(403).json({ error: error.message });
+          return res.status(403).json({ error: error.message, message: error.message });
         }
       }
 
@@ -4226,11 +4226,11 @@ export function setupRoutes(app: Express) {
       console.error("Error deleting flight:", error);
       if (error instanceof Error) {
         if (error.message.includes('Flight not found')) {
-          return res.status(404).json({ error: "Flight not found" });
+          return res.status(404).json({ error: "Flight not found", message: "Flight not found" });
         }
 
         if (error.message.includes('Only the creator')) {
-          return res.status(403).json({ error: error.message });
+          return res.status(403).json({ error: error.message, message: error.message });
         }
       }
 


### PR DESCRIPTION
## Summary
- hide flight delete controls unless the viewer created the entry or is an admin, with an admin tooltip when the override is available
- gate server-side deletion on creator/admin access, return friendly errors, and log each deletion in a new audit table
- surface API permission errors in the client so non-creators receive the "Only the creator can delete this flight." message

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e3e8ec62cc832e9f1237981d3d6caa