### PR TITLE
Fix activity date parsing to preserve selected day

### DIFF
--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
 import { buildActivitySubmission } from "../activitySubmission";
 import { END_TIME_AFTER_START_MESSAGE } from "@shared/activityValidation";
 
@@ -83,5 +85,25 @@ describe("buildActivitySubmission", () => {
     });
 
     expect(payload.endTime).toBeNull();
+  });
+
+  it("preserves the selected calendar date for YYYY-MM-DD inputs", async () => {
+    const originalTimeZone = process.env.TZ;
+
+    jest.resetModules();
+    process.env.TZ = "America/Los_Angeles";
+
+    const module = await import("../activitySubmission");
+    const { payload } = module.buildActivitySubmission({
+      ...baseInput,
+      date: "2025-07-04",
+      startTime: "09:30",
+    });
+
+    expect(payload.date).toBe("2025-07-04");
+    expect(payload.startDate).toBe("2025-07-04");
+
+    process.env.TZ = originalTimeZone;
+    jest.resetModules();
   });
 });

--- a/client/src/lib/activitySubmission.ts
+++ b/client/src/lib/activitySubmission.ts
@@ -77,6 +77,30 @@ const toDateInput = (value: string | Date, label: string): Date => {
     throw new Error(`${label} is required.`);
   }
 
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    const [yearString, monthString, dayString] = trimmed.split("-");
+    const year = Number(yearString);
+    const month = Number(monthString);
+    const day = Number(dayString);
+
+    if (
+      Number.isInteger(year)
+      && Number.isInteger(month)
+      && Number.isInteger(day)
+    ) {
+      const parsedLocal = new Date(year, month - 1, day);
+      if (
+        parsedLocal.getFullYear() === year
+        && parsedLocal.getMonth() === month - 1
+        && parsedLocal.getDate() === day
+      ) {
+        return parsedLocal;
+      }
+    }
+
+    throw new Error(`${label} must be a valid date/time.`);
+  }
+
   const parsed = new Date(trimmed);
   if (Number.isNaN(parsed.getTime())) {
     throw new Error(`${label} must be a valid date/time.`);


### PR DESCRIPTION
## Summary
- parse YYYY-MM-DD activity dates using local time so the selected day is not shifted
- add a regression test that covers the timezone-specific behavior for proposal dates

## Testing
- npx jest client/src/lib/__tests__/activitySubmission.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68e3f0cafe90832ebe09153bd11faee6