### PR TITLE
Ensure activity creation requests use Activities V2

### DIFF
--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -292,6 +292,9 @@ export function useCreateActivity({
       const response = await apiRequest(endpoint, {
         method: "POST",
         body: variables.__meta.payload,
+        headers: {
+          "x-activities-version": "2",
+        },
       });
 
       const created = (await response.json()) as ActivityWithDetails;


### PR DESCRIPTION
## Summary
- ensure trip activity creation requests include the `x-activities-version` header so the backend processes them with the Activities V2 pipeline

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e45cd0f188832eaa6cd0c77478d7b1