### PR TITLE
Default to legacy activity creation pipeline

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -14,6 +14,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useToast } from "@/hooks/use-toast";
+import { useNewActivityCreate } from "@/hooks/use-new-activity-create";
 import {
   useCreateActivity,
   type ActivityCreateFormValues,
@@ -218,6 +219,7 @@ export function AddActivityModal({
   const scheduledActivitiesQueryKey = useMemo(() => [`/api/trips/${tripId}/activities`], [tripId]);
   const proposalActivitiesQueryKey = useMemo(() => [`/api/trips/${tripId}/proposals/activities`], [tripId]);
   const calendarActivitiesQueryKey = useMemo(() => ["/api/trips", tripId, "activities"], [tripId]);
+  const shouldUseActivitiesV2 = useNewActivityCreate();
 
   const memberOptions = useMemo<MemberOption[]>(() => {
     const base = members.map((member) => ({
@@ -396,6 +398,7 @@ export function AddActivityModal({
     enabled: tripId > 0,
     onValidationError: handleValidationError,
     onSuccess: handleSuccess,
+    activitiesVersion: shouldUseActivitiesV2 ? "v2" : "legacy",
   });
 
   const selectedAttendeeIds = form.watch("attendeeIds") ?? [];

--- a/client/src/hooks/use-new-activity-create.ts
+++ b/client/src/hooks/use-new-activity-create.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 const STORAGE_KEY = "feature:new-activity-create";
 
 export function useNewActivityCreate(): boolean {
-  const [enabled, setEnabled] = useState(true);
+  const [enabled, setEnabled] = useState(false);
 
   useEffect(() => {
     if (typeof window === "undefined") {

--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -49,6 +49,7 @@ export interface UseCreateActivityOptions {
   onSuccess?: (activity: ActivityWithDetails, values: ActivityCreateFormValues) => void;
   onValidationError?: (error: ActivityValidationError) => void;
   enabled?: boolean;
+  activitiesVersion?: "legacy" | "v2";
 }
 
 type InternalActivityCreateVariables = ActivityCreateFormValues & {
@@ -277,10 +278,12 @@ export function useCreateActivity({
   onSuccess,
   onValidationError,
   enabled = true,
+  activitiesVersion = "legacy",
 }: UseCreateActivityOptions) {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const trackEvent = useMemo(createAnalyticsTracker, []);
+  const useActivitiesV2 = activitiesVersion === "v2";
 
   const mutation = useMutation<MutationResult, Error, InternalActivityCreateVariables, OptimisticContext>({
     mutationFn: async (variables) => {
@@ -292,9 +295,11 @@ export function useCreateActivity({
       const response = await apiRequest(endpoint, {
         method: "POST",
         body: variables.__meta.payload,
-        headers: {
-          "x-activities-version": "2",
-        },
+        headers: useActivitiesV2
+          ? {
+              "x-activities-version": "2",
+            }
+          : undefined,
       });
 
       const created = (await response.json()) as ActivityWithDetails;


### PR DESCRIPTION
## Summary
- default the new activity creation feature flag to off and only opt in when explicitly enabled
- gate the activities v2 API header behind the feature flag so legacy pipeline handles new activities by default

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e4809a3614832e990009d8c113af02