### PR TITLE
Fix scheduling flow to stay on legacy activity pipeline

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -298,6 +298,11 @@ export function AddActivityModal({
 
   const [mode, setMode] = useState<ActivityType>(initialMode);
 
+  const activitiesVersion = useMemo(
+    () => (shouldUseActivitiesV2 && mode === "PROPOSE" ? "v2" : "legacy"),
+    [mode, shouldUseActivitiesV2],
+  );
+
   useEffect(() => {
     if (open) {
       const { values, mode: nextMode } = computeDefaults();
@@ -398,7 +403,7 @@ export function AddActivityModal({
     enabled: tripId > 0,
     onValidationError: handleValidationError,
     onSuccess: handleSuccess,
-    activitiesVersion: shouldUseActivitiesV2 ? "v2" : "legacy",
+    activitiesVersion,
   });
 
   const selectedAttendeeIds = form.watch("attendeeIds") ?? [];

--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -285,7 +285,13 @@ export function useCreateActivity({
   const trackEvent = useMemo(createAnalyticsTracker, []);
   const useActivitiesV2 = activitiesVersion === "v2";
 
-  const mutation = useMutation<MutationResult, Error, InternalActivityCreateVariables, OptimisticContext>({
+  const mutation = useMutation<
+    MutationResult,
+    Error,
+    InternalActivityCreateVariables,
+    OptimisticContext
+  >({
+    mutationKey: ["create-activity", tripId, useActivitiesV2 ? "v2" : "legacy"],
     mutationFn: async (variables) => {
       const endpoint =
         variables.type === "PROPOSE"


### PR DESCRIPTION
## Summary
- compute the activity creation pipeline dynamically so that scheduled activities continue using the legacy endpoint
- add a mutation key that reflects the selected pipeline so React Query resets the mutation when the mode changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e50db9784c832e8cd56e0dd8cf5089