### PR TITLE
Improve Activities v2 request normalization

### DIFF
--- a/server/__tests__/activitiesV2.create.test.ts
+++ b/server/__tests__/activitiesV2.create.test.ts
@@ -5,6 +5,297 @@ import type { TripWithDetails } from "@shared/schema";
 
 const ORIGINAL_ENV = process.env.NODE_ENV;
 
+const createTripFixture = () => {
+  const now = new Date();
+
+  const creatorUser: TripWithDetails["creator"] = {
+    id: "organizer",
+    email: "organizer@example.com",
+    username: "organizer",
+    firstName: "Organizer",
+    lastName: "User",
+    phoneNumber: null,
+    passwordHash: null,
+    profileImageUrl: null,
+    cashAppUsername: null,
+    cashAppUsernameLegacy: null,
+    cashAppPhone: null,
+    cashAppPhoneLegacy: null,
+    venmoUsername: null,
+    venmoPhone: null,
+    timezone: "UTC",
+    defaultLocation: null,
+    defaultLocationCode: null,
+    defaultCity: null,
+    defaultCountry: null,
+    authProvider: null,
+    notificationPreferences: null,
+    hasSeenHomeOnboarding: false,
+    hasSeenTripOnboarding: false,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  const friendUser: TripWithDetails["creator"] = {
+    id: "friend-1",
+    email: "friend@example.com",
+    username: "friend",
+    firstName: "Friend",
+    lastName: "Traveler",
+    phoneNumber: null,
+    passwordHash: null,
+    profileImageUrl: null,
+    cashAppUsername: null,
+    cashAppUsernameLegacy: null,
+    cashAppPhone: null,
+    cashAppPhoneLegacy: null,
+    venmoUsername: null,
+    venmoPhone: null,
+    timezone: "UTC",
+    defaultLocation: null,
+    defaultLocationCode: null,
+    defaultCity: null,
+    defaultCountry: null,
+    authProvider: null,
+    notificationPreferences: null,
+    hasSeenHomeOnboarding: false,
+    hasSeenTripOnboarding: false,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+
+  const trip: TripWithDetails = {
+    id: 123,
+    name: "Spring Adventure",
+    destination: "Paris",
+    startDate: now.toISOString(),
+    endDate: now.toISOString(),
+    shareCode: "share-code",
+    createdBy: creatorUser.id,
+    createdAt: now.toISOString(),
+    geonameId: null,
+    cityName: null,
+    countryName: null,
+    latitude: null,
+    longitude: null,
+    population: null,
+    coverImageUrl: null,
+    coverPhotoUrl: null,
+    coverPhotoCardUrl: null,
+    coverPhotoThumbUrl: null,
+    coverPhotoAlt: null,
+    coverPhotoAttribution: null,
+    coverPhotoStorageKey: null,
+    coverPhotoOriginalUrl: null,
+    coverPhotoFocalX: null,
+    coverPhotoFocalY: null,
+    coverPhotoUploadSize: null,
+    coverPhotoUploadType: null,
+    creator: creatorUser,
+    members: [
+      {
+        id: 1,
+        tripCalendarId: 123,
+        userId: creatorUser.id,
+        role: "organizer",
+        departureLocation: null,
+        departureAirport: null,
+        joinedAt: now.toISOString(),
+        user: creatorUser,
+      },
+      {
+        id: 2,
+        tripCalendarId: 123,
+        userId: friendUser.id,
+        role: "member",
+        departureLocation: null,
+        departureAirport: null,
+        joinedAt: now.toISOString(),
+        user: friendUser,
+      },
+    ],
+    memberCount: 2,
+  };
+
+  return { now, creatorUser, friendUser, trip };
+};
+
+interface DbMockOptions {
+  now: Date;
+  creatorUser: TripWithDetails["creator"];
+  friendUser: TripWithDetails["creator"];
+  trip: TripWithDetails;
+  onInsert?: (params: unknown[]) => void;
+}
+
+const setupDbMocks = ({ now, creatorUser, friendUser, trip, onInsert }: DbMockOptions) => {
+  let insertedActivityId: string | undefined;
+  let lastInsertParams: unknown[] | null = null;
+
+  const queryMock = jest.fn(async (sql: string) => {
+    const text = typeof sql === "string" ? sql : String(sql);
+
+    if (text.includes("SELECT a.*, u.email AS creator_email")) {
+      if (!insertedActivityId) {
+        throw new Error("activity insert did not run");
+      }
+
+      const insertedValues = lastInsertParams ?? [];
+      return {
+        rows: [
+          {
+            id: insertedActivityId,
+            trip_id: String(trip.id),
+            creator_id: creatorUser.id,
+            title: insertedValues[3] ?? "",
+            description: insertedValues[4] ?? null,
+            category: insertedValues[5] ?? null,
+            date: insertedValues[6] ?? trip.startDate,
+            start_time: insertedValues[7] ?? "00:00",
+            end_time: insertedValues[8] ?? null,
+            timezone: insertedValues[9] ?? "UTC",
+            location: insertedValues[10] ?? null,
+            cost_per_person: insertedValues[11] ?? null,
+            max_participants: insertedValues[12] ?? null,
+            status: insertedValues[13] ?? "scheduled",
+            visibility: "trip",
+            created_at: now,
+            updated_at: now,
+            version: 1,
+            creator_email: creatorUser.email,
+            creator_username: creatorUser.username,
+            creator_first_name: creatorUser.firstName,
+            creator_last_name: creatorUser.lastName,
+            creator_phone_number: creatorUser.phoneNumber,
+            creator_profile_image_url: creatorUser.profileImageUrl,
+            creator_timezone: creatorUser.timezone,
+          },
+        ],
+      };
+    }
+
+    if (text.includes("FROM activity_invitees_v2")) {
+      if (!insertedActivityId) {
+        throw new Error("activity insert did not run");
+      }
+
+      return {
+        rows: [
+          {
+            activity_id: insertedActivityId,
+            user_id: creatorUser.id,
+            role: "participant",
+            created_at: now,
+            updated_at: now,
+            user_email: creatorUser.email,
+            user_username: creatorUser.username,
+            user_first_name: creatorUser.firstName,
+            user_last_name: creatorUser.lastName,
+            user_phone_number: creatorUser.phoneNumber,
+            user_profile_image_url: creatorUser.profileImageUrl,
+            user_timezone: creatorUser.timezone,
+          },
+          {
+            activity_id: insertedActivityId,
+            user_id: friendUser.id,
+            role: "participant",
+            created_at: now,
+            updated_at: now,
+            user_email: friendUser.email,
+            user_username: friendUser.username,
+            user_first_name: friendUser.firstName,
+            user_last_name: friendUser.lastName,
+            user_phone_number: friendUser.phoneNumber,
+            user_profile_image_url: friendUser.profileImageUrl,
+            user_timezone: friendUser.timezone,
+          },
+        ],
+      };
+    }
+
+    if (text.includes("FROM activity_votes_v2")) {
+      return { rows: [] };
+    }
+
+    if (text.includes("FROM activity_rsvps_v2")) {
+      if (!insertedActivityId) {
+        throw new Error("activity insert did not run");
+      }
+
+      const insertedValues = lastInsertParams ?? [];
+      const insertedStatus = String(insertedValues[13] ?? "scheduled");
+      const creatorResponse = insertedStatus === "scheduled" ? "yes" : "pending";
+      return {
+        rows: [
+          {
+            activity_id: insertedActivityId,
+            user_id: creatorUser.id,
+            response: creatorResponse,
+            responded_at: creatorResponse === "yes" ? now : null,
+            rsvp_user_email: creatorUser.email,
+            rsvp_user_username: creatorUser.username,
+            rsvp_user_first_name: creatorUser.firstName,
+            rsvp_user_last_name: creatorUser.lastName,
+            rsvp_user_phone_number: creatorUser.phoneNumber,
+            rsvp_user_profile_image_url: creatorUser.profileImageUrl,
+            rsvp_user_timezone: creatorUser.timezone,
+          },
+          {
+            activity_id: insertedActivityId,
+            user_id: friendUser.id,
+            response: "pending",
+            responded_at: null,
+            rsvp_user_email: friendUser.email,
+            rsvp_user_username: friendUser.username,
+            rsvp_user_first_name: friendUser.firstName,
+            rsvp_user_last_name: friendUser.lastName,
+            rsvp_user_phone_number: friendUser.phoneNumber,
+            rsvp_user_profile_image_url: friendUser.profileImageUrl,
+            rsvp_user_timezone: friendUser.timezone,
+          },
+        ],
+      };
+    }
+
+    return { rows: [] };
+  });
+
+  const clientQueryMock = jest.fn(async (sql: string, params: unknown[] = []) => {
+      const text = typeof sql === "string" ? sql : String(sql);
+
+      if (text.startsWith("BEGIN") || text.startsWith("COMMIT") || text.startsWith("ROLLBACK")) {
+        return { rows: [] };
+      }
+
+    if (text.includes("SELECT id FROM activities_v2")) {
+      return { rows: [] };
+    }
+
+    if (text.includes("INSERT INTO activities_v2")) {
+      insertedActivityId = String(params[0]);
+      lastInsertParams = params;
+      onInsert?.(params);
+      return { rows: [] };
+    }
+
+    return { rows: [] };
+  });
+
+  const connectMock = jest.fn().mockResolvedValue({
+    query: clientQueryMock,
+    release: jest.fn(),
+  });
+
+  jest.doMock("../db", () => ({
+    query: queryMock,
+    pool: {
+      connect: connectMock,
+    },
+  }));
+
+  return { connectMock, clientQueryMock, queryMock, getInsertedActivityId: () => insertedActivityId };
+};
+
 describe("createActivityV2", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -16,116 +307,7 @@ describe("createActivityV2", () => {
   });
 
   it("treats blank end_time strings as null before inserting", async () => {
-    const now = new Date();
-
-    const creatorUser: TripWithDetails["creator"] = {
-      id: "organizer",
-      email: "organizer@example.com",
-      username: "organizer",
-      firstName: "Organizer",
-      lastName: "User",
-      phoneNumber: null,
-      passwordHash: null,
-      profileImageUrl: null,
-      cashAppUsername: null,
-      cashAppUsernameLegacy: null,
-      cashAppPhone: null,
-      cashAppPhoneLegacy: null,
-      venmoUsername: null,
-      venmoPhone: null,
-      timezone: "UTC",
-      defaultLocation: null,
-      defaultLocationCode: null,
-      defaultCity: null,
-      defaultCountry: null,
-      authProvider: null,
-      notificationPreferences: null,
-      hasSeenHomeOnboarding: false,
-      hasSeenTripOnboarding: false,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-    };
-
-    const friendUser: TripWithDetails["creator"] = {
-      id: "friend-1",
-      email: "friend@example.com",
-      username: "friend",
-      firstName: "Friend",
-      lastName: "Traveler",
-      phoneNumber: null,
-      passwordHash: null,
-      profileImageUrl: null,
-      cashAppUsername: null,
-      cashAppUsernameLegacy: null,
-      cashAppPhone: null,
-      cashAppPhoneLegacy: null,
-      venmoUsername: null,
-      venmoPhone: null,
-      timezone: "UTC",
-      defaultLocation: null,
-      defaultLocationCode: null,
-      defaultCity: null,
-      defaultCountry: null,
-      authProvider: null,
-      notificationPreferences: null,
-      hasSeenHomeOnboarding: false,
-      hasSeenTripOnboarding: false,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-    };
-
-    const trip: TripWithDetails = {
-      id: 123,
-      name: "Spring Adventure",
-      destination: "Paris",
-      startDate: now.toISOString(),
-      endDate: now.toISOString(),
-      shareCode: "share-code",
-      createdBy: creatorUser.id,
-      createdAt: now.toISOString(),
-      geonameId: null,
-      cityName: null,
-      countryName: null,
-      latitude: null,
-      longitude: null,
-      population: null,
-      coverImageUrl: null,
-      coverPhotoUrl: null,
-      coverPhotoCardUrl: null,
-      coverPhotoThumbUrl: null,
-      coverPhotoAlt: null,
-      coverPhotoAttribution: null,
-      coverPhotoStorageKey: null,
-      coverPhotoOriginalUrl: null,
-      coverPhotoFocalX: null,
-      coverPhotoFocalY: null,
-      coverPhotoUploadSize: null,
-      coverPhotoUploadType: null,
-      creator: creatorUser,
-      members: [
-        {
-          id: 1,
-          tripCalendarId: 123,
-          userId: creatorUser.id,
-          role: "organizer",
-          departureLocation: null,
-          departureAirport: null,
-          joinedAt: now.toISOString(),
-          user: creatorUser,
-        },
-        {
-          id: 2,
-          tripCalendarId: 123,
-          userId: friendUser.id,
-          role: "member",
-          departureLocation: null,
-          departureAirport: null,
-          joinedAt: now.toISOString(),
-          user: friendUser,
-        },
-      ],
-      memberCount: 2,
-    };
+    const { now, creatorUser, friendUser, trip } = createTripFixture();
 
     const activityRequest: CreateActivityRequest = {
       mode: "scheduled",
@@ -143,162 +325,15 @@ describe("createActivityV2", () => {
       idempotency_key: "demo-key",
     };
 
-    const timestamp = new Date(now);
-    let insertedActivityId: string | undefined;
-
-    const queryMock = jest.fn(async (sql: string) => {
-      if (typeof sql === "string" && sql.includes("SELECT a.*, u.email AS creator_email")) {
-        if (!insertedActivityId) {
-          throw new Error("activity insert did not run");
-        }
-
-        return {
-          rows: [
-            {
-              id: insertedActivityId,
-              trip_id: String(trip.id),
-              creator_id: creatorUser.id,
-              title: activityRequest.title,
-              description: activityRequest.description,
-              category: activityRequest.category,
-              date: activityRequest.date,
-              start_time: activityRequest.start_time,
-              end_time: null,
-              timezone: activityRequest.timezone,
-              location: null,
-              cost_per_person: null,
-              max_participants: null,
-              status: "scheduled",
-              visibility: "trip",
-              created_at: timestamp,
-              updated_at: timestamp,
-              version: 1,
-              creator_email: creatorUser.email,
-              creator_username: creatorUser.username,
-              creator_first_name: creatorUser.firstName,
-              creator_last_name: creatorUser.lastName,
-              creator_phone_number: creatorUser.phoneNumber,
-              creator_profile_image_url: creatorUser.profileImageUrl,
-              creator_timezone: creatorUser.timezone,
-            },
-          ],
-        };
-      }
-
-      if (typeof sql === "string" && sql.includes("FROM activity_invitees_v2")) {
-        if (!insertedActivityId) {
-          throw new Error("activity insert did not run");
-        }
-
-        return {
-          rows: [
-            {
-              activity_id: insertedActivityId,
-              user_id: creatorUser.id,
-              role: "participant",
-              created_at: timestamp,
-              updated_at: timestamp,
-              user_email: creatorUser.email,
-              user_username: creatorUser.username,
-              user_first_name: creatorUser.firstName,
-              user_last_name: creatorUser.lastName,
-              user_phone_number: creatorUser.phoneNumber,
-              user_profile_image_url: creatorUser.profileImageUrl,
-              user_timezone: creatorUser.timezone,
-            },
-            {
-              activity_id: insertedActivityId,
-              user_id: friendUser.id,
-              role: "participant",
-              created_at: timestamp,
-              updated_at: timestamp,
-              user_email: friendUser.email,
-              user_username: friendUser.username,
-              user_first_name: friendUser.firstName,
-              user_last_name: friendUser.lastName,
-              user_phone_number: friendUser.phoneNumber,
-              user_profile_image_url: friendUser.profileImageUrl,
-              user_timezone: friendUser.timezone,
-            },
-          ],
-        };
-      }
-
-      if (typeof sql === "string" && sql.includes("FROM activity_votes_v2")) {
-        return { rows: [] };
-      }
-
-      if (typeof sql === "string" && sql.includes("FROM activity_rsvps_v2")) {
-        if (!insertedActivityId) {
-          throw new Error("activity insert did not run");
-        }
-
-        return {
-          rows: [
-            {
-              activity_id: insertedActivityId,
-              user_id: creatorUser.id,
-              response: "yes",
-              responded_at: timestamp,
-              rsvp_user_email: creatorUser.email,
-              rsvp_user_username: creatorUser.username,
-              rsvp_user_first_name: creatorUser.firstName,
-              rsvp_user_last_name: creatorUser.lastName,
-              rsvp_user_phone_number: creatorUser.phoneNumber,
-              rsvp_user_profile_image_url: creatorUser.profileImageUrl,
-              rsvp_user_timezone: creatorUser.timezone,
-            },
-            {
-              activity_id: insertedActivityId,
-              user_id: friendUser.id,
-              response: "pending",
-              responded_at: null,
-              rsvp_user_email: friendUser.email,
-              rsvp_user_username: friendUser.username,
-              rsvp_user_first_name: friendUser.firstName,
-              rsvp_user_last_name: friendUser.lastName,
-              rsvp_user_phone_number: friendUser.phoneNumber,
-              rsvp_user_profile_image_url: friendUser.profileImageUrl,
-              rsvp_user_timezone: friendUser.timezone,
-            },
-          ],
-        };
-      }
-
-      return { rows: [] };
-    });
-
-    const clientQueryMock = jest.fn(async (sql: string, params: unknown[] = []) => {
-      const text = typeof sql === "string" ? sql : String(sql);
-
-      if (text.startsWith("BEGIN") || text.startsWith("COMMIT") || text.startsWith("ROLLBACK")) {
-        return { rows: [] };
-      }
-
-      if (text.includes("SELECT id FROM activities_v2")) {
-        return { rows: [] };
-      }
-
-      if (text.includes("INSERT INTO activities_v2")) {
-        insertedActivityId = String(params[0]);
+    const { connectMock, clientQueryMock } = setupDbMocks({
+      now,
+      creatorUser,
+      friendUser,
+      trip,
+      onInsert: (params) => {
         expect(params[8]).toBeNull();
-        return { rows: [] };
-      }
-
-      return { rows: [] };
-    });
-
-    const connectMock = jest.fn().mockResolvedValue({
-      query: clientQueryMock,
-      release: jest.fn(),
-    });
-
-    jest.doMock("../db", () => ({
-      query: queryMock,
-      pool: {
-        connect: connectMock,
       },
-    }));
+    });
 
     const { createActivityV2 } = await import("../activitiesV2");
 
@@ -310,14 +345,103 @@ describe("createActivityV2", () => {
 
     expect(connectMock).toHaveBeenCalled();
     expect(clientQueryMock.mock.calls.some(([sql]) => typeof sql === "string" && sql.includes("INSERT INTO activities_v2"))).toBe(true);
-    const insertCall = clientQueryMock.mock.calls.find(
-      ([sql]) => typeof sql === "string" && sql.includes("INSERT INTO activities_v2"),
-    );
-    expect(insertCall?.[1]?.[8]).toBeNull();
 
     expect(result.endTime).toBeNull();
     expect(result.initialVoteOrRsvpState[creatorUser.id]).toBe("yes");
     expect(result.initialVoteOrRsvpState[friendUser.id]).toBe("pending");
+  });
+
+  it("normalizes loosely formatted time strings before inserting", async () => {
+    const { now, creatorUser, friendUser, trip } = createTripFixture();
+
+    const activityRequest: CreateActivityRequest = {
+      mode: "scheduled",
+      title: "Morning Run",
+      description: null,
+      category: null,
+      date: "2024-03-02",
+      start_time: "9:5",
+      end_time: " 10:45 ",
+      timezone: "UTC",
+      location: null,
+      cost_per_person: null,
+      max_participants: null,
+      invitee_ids: [friendUser.id],
+      idempotency_key: "time-test",
+    };
+
+    const { connectMock, clientQueryMock } = setupDbMocks({
+      now,
+      creatorUser,
+      friendUser,
+      trip,
+      onInsert: (params) => {
+        expect(params[7]).toBe("09:05");
+        expect(params[8]).toBe("10:45");
+      },
+    });
+
+    const { createActivityV2 } = await import("../activitiesV2");
+
+    const result = await createActivityV2({
+      trip,
+      creatorId: creatorUser.id,
+      body: activityRequest,
+    });
+
+    expect(connectMock).toHaveBeenCalled();
+    const insertCall = clientQueryMock.mock.calls.find(([sql]) => typeof sql === "string" && sql.includes("INSERT INTO activities_v2"));
+    expect(insertCall?.[1]?.[7]).toBe("09:05");
+    expect(insertCall?.[1]?.[8]).toBe("10:45");
+    expect(result.startTime).toBe("09:05");
+    expect(result.endTime).toBe("10:45");
+  });
+
+  it("generates an idempotency key when the request omits one", async () => {
+    const { now, creatorUser, friendUser, trip } = createTripFixture();
+
+    const activityRequest: CreateActivityRequest = {
+      mode: "scheduled",
+      title: "Lunch Meetup",
+      description: null,
+      category: null,
+      date: "2024-03-03",
+      start_time: "12:00",
+      end_time: null,
+      timezone: "UTC",
+      location: null,
+      cost_per_person: null,
+      max_participants: null,
+      invitee_ids: [friendUser.id],
+      idempotency_key: "   ",
+    };
+
+    let capturedIdempotency: string | undefined;
+
+    const { connectMock, clientQueryMock } = setupDbMocks({
+      now,
+      creatorUser,
+      friendUser,
+      trip,
+      onInsert: (params) => {
+        capturedIdempotency = String(params[14]);
+        expect(capturedIdempotency).toEqual(expect.any(String));
+        expect(capturedIdempotency?.trim().length).toBeGreaterThan(0);
+      },
+    });
+
+    const { createActivityV2 } = await import("../activitiesV2");
+
+    const result = await createActivityV2({
+      trip,
+      creatorId: creatorUser.id,
+      body: activityRequest,
+    });
+
+    expect(connectMock).toHaveBeenCalled();
+    const insertCall = clientQueryMock.mock.calls.find(([sql]) => typeof sql === "string" && sql.includes("INSERT INTO activities_v2"));
+    expect(insertCall?.[1]?.[14]).toBe(capturedIdempotency);
+    expect(capturedIdempotency).toBeDefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- normalize Activities v2 start/end times and generate fallback idempotency keys before inserting
- trim client idempotency headers and create a server-side key when requests opt into Activities v2
- expand Activities v2 unit tests to cover time normalization and automatic idempotency behavior

## Testing
- npm test -- --runTestsByPath server/__tests__/activitiesV2.create.test.ts
- npm test -- --runTestsByPath server/__tests__/createActivityRoute.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e51f5c3688832e9a730b8e3f0eca96