### PR TITLE
Fix activity type schema handling for enum columns

### DIFF
--- a/server/__tests__/storage.ensureActivityTypeColumn.test.ts
+++ b/server/__tests__/storage.ensureActivityTypeColumn.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+describe("ensureActivityTypeColumn", () => {
+  let queryMock: jest.Mock;
+  let DatabaseStorage: typeof import("../storage").DatabaseStorage;
+  const ORIGINAL_DB_URL = process.env.DATABASE_URL;
+  let restoreQuery: (() => void) | null = null;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    queryMock = jest.fn();
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? "postgres://user:pass@localhost:5432/test";
+
+    const dbModule = await import("../db");
+    const querySpy = jest.spyOn(dbModule, "query").mockImplementation(queryMock);
+    restoreQuery = () => querySpy.mockRestore();
+
+    ({ DatabaseStorage } = await import("../storage"));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env.DATABASE_URL = ORIGINAL_DB_URL;
+    restoreQuery?.();
+    restoreQuery = null;
+  });
+
+  it("sets enum defaults when the column uses a user-defined type", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ data_type: "USER-DEFINED", udt_name: "activity_type" }] })
+      .mockResolvedValue({ rows: [] });
+
+    const storage = new DatabaseStorage();
+    await (storage as any).ensureActivityTypeColumn();
+
+    const defaultCall = queryMock.mock.calls.find(([sql]) =>
+      typeof sql === "string" && sql.includes("ALTER TABLE activities ALTER COLUMN type SET DEFAULT"),
+    );
+    expect(defaultCall?.[0]).toContain("'SCHEDULED'::activity_type");
+
+    const updateCall = queryMock.mock.calls.find(([sql]) =>
+      typeof sql === "string" && sql.includes("UPDATE activities SET type"),
+    );
+    expect(updateCall?.[0]).toContain("'SCHEDULED'::activity_type");
+  });
+
+  it("cleans blank string values for text columns", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ data_type: "text", udt_name: null }] })
+      .mockResolvedValue({ rows: [] });
+
+    const storage = new DatabaseStorage();
+    await (storage as any).ensureActivityTypeColumn();
+
+    const updateCall = queryMock.mock.calls.find(([sql]) =>
+      typeof sql === "string" && sql.includes("UPDATE activities SET type"),
+    );
+    expect(updateCall?.[0]).toContain("TRIM(type) = ''");
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle activities.type columns that use enum types when ensuring schema defaults
- normalize blank string values for text columns while keeping the existing migration path
- add unit tests covering enum and text activity type columns

## Testing
- npm test -- --runTestsByPath server/__tests__/storage.ensureActivityTypeColumn.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5269d3fa8832e90bc458177915a10