### PR TITLE
Support optional proposal start times

### DIFF
--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -87,6 +87,18 @@ describe("buildActivitySubmission", () => {
     expect(payload.endTime).toBeNull();
   });
 
+  it("allows proposals without a start time", () => {
+    const { payload } = buildActivitySubmission({
+      ...baseInput,
+      type: "PROPOSE",
+      startTime: "",
+      endTime: undefined,
+    });
+
+    expect(payload.startTime).toEqual(expect.any(String));
+    expect(payload.start_time).toBeNull();
+  });
+
   it("preserves the selected calendar date for YYYY-MM-DD inputs", async () => {
     const originalTimeZone = process.env.TZ;
 

--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -19,7 +19,7 @@ export interface ActivityCreateFormValues {
   name: string;
   description?: string;
   startDate: string;
-  startTime: string;
+  startTime?: string | null;
   endTime?: string | null;
   location?: string;
   cost?: string;
@@ -112,9 +112,17 @@ const createAnalyticsTracker = () => {
 };
 
 const sortByStartTime = (activities: ActivityWithDetails[]) =>
-  [...activities].sort(
-    (a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-  );
+  [...activities].sort((a, b) => {
+    const toTimestamp = (value: ActivityWithDetails["startTime"]) => {
+      if (!value) {
+        return Number.POSITIVE_INFINITY;
+      }
+      const date = new Date(value);
+      return Number.isNaN(date.getTime()) ? Number.POSITIVE_INFINITY : date.getTime();
+    };
+
+    return toTimestamp(a.startTime) - toTimestamp(b.startTime);
+  });
 
 const generateOptimisticId = (() => {
   let counter = -1;


### PR DESCRIPTION
## Summary
- allow the activity modal to treat start time as optional in proposal mode while keeping scheduled activities strict
- extend activity creation payload handling and validation to permit missing proposal start times across client and server
- add coverage ensuring buildActivitySubmission accepts proposal submissions without a start time

## Testing
- npm run test -- activitySubmission
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68e52bb9439c832e9d6ee5d55b854882