### PR TITLE
Require start times for activity creation

### DIFF
--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -87,16 +87,15 @@ describe("buildActivitySubmission", () => {
     expect(payload.endTime).toBeNull();
   });
 
-  it("allows proposals without a start time", () => {
-    const { payload } = buildActivitySubmission({
-      ...baseInput,
-      type: "PROPOSE",
-      startTime: "",
-      endTime: undefined,
-    });
-
-    expect(payload.startTime).toEqual(expect.any(String));
-    expect(payload.start_time).toBeNull();
+  it("requires a start time for proposals", () => {
+    expect(() =>
+      buildActivitySubmission({
+        ...baseInput,
+        type: "PROPOSE",
+        startTime: "",
+        endTime: undefined,
+      }),
+    ).toThrow("Start time is required so we can place this on the calendar.");
   });
 
   it("preserves the selected calendar date for YYYY-MM-DD inputs", async () => {

--- a/client/src/lib/activities/clientValidation.ts
+++ b/client/src/lib/activities/clientValidation.ts
@@ -26,7 +26,7 @@ const clientValidationMessageMap: Array<{
   {
     field: "startTime",
     messages: [
-      "Start time is required.",
+      "Start time is required so we can place this on the calendar.",
       "Start time must be in HH:MM format.",
       "Start time must be a valid date/time.",
     ],

--- a/client/src/lib/activities/createActivity.ts
+++ b/client/src/lib/activities/createActivity.ts
@@ -19,7 +19,7 @@ export interface ActivityCreateFormValues {
   name: string;
   description?: string;
   startDate: string;
-  startTime?: string | null;
+  startTime: string;
   endTime?: string | null;
   location?: string;
   cost?: string;

--- a/client/src/lib/activitySubmission.ts
+++ b/client/src/lib/activitySubmission.ts
@@ -16,7 +16,7 @@ interface BaseActivitySubmissionInput {
   name: string;
   description?: string | null;
   date: string | Date;
-  startTime?: string | Date | null;
+  startTime: string | Date;
   endTime?: string | Date | null;
   location?: string | null;
   cost?: string | number | null;
@@ -48,7 +48,7 @@ interface ActivitySubmissionPayload {
   title: string;
   mode: "scheduled" | "proposed";
   date: string;
-  start_time: string | null;
+  start_time: string;
   end_time: string | null;
   timezone: string;
   timeZone: string;
@@ -202,11 +202,11 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
     || (typeof rawStartTime === "string" && rawStartTime.trim() === "")
   );
 
-  if (!hasStartTime && !isProposal) {
-    throw new Error("Start time is required for scheduled activities.");
+  if (!hasStartTime) {
+    throw new Error("Start time is required so we can place this on the calendar.");
   }
 
-  const startTimeString = hasStartTime ? toTimeString(rawStartTime as string | Date, "Start time") : null;
+  const startTimeString = toTimeString(rawStartTime as string | Date, "Start time");
 
   const endTimeInput = input.endTime;
   const shouldUseEndTime = !(
@@ -215,20 +215,14 @@ export function buildActivitySubmission(input: BaseActivitySubmissionInput): Act
     || (typeof endTimeInput === "string" && endTimeInput.trim() === "")
   );
 
-  if (shouldUseEndTime && !startTimeString) {
-    throw new Error("Add a start time before setting an end time.");
-  }
-
   const endTimeString = shouldUseEndTime
     ? toTimeString(endTimeInput as string | Date, "End time")
     : null;
 
-  const startDateTime = startTimeString
-    ? buildDateTime(baseDate, startTimeString, "Start time")
-    : new Date(baseDate);
+  const startDateTime = buildDateTime(baseDate, startTimeString, "Start time");
   const endDateTime = endTimeString ? buildDateTime(baseDate, endTimeString, "End time") : null;
 
-  if (endDateTime && startTimeString && endDateTime <= startDateTime) {
+  if (endDateTime && endDateTime <= startDateTime) {
     throw new Error(END_TIME_AFTER_START_MESSAGE);
   }
 

--- a/server/activitiesV2.ts
+++ b/server/activitiesV2.ts
@@ -472,10 +472,15 @@ export async function createActivityV2({
     throw error;
   }
 
-  if (!startTime && data.mode === "scheduled") {
+  if (!startTime) {
     const error = new Error("missing_start_time");
     (error as any).code = "VALIDATION";
-    (error as any).details = [{ field: "start_time", message: "Start time is required." }];
+    (error as any).details = [
+      {
+        field: "start_time",
+        message: "Start time is required so we can place this on the calendar.",
+      },
+    ];
     throw error;
   }
 

--- a/shared/activitiesV2.ts
+++ b/shared/activitiesV2.ts
@@ -69,6 +69,8 @@ export interface ActivityWithDetails extends Activity {
   currentUserRsvp?: ActivityRsvp | null;
 }
 
+const START_TIME_REQUIRED_MESSAGE = "Start time is required so we can place this on the calendar.";
+
 export const createActivityRequestSchema = z
   .object({
     mode: z.enum(["proposed", "scheduled"]),
@@ -106,14 +108,15 @@ export const createActivityRequestSchema = z
     idempotency_key: z.string().min(1),
   })
   .superRefine((data, ctx) => {
-    if (data.mode === "scheduled") {
-      if (!data.start_time || data.start_time.trim().length === 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["start_time"],
-          message: "Start time is required for scheduled activities.",
-        });
-      }
+    const normalizedStartTime =
+      typeof data.start_time === "string" ? data.start_time.trim() : data.start_time;
+
+    if (!normalizedStartTime) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["start_time"],
+        message: START_TIME_REQUIRED_MESSAGE,
+      });
     }
   });
 

--- a/shared/activityValidation.ts
+++ b/shared/activityValidation.ts
@@ -171,11 +171,11 @@ export const normalizeCategoryInput = (
 const normalizeDateTimeInput = (
   value: unknown,
   fieldLabel: string,
-  { required }: { required: boolean },
+  { required, requiredMessage }: { required: boolean; requiredMessage?: string },
 ): { value: string | null; error?: string } => {
   if (value === undefined || value === null) {
     return required
-      ? { value: null, error: `${fieldLabel} is required.` }
+      ? { value: null, error: requiredMessage ?? `${fieldLabel} is required.` }
       : { value: null };
   }
 
@@ -183,7 +183,7 @@ const normalizeDateTimeInput = (
     const trimmed = value.trim();
     if (trimmed === "") {
       return required
-        ? { value: null, error: `${fieldLabel} is required.` }
+        ? { value: null, error: requiredMessage ?? `${fieldLabel} is required.` }
         : { value: null };
     }
 
@@ -264,7 +264,10 @@ export const validateActivityInput = (
     });
   }
 
-  const startResult = normalizeDateTimeInput(rawData.startTime, "Start time", { required: true });
+  const startResult = normalizeDateTimeInput(rawData.startTime, "Start time", {
+    required: true,
+    requiredMessage: "Start time is required so we can place this on the calendar.",
+  });
   if (startResult.error) {
     errors.push({ field: "startTime", message: startResult.error });
   }


### PR DESCRIPTION
## Summary
- require start times in the activity modal with inline guidance, button disablement, and updated mode copy
- enforce start time on client/server validation and submission payloads for all activity types
- adjust supporting schemas and tests to reflect the new start time requirement

## Testing
- npm run check
- npm run test -- activitySubmission

------
https://chatgpt.com/codex/tasks/task_e_68e5306cfa9c832ea1699e88a324d0f7