### PR TITLE
Normalize calendar activity query key

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -230,7 +230,11 @@ export function AddActivityModal({
 
   const scheduledActivitiesQueryKey = useMemo(() => [`/api/trips/${tripId}/activities`], [tripId]);
   const proposalActivitiesQueryKey = useMemo(() => [`/api/trips/${tripId}/proposals/activities`], [tripId]);
-  const calendarActivitiesQueryKey = useMemo(() => ["/api/trips", tripId, "activities"], [tripId]);
+  const tripIdString = useMemo(() => (Number.isFinite(tripId) ? String(tripId) : ""), [tripId]);
+  const calendarActivitiesQueryKey = useMemo(
+    () => ["/api/trips", tripIdString, "activities"],
+    [tripIdString],
+  );
 
   const memberOptions = useMemo<MemberOption[]>(() => {
     const base = members.map((member) => ({


### PR DESCRIPTION
## Summary
- normalize the calendar activities query key in the Add Activity modal so it matches existing queries

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55723766c832e909373fa84813097