### PR TITLE
Add thumbs-based responses for proposed activities

### DIFF
--- a/client/src/components/activity-details-dialog.tsx
+++ b/client/src/components/activity-details-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Calendar, MapPin, DollarSign, Users, ChevronDown } from "lucide-react";
+import { Calendar, MapPin, DollarSign, Users, ChevronDown, ThumbsDown, ThumbsUp } from "lucide-react";
 import { format } from "date-fns";
 import type { ActivityInviteStatus, ActivityWithDetails } from "@shared/schema";
 import type { User } from "@shared/schema";
@@ -157,32 +157,68 @@ export function ActivityDetailsDialog({
       );
     }
 
-    const declineLabel = isProposal ? "Not interested" : "Decline";
-    const acceptLabel = isProposal ? "Interested" : "Accept";
-
     if (isProposal) {
+      const isAccepted = statusForDisplay === "accepted";
+      const isDeclined = statusForDisplay === "declined";
+
+      const handleThumbsUp = () => {
+        if (isAccepted) {
+          handleRespond("pending");
+          return;
+        }
+        handleRespond("accepted");
+      };
+
+      const handleThumbsDown = () => {
+        if (isDeclined) {
+          handleRespond("pending");
+          return;
+        }
+        handleRespond("declined");
+      };
+
       return (
-        <>
+        <div className="flex items-center gap-2">
           <Button
             size="sm"
-            onClick={() => handleRespond("accepted")}
+            variant="outline"
+            onClick={handleThumbsUp}
             disabled={isResponding}
-            aria-label="Accept invitation"
+            aria-label={isAccepted ? "Remove thumbs up" : "Give thumbs up"}
+            aria-pressed={isAccepted}
+            className={cn(
+              "flex h-9 w-9 items-center justify-center p-0 text-neutral-600",
+              isAccepted
+                ? "border-transparent bg-emerald-600 text-white hover:bg-emerald-600/90"
+                : "border-neutral-300 hover:border-emerald-500 hover:text-emerald-600",
+            )}
           >
-            {acceptLabel}
+            <ThumbsUp className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Thumbs up</span>
           </Button>
           <Button
             size="sm"
             variant="outline"
-            onClick={() => handleRespond("declined")}
+            onClick={handleThumbsDown}
             disabled={isResponding}
-            aria-label="Decline invitation"
+            aria-label={isDeclined ? "Remove thumbs down" : "Give thumbs down"}
+            aria-pressed={isDeclined}
+            className={cn(
+              "flex h-9 w-9 items-center justify-center p-0 text-neutral-600",
+              isDeclined
+                ? "border-transparent bg-red-600 text-white hover:bg-red-600/90"
+                : "border-neutral-300 hover:border-red-500 hover:text-red-600",
+            )}
           >
-            {declineLabel}
+            <ThumbsDown className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">Thumbs down</span>
           </Button>
-        </>
+        </div>
       );
     }
+
+    const declineLabel = "Decline";
+    const acceptLabel = "Accept";
 
     if (statusForDisplay === "accepted") {
       return (

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -37,13 +37,15 @@ import {
   Settings,
   Search,
   Loader2,
+  ThumbsDown,
+  ThumbsUp,
   type LucideIcon
 } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { apiFetch } from "@/lib/api";
-import { formatCurrency } from "@/lib/utils";
+import { cn, formatCurrency } from "@/lib/utils";
 import {
   TRIP_COVER_GRADIENT,
   buildCoverPhotoSrcSet,
@@ -630,32 +632,68 @@ function DayView({
                 );
               }
 
-              const declineLabel = isProposal ? "Not interested" : "Decline";
-              const acceptLabel = isProposal ? "Interested" : "Accept";
-
               if (isProposal) {
+                const isAccepted = derivedStatus === "accepted";
+                const isDeclined = derivedStatus === "declined";
+
+                const handleThumbsUp = () => {
+                  if (isAccepted) {
+                    handleAction("MAYBE");
+                    return;
+                  }
+                  handleAction("ACCEPT");
+                };
+
+                const handleThumbsDown = () => {
+                  if (isDeclined) {
+                    handleAction("MAYBE");
+                    return;
+                  }
+                  handleAction("DECLINE");
+                };
+
                 return (
                   <div className="flex flex-wrap items-center justify-end gap-2">
                     <Button
                       size="sm"
-                      onClick={() => handleAction("ACCEPT")}
+                      variant="outline"
+                      onClick={handleThumbsUp}
                       disabled={isRsvpPending}
-                      aria-label="Accept invitation"
+                      aria-label={isAccepted ? "Remove thumbs up" : "Give thumbs up"}
+                      aria-pressed={isAccepted}
+                      className={cn(
+                        "flex h-9 w-9 items-center justify-center p-0 text-neutral-600",
+                        isAccepted
+                          ? "border-transparent bg-emerald-600 text-white hover:bg-emerald-600/90"
+                          : "border-neutral-300 hover:border-emerald-500 hover:text-emerald-600",
+                      )}
                     >
-                      {acceptLabel}
+                      <ThumbsUp className="h-4 w-4" aria-hidden="true" />
+                      <span className="sr-only">Thumbs up</span>
                     </Button>
                     <Button
                       size="sm"
                       variant="outline"
-                      onClick={() => handleAction("DECLINE")}
+                      onClick={handleThumbsDown}
                       disabled={isRsvpPending}
-                      aria-label="Decline invitation"
+                      aria-label={isDeclined ? "Remove thumbs down" : "Give thumbs down"}
+                      aria-pressed={isDeclined}
+                      className={cn(
+                        "flex h-9 w-9 items-center justify-center p-0 text-neutral-600",
+                        isDeclined
+                          ? "border-transparent bg-red-600 text-white hover:bg-red-600/90"
+                          : "border-neutral-300 hover:border-red-500 hover:text-red-600",
+                      )}
                     >
-                      {declineLabel}
+                      <ThumbsDown className="h-4 w-4" aria-hidden="true" />
+                      <span className="sr-only">Thumbs down</span>
                     </Button>
                   </div>
                 );
               }
+
+              const declineLabel = "Decline";
+              const acceptLabel = "Accept";
 
               if (derivedStatus === "accepted") {
                 return (


### PR DESCRIPTION
## Summary
- add thumbs up/down controls for proposed activities in the trip day view so members can signal interest quickly
- mirror the thumbs controls inside the activity details dialog, including the ability to toggle interest off
- update shared imports to include the new icon assets used by the controls

## Testing
- npm test -- --runTestsByPath client/src/components/__tests__/calendar-grid.proposal.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e564af079c832eadb5d56cb534ca7b