### PR TITLE
Allow proposals without start times

### DIFF
--- a/client/src/lib/__tests__/activitySubmission.test.ts
+++ b/client/src/lib/__tests__/activitySubmission.test.ts
@@ -87,15 +87,18 @@ describe("buildActivitySubmission", () => {
     expect(payload.endTime).toBeNull();
   });
 
-  it("requires a start time for proposals", () => {
-    expect(() =>
-      buildActivitySubmission({
-        ...baseInput,
-        type: "PROPOSE",
-        startTime: "",
-        endTime: undefined,
-      }),
-    ).toThrow("Start time is required so we can place this on the calendar.");
+  it("allows proposals without a start time", () => {
+    const { payload } = buildActivitySubmission({
+      ...baseInput,
+      type: "PROPOSE",
+      startTime: "",
+      endTime: undefined,
+    });
+
+    expect(payload.startTime).toBeNull();
+    expect(payload.start_time).toBeNull();
+    expect(payload.endTime).toBeNull();
+    expect(payload.end_time).toBeNull();
   });
 
   it("preserves the selected calendar date for YYYY-MM-DD inputs", async () => {

--- a/client/src/lib/activities/activityCreation.ts
+++ b/client/src/lib/activities/activityCreation.ts
@@ -18,7 +18,7 @@ export interface ActivityCreateFormValues {
   name: string;
   description?: string;
   startDate: string;
-  startTime: string;
+  startTime?: string;
   endTime?: string | null;
   location?: string;
   cost?: string;
@@ -106,6 +106,7 @@ export const prepareActivitySubmission = ({
     const sanitizedValues: ActivityCreateFormValues = {
       ...values,
       description: payload.description ?? undefined,
+      startTime: payload.start_time ?? undefined,
       endTime: payload.endTime ? payload.endTime.slice(11, 16) : undefined,
       location: payload.location ?? undefined,
       cost: values.cost,

--- a/client/src/lib/activities/clientValidation.ts
+++ b/client/src/lib/activities/clientValidation.ts
@@ -8,6 +8,7 @@ import {
   MAX_ACTIVITY_DESCRIPTION_LENGTH,
   MAX_ACTIVITY_LOCATION_LENGTH,
   MAX_CAPACITY_MESSAGE,
+  START_TIME_REQUIRED_FOR_END_MESSAGE,
 } from "@shared/activityValidation";
 
 export const CLIENT_VALIDATION_FALLBACK_MESSAGE =
@@ -37,6 +38,7 @@ const clientValidationMessageMap: Array<{
       "End time must be in HH:MM format.",
       "End time must be a valid date/time.",
       END_TIME_AFTER_START_MESSAGE,
+      START_TIME_REQUIRED_FOR_END_MESSAGE,
     ],
   },
   {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -3651,7 +3651,7 @@ export class DatabaseStorage implements IStorage {
         FROM activities
         WHERE trip_calendar_id = $1
           AND LOWER(name) = LOWER($2)
-          AND start_time = $3
+          AND start_time IS NOT DISTINCT FROM $3
           AND COALESCE(type, 'SCHEDULED') = $4
         LIMIT 1
         FOR SHARE

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -229,7 +229,7 @@ export interface Activity {
   postedBy: string;
   name: string;
   description: string | null;
-  startTime: IsoDate;
+  startTime: IsoDate | null;
   endTime: IsoDate | null;
   location: string | null;
   cost: number | null;
@@ -258,10 +258,14 @@ const enforceRequiredStartTime = (
   data: z.infer<typeof baseInsertActivitySchema>,
   ctx: z.RefinementCtx,
 ) => {
+  const normalizedType = data.type === "PROPOSE" ? "PROPOSE" : "SCHEDULED";
   const normalizedStartTime =
     typeof data.startTime === "string" ? data.startTime.trim() : data.startTime;
 
-  if (normalizedStartTime === null || normalizedStartTime === undefined || normalizedStartTime === "") {
+  if (
+    normalizedType !== "PROPOSE"
+    && (normalizedStartTime === null || normalizedStartTime === undefined || normalizedStartTime === "")
+  ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["startTime"],


### PR DESCRIPTION
## Summary
- allow proposals to be submitted without a start time by relaxing the activity modal validation and activity submission builder
- update shared validation, schema, and storage to support null start times and improve notification copy when time is TBD
- adjust duplicate detection to handle null start times and reuse shared messaging for end-time validation

## Testing
- CI=1 npm test -- --runTestsByPath client/src/lib/__tests__/activitySubmission.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e58017d7e0832e8d4f5b3b1e29af3f