### PR TITLE
Enforce trip date bounds in activity creation

### DIFF
--- a/client/src/pages/activities.tsx
+++ b/client/src/pages/activities.tsx
@@ -1016,6 +1016,8 @@ export default function Activities() {
         allowModeToggle
         currentUserId={user?.id}
         prefill={activityComposerPrefill}
+        tripStartDate={trip?.startDate ?? null}
+        tripEndDate={trip?.endDate ?? null}
       />
 
       {/* Booking Confirmation Modal */}

--- a/client/src/pages/member-schedule.tsx
+++ b/client/src/pages/member-schedule.tsx
@@ -533,6 +533,8 @@ export default function MemberSchedule() {
         allowModeToggle
         currentUserId={currentUser?.id}
         prefill={activityPrefill}
+        tripStartDate={trip.startDate}
+        tripEndDate={trip.endDate}
       />
     </>
   );

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -2998,6 +2998,8 @@ export default function Trip() {
           defaultMode={addActivityMode}
           allowModeToggle={isAddActivityModeToggleEnabled}
           currentUserId={user?.id}
+          tripStartDate={trip?.startDate ?? null}
+          tripEndDate={trip?.endDate ?? null}
         />
 
         {trip && (


### PR DESCRIPTION
## Summary
- add trip date range awareness to the activity creation modal schema and UI, including range hints and trimmed submissions
- pass trip start/end dates from trip, activities, and member schedule pages so the modal can enforce calendar bounds

## Testing
- npm test -- --runTestsByPath client/src/lib/activities/__tests__/createActivity.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e589db2a50832e97aafa3342761fd2