### PR TITLE
Filter proposal activities returned by proposals endpoint

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2992,18 +2992,19 @@ export function setupRoutes(app: Express) {
         }
 
         const activities = await storage.getTripActivities(tripId, userId);
+        const proposalActivities = activities.filter(
+          (activity) => activity.type === "PROPOSE",
+        );
         const mineOnly = parseBooleanQueryParam(req.query?.mineOnly);
 
-        if (mineOnly) {
-          const filtered = activities.filter((activity) => {
-            const proposerId = activity.postedBy ?? activity.poster?.id ?? null;
-            return proposerId === userId;
-          });
-          res.json(filtered);
-          return;
-        }
+        const filteredActivities = mineOnly
+          ? proposalActivities.filter((activity) => {
+              const proposerId = activity.postedBy ?? activity.poster?.id ?? null;
+              return proposerId === userId;
+            })
+          : proposalActivities;
 
-        res.json(activities);
+        res.json(filteredActivities);
       } catch (error: unknown) {
         console.error('Error fetching activity proposals:', error);
         res.status(500).json({ message: 'Failed to fetch activity proposals' });


### PR DESCRIPTION
## Summary
- implement `/api/trips/:tripId/proposals/activities` so activity proposals respect membership checks and optional personal filtering
- load the proposals page from the new endpoint and update activity invite mutations to target the refreshed query key
- invalidate the new proposals cache after creating activities through the various booking and manual flows
- ensure the proposals endpoint filters activities to proposals before applying the optional mine-only filter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d0b19abc832e93513edc3208be91