### PR TITLE
Adjust discovery proposal capacity to attendee count

### DIFF
--- a/client/src/pages/activities.tsx
+++ b/client/src/pages/activities.tsx
@@ -294,6 +294,8 @@ export default function Activities() {
           ? [user.id]
           : [];
 
+      const maxCapacity = Math.max(attendeeIds.length, 1);
+
       const response = await apiFetch(`/api/trips/${tripId}/activities`, {
         method: 'POST',
         headers: {
@@ -308,7 +310,7 @@ export default function Activities() {
           endTime: null,
           category: activity.category,
           cost: activity.price ? parseFloat(activity.price) : null,
-          maxCapacity: 10,
+          maxCapacity,
           tripCalendarId: parseInt(tripId!),
           attendeeIds,
         }),


### PR DESCRIPTION
## Summary
- update the discovery activity proposal flow to include all trip members in the attendee list so invitations reach the rest of the group
- adjust the proposed activity capacity to match the attendee list so large trips can submit proposals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5d0b1cc34832e9ef5f2f6657fc735