### PR TITLE
Fix activity invite transaction client usage

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,4 +1,4 @@
-import { query } from "./db";
+import { pool, query } from "./db";
 import {
   computeSplits,
   minorUnitsToAmount,
@@ -3450,9 +3450,11 @@ export class DatabaseStorage implements IStorage {
         : parsedMaxCapacity;
     const typeValue = toActivityType(activity.type);
 
-    await query("BEGIN");
+    const client = await pool.connect();
     try {
-      const { rows } = await query<ActivityRow>(
+      await client.query("BEGIN");
+
+      const { rows } = await client.query<ActivityRow>(
         `
         INSERT INTO activities (
           trip_calendar_id,
@@ -3509,7 +3511,7 @@ export class DatabaseStorage implements IStorage {
 
       const uniqueInviteeIds = Array.from(new Set(inviteeIds));
       if (uniqueInviteeIds.length > 0) {
-        await query(
+        await client.query(
           `
           INSERT INTO activity_invites (activity_id, user_id, status, responded_at)
           SELECT
@@ -3527,7 +3529,7 @@ export class DatabaseStorage implements IStorage {
         );
       }
 
-      const { rows: organizerInviteRows } = await query<ActivityInviteRow>(
+      const { rows: organizerInviteRows } = await client.query<ActivityInviteRow>(
         `
         INSERT INTO activity_invites (activity_id, user_id, status, responded_at)
         VALUES ($1, $2, $3, CASE WHEN $3 = 'pending' THEN NULL ELSE NOW() END)
@@ -3552,12 +3554,14 @@ export class DatabaseStorage implements IStorage {
         throw new Error("Failed to update activity invite");
       }
 
-      await query("COMMIT");
+      await client.query("COMMIT");
 
       return mapActivity(row);
     } catch (error) {
-      await query("ROLLBACK");
+      await client.query("ROLLBACK");
       throw error;
+    } finally {
+      client.release();
     }
   }
 


### PR DESCRIPTION
## Summary
- add a transactional helper that wraps activity creation, invite persistence, and organizer acceptance
- update the trips activity creation route to rely on the transactional helper
- add a regression test that verifies invite failures roll back the activity insert
- ensure the transactional helper runs on a dedicated pooled client and releases it after commit/rollback

## Testing
- npm test -- --runTestsByPath server/__tests__/createActivityWithInvites.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5d0b37c04832eab61a4bd6675735a