### PR TITLE
Support activity proposals

### DIFF
--- a/client/src/components/activity-details-dialog.tsx
+++ b/client/src/components/activity-details-dialog.tsx
@@ -101,11 +101,24 @@ export function ActivityDetailsDialog({
       return false;
     }
     const end = activity.endTime ? new Date(activity.endTime) : null;
-    const start = new Date(activity.startTime);
-    const comparisonTarget = end && !Number.isNaN(end.getTime()) ? end : start;
-    if (Number.isNaN(comparisonTarget.getTime())) {
+    const start = activity.startTime ? new Date(activity.startTime) : null;
+
+    const comparisonTarget = (() => {
+      if (end && !Number.isNaN(end.getTime())) {
+        return end;
+      }
+
+      if (start && !Number.isNaN(start.getTime())) {
+        return start;
+      }
+
+      return null;
+    })();
+
+    if (!comparisonTarget) {
       return false;
     }
+
     return comparisonTarget.getTime() < now.getTime();
   })();
   const rsvpCloseDate = activity?.rsvpCloseTime ? new Date(activity.rsvpCloseTime) : null;

--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -383,11 +383,25 @@ function DayView({
               : inviteStatusBadgeClasses[derivedStatus];
             const isPastActivity = (() => {
               const end = activity.endTime ? new Date(activity.endTime) : null;
-              const start = new Date(activity.startTime);
-              const comparisonTarget = end && !Number.isNaN(end.getTime()) ? end : start;
-              return Number.isNaN(comparisonTarget.getTime())
-                ? false
-                : comparisonTarget.getTime() < now.getTime();
+              const start = activity.startTime ? new Date(activity.startTime) : null;
+
+              const comparisonTarget = (() => {
+                if (end && !Number.isNaN(end.getTime())) {
+                  return end;
+                }
+
+                if (start && !Number.isNaN(start.getTime())) {
+                  return start;
+                }
+
+                return null;
+              })();
+
+              if (!comparisonTarget) {
+                return false;
+              }
+
+              return comparisonTarget.getTime() < now.getTime();
             })();
             const rsvpCloseDate = activity.rsvpCloseTime
               ? new Date(activity.rsvpCloseTime)

--- a/server/db.ts
+++ b/server/db.ts
@@ -7,6 +7,7 @@ type QueryFunction = <T>(text: string, params?: unknown[]) => Promise<{ rows: T[
 const globalAny = globalThis as { __TEST_DB_QUERY__?: QueryFunction };
 
 let queryImpl: QueryFunction;
+export let pool: Pool | undefined;
 
 if (typeof globalAny.__TEST_DB_QUERY__ === "function") {
   queryImpl = globalAny.__TEST_DB_QUERY__;
@@ -19,12 +20,12 @@ if (typeof globalAny.__TEST_DB_QUERY__ === "function") {
     );
   }
 
-  const pool = new Pool({
+  pool = new Pool({
     connectionString: process.env.DATABASE_URL,
     ssl: { rejectUnauthorized: false },
   });
 
-  queryImpl = (text, params = []) => pool.query(text, params);
+  queryImpl = (text, params = []) => pool!.query(text, params);
 }
 
 export const query: QueryFunction = (text, params = []) => queryImpl(text, params);


### PR DESCRIPTION
## Summary
- add activity type validation, optional proposal time options, and vote metadata to the shared schema
- branch the activity creation flow to persist proposal records, include them when fetching trip activities, and provide in-memory db shims for tests
- update the activities page to submit proposal payloads and add tests ensuring proposals are stored and surfaced
- restore the pg pool export for the session store
- treat proposal activities without a chosen time as upcoming so RSVP actions remain available

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e5ccfc92a4832e929fca32074c2581