### PR TITLE
Format trip date bounds before enforcing activity constraints

### DIFF
--- a/client/src/components/add-activity-modal.tsx
+++ b/client/src/components/add-activity-modal.tsx
@@ -309,7 +309,20 @@ const formatDateValue = (value: string | Date | null | undefined) => {
   }
 
   if (typeof value === "string") {
-    return value;
+    if (dateInputPattern.test(value)) {
+      return value;
+    }
+
+    try {
+      const parsed = parseISO(value);
+      if (isValid(parsed)) {
+        return format(parsed, "yyyy-MM-dd");
+      }
+    } catch {
+      // fall through to return empty string
+    }
+
+    return "";
   }
 
   return "";


### PR DESCRIPTION
## Summary
- format trip start/end date bounds to `yyyy-MM-dd` before applying them to inputs and schema
- normalize invalid bound strings by falling back to an empty constraint

## Testing
- npm test -- --runTestsByPath client/src/lib/activities/__tests__/createActivity.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e5ccb1b52c832e8df204309577131c