### PR TITLE
Address review feedback for Allow proposals without start times

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2293,7 +2293,9 @@ export function setupRoutes(app: Express) {
         const missingFields: string[] = [];
         if (createPayload.title.trim().length === 0) missingFields.push("title");
         if (createPayload.date.trim().length === 0) missingFields.push("date");
-        if (createPayload.start_time.trim().length === 0) missingFields.push("start_time");
+        const hasStartTime =
+          typeof createPayload.start_time === "string" && createPayload.start_time.trim().length > 0;
+        if (requestMode !== "proposed" && !hasStartTime) missingFields.push("start_time");
         if (createPayload.timezone.trim().length === 0) missingFields.push("timezone");
         const missingRequired = missingFields.length > 0;
 


### PR DESCRIPTION
## Summary
- skip the start time required check for proposed activities in the v2 activity creation route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5ccafdc58832eb42a658c38676a56