### PR TITLE
Allow proposals to omit start time without DB errors

### DIFF
--- a/server/activitiesV2.ts
+++ b/server/activitiesV2.ts
@@ -29,7 +29,7 @@ const ensureActivitiesTablePromise = shouldEnsureTables
         description TEXT NULL,
         category TEXT NULL,
         date DATE NOT NULL,
-        start_time TIME NOT NULL,
+        start_time TIME NULL,
         end_time TIME NULL,
         timezone TEXT NOT NULL,
         location TEXT NULL,
@@ -44,6 +44,11 @@ const ensureActivitiesTablePromise = shouldEnsureTables
         UNIQUE (trip_id, idempotency_key)
     )
   `);
+
+    await query(`
+      ALTER TABLE activities_v2
+        ALTER COLUMN start_time DROP NOT NULL
+    `);
 
     await query(`
       CREATE TABLE IF NOT EXISTS activity_invitees_v2 (


### PR DESCRIPTION
## Summary
- relax the activities_v2.start_time column so null values are accepted
- run an ALTER TABLE on startup to drop the NOT NULL constraint for existing deployments

## Testing
- npm run test -- activitiesV2.create

------
https://chatgpt.com/codex/tasks/task_e_68e5d3959bb8832ea80458364651fcdd