### PR TITLE
Prefill add activity modal date after calendar clicks

### DIFF
--- a/client/src/pages/trip.tsx
+++ b/client/src/pages/trip.tsx
@@ -53,7 +53,7 @@ import {
   useCoverPhotoImage,
 } from "@/lib/tripCover";
 import { CalendarGrid } from "@/components/calendar-grid";
-import { AddActivityModal } from "@/components/add-activity-modal";
+import { AddActivityModal, type ActivityComposerPrefill } from "@/components/add-activity-modal";
 import { EditTripModal } from "@/components/edit-trip-modal";
 import { InviteLinkModal } from "@/components/invite-link-modal";
 import { MobileNav } from "@/components/mobile-nav";
@@ -909,6 +909,7 @@ export default function Trip() {
   const queryClient = useQueryClient();
 
   const [showAddActivity, setShowAddActivity] = useState(false);
+  const [addActivityPrefill, setAddActivityPrefill] = useState<ActivityComposerPrefill | null>(null);
   const [addActivityMode, setAddActivityMode] = useState<ActivityType>("SCHEDULED");
   const [isAddActivityModeToggleEnabled, setIsAddActivityModeToggleEnabled] = useState(true);
   const [showEditTrip, setShowEditTrip] = useState(false);
@@ -1575,6 +1576,9 @@ export default function Trip() {
       setSelectedDate(targetDate);
       setGroupViewDate(targetDate);
       setScheduleViewDate(targetDate);
+      setAddActivityPrefill({ startDate: targetDate });
+    } else {
+      setAddActivityPrefill(null);
     }
 
     setAddActivityMode(mode);
@@ -2990,6 +2994,7 @@ export default function Trip() {
             setShowAddActivity(open);
             if (!open) {
               setSelectedDate(null);
+              setAddActivityPrefill(null);
             }
           }}
           tripId={numericTripId}
@@ -3000,6 +3005,7 @@ export default function Trip() {
           currentUserId={user?.id}
           tripStartDate={trip?.startDate ?? null}
           tripEndDate={trip?.endDate ?? null}
+          prefill={addActivityPrefill}
         />
 
         {trip && (


### PR DESCRIPTION
## Summary
- ensure the trip calendar passes the clicked date into the add activity modal so the date input is pre-filled
- clear any temporary add-activity prefill data when the modal closes to avoid stale selections

## Testing
- npm run check *(fails: existing TypeScript errors in activity card/details and member schedule)*

------
https://chatgpt.com/codex/tasks/task_e_68e66ae2fd3c832eac4c1266b53ba6a0