### PR TITLE
Fix proposal visibility and add status/history filters

### DIFF
--- a/client/src/pages/__tests__/flightProposals.integration.test.tsx
+++ b/client/src/pages/__tests__/flightProposals.integration.test.tsx
@@ -18,7 +18,7 @@ type FlightProposal = {
 
 const FlightProposalsLoader = ({ tripId }: { tripId: number }) => {
   const { data } = useQuery<FlightProposal[]>({
-    queryKey: [`/api/trips/${tripId}/proposals?type=flight&status=OPEN`],
+    queryKey: [`/api/trips/${tripId}/proposals?type=flight`],
   });
 
   const proposals = Array.isArray(data) ? data : [];
@@ -38,7 +38,7 @@ describe("flight proposals fetch", () => {
   beforeEach(() => {
     (global.fetch as jest.Mock) = jest.fn((input: RequestInfo) => {
       const url = typeof input === "string" ? input : input.url;
-      if (url === "/api/trips/123/proposals?type=flight&status=OPEN") {
+      if (url === "/api/trips/123/proposals?type=flight") {
         return okJson([{ id: 1, airline: "Test Air" }]);
       }
 
@@ -71,7 +71,7 @@ describe("flight proposals fetch", () => {
 
     const fetchMock = global.fetch as jest.Mock;
     const flightCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).includes("/api/trips/123/proposals?type=flight&status=OPEN"),
+      String(url).includes("/api/trips/123/proposals?type=flight"),
     );
 
     expect(flightCall).toBeDefined();

--- a/client/src/pages/__tests__/proposalStatusFilters.test.ts
+++ b/client/src/pages/__tests__/proposalStatusFilters.test.ts
@@ -1,4 +1,4 @@
-import { filterActiveProposals } from "../proposalStatusFilters";
+import { filterActiveProposals, filterProposalsByStatus } from "../proposalStatusFilters";
 
 describe("filterActiveProposals", () => {
   const proposals = [
@@ -22,5 +22,45 @@ describe("filterActiveProposals", () => {
     ]);
 
     expect(result.map((proposal) => proposal.id)).toEqual([3, 4, 5, 6]);
+  });
+});
+
+describe("filterProposalsByStatus", () => {
+  const proposals = [
+    { id: 1, status: "OPEN" },
+    { id: 2, status: "closed" },
+    { id: 3, status: "confirmed" },
+    { id: 4, status: "cancelled" },
+    { id: 5, status: null },
+  ];
+
+  it("filters open proposals", () => {
+    const result = filterProposalsByStatus(proposals, "open");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([1, 5]);
+  });
+
+  it("filters closed proposals", () => {
+    const result = filterProposalsByStatus(proposals, "closed");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([2, 3]);
+  });
+
+  it("filters cancelled proposals", () => {
+    const result = filterProposalsByStatus(proposals, "cancelled");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([4]);
+  });
+
+  it("filters history proposals", () => {
+    const result = filterProposalsByStatus(proposals, "history");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([2, 3, 4]);
+  });
+
+  it("returns all proposals", () => {
+    const result = filterProposalsByStatus(proposals, "all");
+
+    expect(result.map((proposal) => proposal.id)).toEqual([1, 2, 3, 4, 5]);
   });
 });

--- a/client/src/pages/__tests__/proposalVisibility.test.ts
+++ b/client/src/pages/__tests__/proposalVisibility.test.ts
@@ -1,0 +1,58 @@
+import { filterCategoryProposals, filterMyProposals } from "../proposalVisibility";
+
+describe("proposal visibility filters", () => {
+  const currentUserId = "user-123";
+  const flightProposal = {
+    id: 10,
+    proposedBy: currentUserId,
+    status: "OPEN",
+  };
+  const otherProposal = {
+    id: 11,
+    proposedBy: "user-999",
+    status: "OPEN",
+  };
+
+  it("includes the current user's open proposal in category views by default", () => {
+    const result = filterCategoryProposals([flightProposal, otherProposal], {
+      userId: currentUserId,
+      hideMine: false,
+      statusFilter: "open",
+    });
+
+    expect(result.map((proposal) => proposal.id)).toEqual([10, 11]);
+  });
+
+  it("includes the current user's open proposal in My Proposals", () => {
+    const result = filterMyProposals([flightProposal, otherProposal], {
+      userId: currentUserId,
+      statusFilter: "open",
+    });
+
+    expect(result.map((proposal) => proposal.id)).toEqual([10]);
+  });
+
+  it("moves closed proposals out of the open filter but into history and all", () => {
+    const closedProposal = { ...flightProposal, status: "CLOSED" };
+
+    const openResult = filterCategoryProposals([closedProposal], {
+      userId: currentUserId,
+      hideMine: false,
+      statusFilter: "open",
+    });
+    const historyResult = filterCategoryProposals([closedProposal], {
+      userId: currentUserId,
+      hideMine: false,
+      statusFilter: "history",
+    });
+    const allResult = filterCategoryProposals([closedProposal], {
+      userId: currentUserId,
+      hideMine: false,
+      statusFilter: "all",
+    });
+
+    expect(openResult).toHaveLength(0);
+    expect(historyResult.map((proposal) => proposal.id)).toEqual([10]);
+    expect(allResult.map((proposal) => proposal.id)).toEqual([10]);
+  });
+});

--- a/client/src/pages/proposalStatusFilters.ts
+++ b/client/src/pages/proposalStatusFilters.ts
@@ -1,14 +1,69 @@
+const OPEN_STATUSES = new Set(["open", "active", "proposed", "scheduled"]);
+const CLOSED_STATUSES = new Set(["confirmed", "closed"]);
 const CANCELED_STATUSES = new Set(["canceled", "cancelled", "void", "voided", "archived"]);
-const INACTIVE_STATUSES = new Set(["confirmed", "closed"]);
+
+export type CategoryStatusFilter = "open" | "history" | "all";
+export type MyProposalStatusFilter = "open" | "closed" | "cancelled" | "all";
+export type ProposalStatusFilter = CategoryStatusFilter | MyProposalStatusFilter;
+
+export const CATEGORY_STATUS_FILTER_OPTIONS: Array<{ value: CategoryStatusFilter; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "history", label: "History" },
+  { value: "all", label: "All" },
+];
+
+export const MY_PROPOSAL_STATUS_FILTER_OPTIONS: Array<{ value: MyProposalStatusFilter; label: string }> = [
+  { value: "open", label: "Open" },
+  { value: "closed", label: "Closed/Confirmed" },
+  { value: "cancelled", label: "Cancelled" },
+  { value: "all", label: "All" },
+];
 
 export const normalizeProposalStatus = (status?: string | null): string =>
   (status ?? "active").toLowerCase();
+
+export const isOpenStatus = (status?: string | null): boolean => {
+  const normalized = normalizeProposalStatus(status);
+  if (!normalized) {
+    return true;
+  }
+  if (OPEN_STATUSES.has(normalized)) {
+    return true;
+  }
+  if (CLOSED_STATUSES.has(normalized) || CANCELED_STATUSES.has(normalized)) {
+    return false;
+  }
+
+  return true;
+};
 
 export const isCanceledStatus = (status?: string | null): boolean =>
   CANCELED_STATUSES.has(normalizeProposalStatus(status));
 
 export const isInactiveStatus = (status?: string | null): boolean =>
-  INACTIVE_STATUSES.has(normalizeProposalStatus(status));
+  CLOSED_STATUSES.has(normalizeProposalStatus(status));
+
+export const isClosedStatus = (status?: string | null): boolean =>
+  CLOSED_STATUSES.has(normalizeProposalStatus(status));
 
 export const filterActiveProposals = <T extends { status?: string | null }>(items: T[]): T[] =>
-  items.filter((item) => !isCanceledStatus(item.status) && !isInactiveStatus(item.status));
+  items.filter((item) => isOpenStatus(item.status));
+
+export const filterProposalsByStatus = <T extends { status?: string | null }>(
+  items: T[],
+  filter: ProposalStatusFilter,
+): T[] => {
+  switch (filter) {
+    case "open":
+      return items.filter((item) => isOpenStatus(item.status));
+    case "closed":
+      return items.filter((item) => isClosedStatus(item.status));
+    case "cancelled":
+      return items.filter((item) => isCanceledStatus(item.status));
+    case "history":
+      return items.filter((item) => !isOpenStatus(item.status));
+    case "all":
+    default:
+      return items;
+  }
+};

--- a/client/src/pages/proposalVisibility.ts
+++ b/client/src/pages/proposalVisibility.ts
@@ -1,0 +1,68 @@
+import type { ProposalPermissions } from "@shared/schema";
+import {
+  filterProposalsByStatus,
+  type CategoryStatusFilter,
+  type MyProposalStatusFilter,
+} from "./proposalStatusFilters";
+
+type ProposalOwnership = {
+  proposedBy?: string | null;
+  proposer?: { id?: string | null } | null;
+  permissions?: ProposalPermissions | null;
+};
+
+const normalizeUserId = (value: unknown): string | null => {
+  if (typeof value === "string") {
+    const trimmed = value.trim().toLowerCase();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+
+  return null;
+};
+
+export const isProposalOwnedByUser = (
+  proposal: ProposalOwnership,
+  userId?: string | null,
+): boolean => {
+  if (proposal.permissions?.canCancel) {
+    return true;
+  }
+
+  const viewerId = normalizeUserId(userId);
+  if (!viewerId) {
+    return false;
+  }
+
+  const proposedById = normalizeUserId(proposal.proposedBy);
+  const proposerFallbackId = normalizeUserId(proposal.proposer?.id);
+  const proposerId = proposedById ?? proposerFallbackId ?? null;
+
+  return proposerId !== null && proposerId === viewerId;
+};
+
+export const filterCategoryProposals = <T extends ProposalOwnership & { status?: string | null }>(
+  proposals: T[],
+  options: {
+    userId?: string | null;
+    hideMine?: boolean;
+    statusFilter: CategoryStatusFilter;
+  },
+): T[] => {
+  const visible = options.hideMine
+    ? proposals.filter((proposal) => !isProposalOwnedByUser(proposal, options.userId))
+    : proposals;
+
+  return filterProposalsByStatus(visible, options.statusFilter);
+};
+
+export const filterMyProposals = <T extends ProposalOwnership & { status?: string | null }>(
+  proposals: T[],
+  options: {
+    userId?: string | null;
+    statusFilter: MyProposalStatusFilter;
+  },
+): T[] =>
+  filterProposalsByStatus(
+    proposals.filter((proposal) => isProposalOwnedByUser(proposal, options.userId)),
+    options.statusFilter,
+  );


### PR DESCRIPTION
### Motivation
- Category lists were implicitly excluding proposals created by the current user and only requesting `status=OPEN` from the API, causing user-created proposals to “disappear” from category tabs and making history unreachable without a dedicated view.
- The goal is to always show open proposals (including those I created) in category tabs, provide an explicit “Hide my proposals” toggle, add a My Proposals tab with status filters, and avoid silent disappearance by surfacing history/all options.

### Description
- Show current user proposals in category tabs by default and add a `Hide my proposals` toggle (default OFF) with a category status selector; this is implemented in `client/src/pages/proposals.tsx` by changing the default behavior and adding UI controls and state (`hideMyProposalsInCategories`, `categoryStatusFilter`, `myProposalStatusFilter`).
- Move status filtering client-side and broaden normalized status handling: `client/src/pages/proposalStatusFilters.ts` adds `OPEN`/`CLOSED`/`CANCELED` sets, `filterProposalsByStatus`, explicit filter option lists, and `isOpenStatus` logic to map legacy status strings to `open` vs history.
- Add ownership and visibility helpers in `client/src/pages/proposalVisibility.ts` exposing `isProposalOwnedByUser`, `filterCategoryProposals`, and `filterMyProposals` and wire them into `proposals.tsx` so category tabs include my proposals unless explicitly hidden and My Proposals always includes my items.
- Stop silently requesting only `status=OPEN` from flight endpoints: flight query keys were updated to request `/api/trips/:tripId/proposals?type=flight` and the UI now filters results client-side so history/all remain accessible.
- Update and add tests: extended `proposalStatusFilters` tests and added `proposalVisibility` unit tests; updated the flight fetch integration test to match the new query URL and ensure it still uses credentials.

### Testing
- Ran the focused unit/integration suites with `npm test -- --runTestsByPath client/src/pages/__tests__/proposalStatusFilters.test.ts client/src/pages/__tests__/proposalVisibility.test.ts client/src/pages/__tests__/flightProposals.integration.test.tsx` and all tests passed.
- Test output: 3 test suites passed, 11 tests passed (the above command executed successfully in CI/dev environment).
- Attempted a live UI screenshot via Playwright to confirm a newly proposed flight appears in both Flights and My Proposals, but Playwright crashed on launch (SIGSEGV) and the local dev server failed due to missing `DATABASE_URL`, so visual verification could not be captured; logic is covered by the new unit/integration tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69729a1dd9e8832eb65727a2fbfadec7)